### PR TITLE
feat: add minimal flask server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+
+# optional
+.DS_Store
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,56 @@
-# sevenn
+# Sevenn
+
+Sevenn is an offline-first study app for organizing diseases, drugs, and concepts.
+This repository hosts the SPA implementation using vanilla JavaScript modules.
+
+## Development
+
+Install dependencies (for the optional local server and future tooling):
+
+```bash
+npm install
+```
+
+Start a dev server:
+
+```bash
+npm start
+```
+
+Run the placeholder test suite:
+
+```bash
+npm test
+```
+
+The site will be available at the URL shown in the terminal. You can also simply open
+`index.html` directly in a modern browser.
+
+The **Settings** tab lets you adjust the daily review target and manage curriculum
+blocks with their lectures. It also offers buttons to export or import the
+database as JSON and to export an Anki-compatible CSV. Data is stored locally
+using IndexedDB.
+
+## Roadmap
+
+See the implementation blueprint in the repository for planned modules and features.
+
+## Python prototype
+
+An optional Python entry point is included for future backend experiments. It
+spins up a very small Flask application that returns a greeting.
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Start the development server:
+
+```bash
+python -m app.main
+```
+
+Then visit [http://localhost:5000/hello/world](http://localhost:5000/hello/world)
+in your browser to verify the server responds with a JSON greeting.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,37 @@
+"""Sevenn placeholder application entry point.
+
+This module exposes a tiny Flask application for future experimentation.
+Running it will start a development web server that responds with a friendly
+greeting.
+"""
+
+from __future__ import annotations
+
+from flask import Flask, jsonify
+
+
+def greet(name: str) -> str:
+    """Return a friendly greeting for the provided ``name``."""
+    return f"Hello, {name}! Welcome to Sevenn."
+
+
+def create_app() -> Flask:
+    """Create and configure a small Flask application."""
+
+    app = Flask(__name__)
+
+    @app.get("/hello/<name>")
+    def hello(name: str):  # pragma: no cover - trivial wrapper
+        return jsonify(message=greet(name))
+
+    return app
+
+
+def main() -> None:
+    """Run the development server when executed as a script."""
+    app = create_app()
+    app.run(debug=True)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sevenn</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="js/main.js"></script>
+</body>
+</html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,144 @@
+import { state, setTab, setSubtab, setFlashSession, setQuizSession } from './state.js';
+import { initDB, listItemsByKind } from './storage/storage.js';
+import { renderSettings } from './ui/settings.js';
+import { openEditor } from './ui/components/editor.js';
+import { renderTable } from './ui/components/table.js';
+import { renderCards } from './ui/components/cards.js';
+import { renderStats } from './ui/components/stats.js';
+import { renderBuilder } from './ui/components/builder.js';
+import { renderFlashcards } from './ui/components/flashcards.js';
+import { renderReview } from './ui/components/review.js';
+import { renderQuiz } from './ui/components/quiz.js';
+import { renderExams, renderExamRunner } from './ui/components/exams.js';
+import { renderMap } from './ui/components/map.js';
+
+const tabs = ["Diseases","Drugs","Concepts","Study","Exams","Map","Settings"];
+
+async function render() {
+  const root = document.getElementById('app');
+  root.innerHTML = '';
+
+  const header = document.createElement('header');
+  header.className = 'header row';
+
+  const brand = document.createElement('div');
+  brand.className = 'brand';
+  brand.textContent = '✨ Sevenn';
+  header.appendChild(brand);
+
+  const nav = document.createElement('nav');
+  nav.className = 'tabs row';
+
+  tabs.forEach(t => {
+    const btn = document.createElement('button');
+    btn.className = 'tab' + (state.tab === t ? ' active' : '');
+    btn.textContent = t;
+    btn.addEventListener('click', () => {
+      setTab(t);
+      render();
+    });
+    nav.appendChild(btn);
+  });
+
+  header.appendChild(nav);
+  root.appendChild(header);
+
+  const main = document.createElement('main');
+  root.appendChild(main);
+  if (state.tab === 'Settings') {
+    await renderSettings(main);
+  } else if (['Diseases','Drugs','Concepts'].includes(state.tab)) {
+    const kindMap = { Diseases:'disease', Drugs:'drug', Concepts:'concept' };
+    const kind = kindMap[state.tab];
+    const addBtn = document.createElement('button');
+    addBtn.className = 'btn';
+    addBtn.textContent = 'Add ' + kind;
+    addBtn.addEventListener('click', () => openEditor(kind, render));
+    main.appendChild(addBtn);
+    const subnav = document.createElement('div');
+    subnav.className = 'tabs row subtabs';
+    ['Browse','Cards','Stats'].forEach(st => {
+      const sb = document.createElement('button');
+      sb.className = 'tab' + (state.subtab[state.tab] === st ? ' active' : '');
+      sb.textContent = st;
+      sb.addEventListener('click', () => {
+        setSubtab(state.tab, st);
+        render();
+      });
+      subnav.appendChild(sb);
+    });
+    main.appendChild(subnav);
+
+    const items = await listItemsByKind(kind);
+    if (state.subtab[state.tab] === 'Cards') {
+      renderCards(main, items, kind, render);
+    } else if (state.subtab[state.tab] === 'Stats') {
+      renderStats(main, items);
+    } else {
+      await renderTable(main, items, kind, render);
+    }
+  } else if (state.tab === 'Study') {
+    if (state.flashSession) {
+      renderFlashcards(main, render);
+    } else if (state.quizSession) {
+      renderQuiz(main, render);
+    } else {
+      const wrap = document.createElement('div');
+      await renderBuilder(wrap);
+      main.appendChild(wrap);
+
+      const subnav = document.createElement('div');
+      subnav.className = 'tabs row subtabs';
+      ['Flashcards','Review','Quiz'].forEach(st => {
+        const sb = document.createElement('button');
+        sb.className = 'tab' + (state.subtab.Study === st ? ' active' : '');
+        sb.textContent = st;
+        sb.addEventListener('click', () => {
+          setSubtab('Study', st);
+          render();
+        });
+        subnav.appendChild(sb);
+      });
+      main.appendChild(subnav);
+
+      if (state.cohort.length) {
+        if (state.subtab.Study === 'Flashcards') {
+          const startBtn = document.createElement('button');
+          startBtn.className = 'btn';
+          startBtn.textContent = 'Start Flashcards';
+          startBtn.addEventListener('click', () => {
+            setFlashSession({ idx: 0, pool: state.cohort });
+            render();
+          });
+          main.appendChild(startBtn);
+        } else if (state.subtab.Study === 'Review') {
+          renderReview(main, render);
+        } else {
+          const startBtn = document.createElement('button');
+          startBtn.className = 'btn';
+          startBtn.textContent = 'Start Quiz';
+          startBtn.addEventListener('click', () => {
+            setQuizSession({ idx:0, score:0, pool: state.cohort });
+            render();
+          });
+          main.appendChild(startBtn);
+        }
+      }
+    }
+  } else if (state.tab === 'Exams') {
+    if (state.examSession) {
+      renderExamRunner(main, render);
+    } else {
+      await renderExams(main, render);
+    }
+  } else if (state.tab === 'Map') {
+    await renderMap(main);
+  } else {
+    main.textContent = `Currently viewing: ${state.tab}`;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  await initDB();
+  render();
+});

--- a/js/search.js
+++ b/js/search.js
@@ -1,0 +1,12 @@
+export function tokenize(str) {
+  return str.toLowerCase().replace(/[^\p{L}\p{N}\s]/gu, ' ').split(/\s+/).filter(Boolean);
+}
+
+export function buildTokens(item) {
+  const fields = [];
+  if (item.name) fields.push(item.name);
+  if (item.concept) fields.push(item.concept);
+  fields.push(...(item.facts || []), ...(item.tags || []));
+  if (item.lectures) fields.push(...item.lectures.map(l => l.name));
+  return Array.from(new Set(tokenize(fields.join(' ')))).slice(0,200).join(' ');
+}

--- a/js/state.js
+++ b/js/state.js
@@ -1,0 +1,33 @@
+export const state = {
+  tab: "Diseases",
+  subtab: {
+    Diseases: "Browse",
+    Drugs: "Browse",
+    Concepts: "Browse",
+    Study: "Flashcards",
+    Exams: "", // placeholder
+    Map: "",
+    Settings: ""
+  },
+  query: "",
+  filters: { types:["disease","drug","concept"], block:"", week:"", onlyFav:false, sort:"updated" },
+  builder: { blocks:[], weeks:[], lectures:[], types:["disease","drug","concept"], tags:[], onlyFav:false, manualPicks:[] },
+  cohort: [],
+  review: { count:20, format:"flashcards" },
+  quizSession: null,
+  flashSession: null,
+  examSession: null,
+  map: { panzoom:false }
+};
+
+export function setTab(t){ state.tab = t; }
+export function setSubtab(tab, sub){ state.subtab[tab] = sub; }
+export function setQuery(q){ state.query = q; }
+export function setFilters(patch){ Object.assign(state.filters, patch); }
+export function setBuilder(patch){ Object.assign(state.builder, patch); }
+export function setCohort(items){ state.cohort = items; }
+export function resetTransientSessions(){ state.quizSession = null; state.flashSession = null; state.examSession = null; }
+export function setFlashSession(sess){ state.flashSession = sess; }
+export function setQuizSession(sess){ state.quizSession = sess; }
+export function setReviewConfig(patch){ Object.assign(state.review, patch); }
+export function setExamSession(sess){ state.examSession = sess; }

--- a/js/storage/export.js
+++ b/js/storage/export.js
@@ -1,0 +1,121 @@
+import { openDB } from './idb.js';
+import { buildTokens } from '../search.js';
+
+function prom(req){
+  return new Promise((resolve,reject)=>{
+    req.onsuccess = ()=> resolve(req.result);
+    req.onerror = ()=> reject(req.error);
+  });
+}
+
+export async function exportJSON(){
+  const db = await openDB();
+  const tx = db.transaction(['items','blocks','exams','settings']);
+  const items = await prom(tx.objectStore('items').getAll());
+  const blocks = await prom(tx.objectStore('blocks').getAll());
+  const exams = await prom(tx.objectStore('exams').getAll());
+  const settingsArr = await prom(tx.objectStore('settings').getAll());
+  const settings = settingsArr.find(s => s.id === 'app') || { id:'app', dailyCount:20, theme:'dark' };
+  return { items, blocks, exams, settings };
+}
+
+export async function importJSON(dbDump){
+  try {
+    const db = await openDB();
+    const tx = db.transaction(['items','blocks','exams','settings'],'readwrite');
+    const items = tx.objectStore('items');
+    const blocks = tx.objectStore('blocks');
+    const exams = tx.objectStore('exams');
+    const settings = tx.objectStore('settings');
+
+    await Promise.all([
+      prom(items.clear()),
+      prom(blocks.clear()),
+      prom(exams.clear()),
+      prom(settings.clear())
+    ]);
+
+    if (dbDump.settings) await prom(settings.put({ ...dbDump.settings, id:'app' }));
+    if (Array.isArray(dbDump.blocks)) {
+      for (const b of dbDump.blocks) {
+        await prom(blocks.put(b));
+      }
+    }
+    if (Array.isArray(dbDump.items)) {
+      for (const it of dbDump.items) {
+        it.tokens = buildTokens(it);
+        await prom(items.put(it));
+      }
+    }
+    if (Array.isArray(dbDump.exams)) {
+      for (const ex of dbDump.exams) {
+        await prom(exams.put(ex));
+      }
+    }
+
+    await new Promise((resolve,reject)=>{ tx.oncomplete=()=>resolve(); tx.onerror=()=>reject(tx.error); });
+    return { ok:true, message:'Import complete' };
+  } catch (e) {
+    return { ok:false, message:e.message };
+  }
+}
+
+function escapeCSV(value){
+  return '"' + String(value).replace(/"/g,'""') + '"';
+}
+
+export async function exportAnkiCSV(profile, cohort){
+  const rows = [];
+  if (profile === 'cloze') {
+    const regex = /\{\{c\d+::(.*?)\}\}/g;
+    for (const item of cohort) {
+      const title = item.name || item.concept || '';
+      for (const [key, val] of Object.entries(item)) {
+        if (typeof val !== 'string') continue;
+        let m;
+        while ((m = regex.exec(val))) {
+          const answer = m[1];
+          const question = val.replace(regex, '_____');
+          rows.push([question, answer, title]);
+        }
+      }
+    }
+  } else {
+    const qaMap = {
+      disease: [
+        ['etiology','Etiology of NAME?'],
+        ['pathophys','Pathophysiology of NAME?'],
+        ['clinical','Clinical features of NAME?'],
+        ['diagnosis','Diagnosis of NAME?'],
+        ['treatment','Treatment of NAME?'],
+        ['complications','Complications of NAME?']
+      ],
+      drug: [
+        ['class','Class of NAME?'],
+        ['moa','Mechanism of action of NAME?'],
+        ['uses','Uses of NAME?'],
+        ['sideEffects','Side effects of NAME?'],
+        ['contraindications','Contraindications of NAME?']
+      ],
+      concept: [
+        ['definition','Definition of NAME?'],
+        ['mechanism','Mechanism of NAME?'],
+        ['clinicalRelevance','Clinical relevance of NAME?'],
+        ['example','Example of NAME?']
+      ]
+    };
+    for (const item of cohort) {
+      const title = item.name || item.concept || '';
+      const mappings = qaMap[item.kind] || [];
+      for (const [field, tmpl] of mappings) {
+        const val = item[field];
+        if (!val) continue;
+        const question = tmpl.replace('NAME', title);
+        rows.push([question, val, title]);
+      }
+    }
+  }
+  const csv = rows.map(r => r.map(escapeCSV).join(',')).join('\n');
+  return new Blob([csv], { type:'text/csv' });
+}
+

--- a/js/storage/idb.js
+++ b/js/storage/idb.js
@@ -1,0 +1,39 @@
+const DB_NAME = 'sevenn-db';
+const DB_VERSION = 1;
+
+export function openDB() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onerror = () => reject(req.error);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+
+      if (!db.objectStoreNames.contains('items')) {
+        const items = db.createObjectStore('items', { keyPath: 'id' });
+        items.createIndex('by_kind', 'kind');
+        items.createIndex('by_updatedAt', 'updatedAt');
+        items.createIndex('by_favorite', 'favorite');
+        items.createIndex('by_blocks', 'blocks', { multiEntry: true });
+        items.createIndex('by_weeks', 'weeks', { multiEntry: true });
+        items.createIndex('by_lecture_ids', 'lectures.id', { multiEntry: true });
+        items.createIndex('by_search', 'tokens');
+      }
+
+      if (!db.objectStoreNames.contains('blocks')) {
+        const blocks = db.createObjectStore('blocks', { keyPath: 'blockId' });
+        blocks.createIndex('by_title', 'title');
+        blocks.createIndex('by_createdAt', 'createdAt');
+      }
+
+      if (!db.objectStoreNames.contains('exams')) {
+        const exams = db.createObjectStore('exams', { keyPath: 'id' });
+        exams.createIndex('by_createdAt', 'createdAt');
+      }
+
+      if (!db.objectStoreNames.contains('settings')) {
+        db.createObjectStore('settings', { keyPath: 'id' });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+  });
+}

--- a/js/storage/storage.js
+++ b/js/storage/storage.js
@@ -1,0 +1,139 @@
+import { openDB } from './idb.js';
+import { exportJSON, importJSON, exportAnkiCSV } from './export.js';
+
+let dbPromise;
+
+function prom(req) {
+  return new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function store(name, mode = 'readonly') {
+  const db = await dbPromise;
+  return db.transaction(name, mode).objectStore(name);
+}
+
+export async function initDB() {
+  if (!dbPromise) dbPromise = openDB();
+  const s = await store('settings', 'readwrite');
+  const existing = await prom(s.get('app'));
+  if (!existing) {
+    await prom(s.put({ id: 'app', dailyCount: 20, theme: 'dark' }));
+  }
+}
+
+export async function getSettings() {
+  const s = await store('settings');
+  const settings = await prom(s.get('app'));
+  return settings || { id: 'app', dailyCount: 20, theme: 'dark' };
+}
+
+export async function saveSettings(patch) {
+  const s = await store('settings', 'readwrite');
+  const current = await prom(s.get('app')) || { id: 'app', dailyCount: 20, theme: 'dark' };
+  const next = { ...current, ...patch, id: 'app' };
+  await prom(s.put(next));
+}
+
+export async function listBlocks() {
+  const b = await store('blocks');
+  return await prom(b.getAll());
+}
+
+export async function upsertBlock(def) {
+  const b = await store('blocks', 'readwrite');
+  const existing = await prom(b.get(def.blockId));
+  const now = Date.now();
+  const next = {
+    ...def,
+    lectures: def.lectures || [],
+    createdAt: existing?.createdAt || now,
+    updatedAt: now
+  };
+  await prom(b.put(next));
+}
+
+export async function deleteBlock(blockId) {
+  const b = await store('blocks', 'readwrite');
+  await prom(b.delete(blockId));
+}
+
+import { buildTokens } from '../search.js';
+import { cleanItem } from '../validators.js';
+
+export async function listItemsByKind(kind) {
+  const i = await store('items');
+  const idx = i.index('by_kind');
+  return await prom(idx.getAll(kind));
+}
+
+export async function getItem(id) {
+  const i = await store('items');
+  return await prom(i.get(id));
+}
+
+export async function upsertItem(item) {
+  const i = await store('items', 'readwrite');
+  const existing = await prom(i.get(item.id));
+  const now = Date.now();
+  const next = cleanItem({
+    ...item,
+    createdAt: existing?.createdAt || now,
+    updatedAt: now,
+  });
+  next.tokens = buildTokens(next);
+  // enforce link symmetry (basic)
+  for (const link of next.links) {
+    const other = await prom(i.get(link.id));
+    if (other) {
+      other.links = other.links || [];
+      if (!other.links.find(l => l.id === next.id)) {
+        other.links.push({ id: next.id, type: link.type });
+        other.tokens = buildTokens(other);
+        await prom(i.put(other));
+      }
+    }
+  }
+  await prom(i.put(next));
+}
+
+export async function deleteItem(id) {
+  const i = await store('items', 'readwrite');
+  const all = await prom(i.getAll());
+  for (const it of all) {
+    if (it.links?.some(l => l.id === id)) {
+      it.links = it.links.filter(l => l.id !== id);
+      it.tokens = buildTokens(it);
+      await prom(i.put(it));
+    }
+  }
+  await prom(i.delete(id));
+}
+
+export async function listExams() {
+  const e = await store('exams');
+  return await prom(e.getAll());
+}
+
+export async function upsertExam(exam) {
+  const e = await store('exams', 'readwrite');
+  const existing = await prom(e.get(exam.id));
+  const now = Date.now();
+  const next = {
+    ...exam,
+    createdAt: existing?.createdAt || now,
+    updatedAt: now,
+    results: exam.results || existing?.results || []
+  };
+  await prom(e.put(next));
+}
+
+export async function deleteExam(id) {
+  const e = await store('exams', 'readwrite');
+  await prom(e.delete(id));
+}
+
+// export/import helpers
+export { exportJSON, importJSON, exportAnkiCSV };

--- a/js/types.js
+++ b/js/types.js
@@ -1,0 +1,57 @@
+/** @typedef {"disease"|"drug"|"concept"} Kind */
+/** @typedef {"assoc"|"treats"|"causes"|"mech"|"contra"} LinkType */
+
+/** @typedef {{ box:number, last:number, due:number, ease:number }} SR */
+
+/** @typedef {{ blockId:string, id:number, name:string, week:number }} LectureRef */
+
+/// Base item
+/**
+ * @typedef {Object} Base
+ * @property {string} id
+ * @property {Kind} kind
+ * @property {boolean} favorite
+ * @property {string|null} color         // pastel override or null
+ * @property {string[]} facts            // chips
+ * @property {string[]} tags             // chips
+ * @property {{id:string, type:LinkType}[]} links
+ * @property {string[]} blocks           // ["F1","MSK"]
+ * @property {number[]} weeks            // [1,3]
+ * @property {LectureRef[]} lectures     // chosen by number → resolves name+week
+ * @property {number} createdAt
+ * @property {number} updatedAt
+ * @property {SR} sr
+ */
+
+/** @typedef {Base & {
+ *  kind:"disease", name:string, etiology:string, pathophys:string,
+ *  clinical:string, diagnosis:string, treatment:string, complications:string, mnemonic:string
+ * }} Disease */
+
+/** @typedef {Base & {
+ *  kind:"drug", name:string, class:string, source:string, moa:string, uses:string,
+ *  sideEffects:string, contraindications:string, mnemonic:string
+ * }} Drug */
+
+/** @typedef {Base & {
+ *  kind:"concept", concept:string, type:string, definition:string,
+ *  mechanism:string, clinicalRelevance:string, example:string, mnemonic:string
+ * }} Concept */
+
+/** @typedef {Disease|Drug|Concept} Item */
+
+/** @typedef {{ blockId:string, title:string, weeks:number,
+ *              lectures:{id:number, name:string, week:number}[],
+ *              createdAt:number, updatedAt:number }} BlockDef */
+
+/** @typedef {{ id:string, stem:string, options:{id:string,text:string}[], answer:string, explanation?:string, tags?:string[] }} Question */
+
+/** @typedef {{ id:string, examTitle:string, block?:string, week?:string,
+ *   timerMode:"timed"|"untimed", secondsPerQuestion:number,
+ *   questions:Question[], results:ExamResult[] }} Exam */
+
+/** @typedef {{ when:number, correct:number, total:number, answers:Record<number,string> }} ExamResult */
+
+/** @typedef {{ dailyCount:number, theme:"dark" }} Settings */
+
+/** @typedef {{ items:Item[], blocks:BlockDef[], exams:Exam[], settings:Settings }} DB */

--- a/js/ui/components/builder.js
+++ b/js/ui/components/builder.js
@@ -1,0 +1,116 @@
+import { state, setBuilder, setCohort } from '../../state.js';
+import { listBlocks, listItemsByKind } from '../../storage/storage.js';
+
+// Render Study Builder panel
+export async function renderBuilder(root) {
+  root.innerHTML = '';
+  const wrap = document.createElement('div');
+  wrap.className = 'builder';
+  root.appendChild(wrap);
+
+  // Blocks selection
+  const blocks = await listBlocks();
+  const blockSection = document.createElement('div');
+  blockSection.className = 'builder-section';
+  const blockTitle = document.createElement('div');
+  blockTitle.textContent = 'Blocks:';
+  blockSection.appendChild(blockTitle);
+  blocks.forEach(b => {
+    const label = document.createElement('label');
+    label.className = 'row';
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.checked = state.builder.blocks.includes(b.blockId);
+    cb.addEventListener('change', () => {
+      const set = new Set(state.builder.blocks);
+      if (cb.checked) set.add(b.blockId); else set.delete(b.blockId);
+      setBuilder({ blocks: Array.from(set) });
+    });
+    label.appendChild(cb);
+    label.appendChild(document.createTextNode(b.title || b.blockId));
+    blockSection.appendChild(label);
+  });
+  wrap.appendChild(blockSection);
+
+  // Week selection (1-8)
+  const weekSection = document.createElement('div');
+  weekSection.className = 'builder-section';
+  const weekTitle = document.createElement('div');
+  weekTitle.textContent = 'Weeks:';
+  weekSection.appendChild(weekTitle);
+  for (let w = 1; w <= 8; w++) {
+    const label = document.createElement('label');
+    label.className = 'row';
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.checked = state.builder.weeks.includes(w);
+    cb.addEventListener('change', () => {
+      const set = new Set(state.builder.weeks);
+      if (cb.checked) set.add(w); else set.delete(w);
+      setBuilder({ weeks: Array.from(set) });
+    });
+    label.appendChild(cb);
+    label.appendChild(document.createTextNode(String(w)));
+    weekSection.appendChild(label);
+  }
+  wrap.appendChild(weekSection);
+
+  // Type selection
+  const typeSection = document.createElement('div');
+  typeSection.className = 'builder-section';
+  const typeTitle = document.createElement('div');
+  typeTitle.textContent = 'Types:';
+  typeSection.appendChild(typeTitle);
+  const typeMap = { disease: 'Disease', drug: 'Drug', concept: 'Concept' };
+  Object.entries(typeMap).forEach(([val, labelText]) => {
+    const label = document.createElement('label');
+    label.className = 'row';
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.checked = state.builder.types.includes(val);
+    cb.addEventListener('change', () => {
+      const set = new Set(state.builder.types);
+      if (cb.checked) set.add(val); else set.delete(val);
+      setBuilder({ types: Array.from(set) });
+    });
+    label.appendChild(cb);
+    label.appendChild(document.createTextNode(labelText));
+    typeSection.appendChild(label);
+  });
+  wrap.appendChild(typeSection);
+
+  // Favorites toggle
+  const favSection = document.createElement('label');
+  favSection.className = 'row';
+  const favCb = document.createElement('input');
+  favCb.type = 'checkbox';
+  favCb.checked = state.builder.onlyFav;
+  favCb.addEventListener('change', () => setBuilder({ onlyFav: favCb.checked }));
+  favSection.appendChild(favCb);
+  favSection.appendChild(document.createTextNode('Only favorites'));
+  wrap.appendChild(favSection);
+
+  // Build button and result count
+  const buildBtn = document.createElement('button');
+  buildBtn.className = 'btn btn-primary';
+  buildBtn.textContent = 'Build Set';
+  const count = document.createElement('div');
+  count.className = 'builder-count';
+  count.textContent = `Set size: ${state.cohort.length}`;
+  buildBtn.addEventListener('click', async () => {
+    let items = [];
+    for (const kind of state.builder.types) {
+      items = items.concat(await listItemsByKind(kind));
+    }
+    items = items.filter(it => {
+      if (state.builder.onlyFav && !it.favorite) return false;
+      if (state.builder.blocks.length && !it.blocks?.some(b => state.builder.blocks.includes(b))) return false;
+      if (state.builder.weeks.length && !it.weeks?.some(w => state.builder.weeks.includes(w))) return false;
+      return true;
+    });
+    setCohort(items);
+    count.textContent = `Set size: ${items.length}`;
+  });
+  wrap.appendChild(buildBtn);
+  wrap.appendChild(count);
+}

--- a/js/ui/components/cards.js
+++ b/js/ui/components/cards.js
@@ -1,0 +1,29 @@
+import { createTitleCell } from './titlecell.js';
+
+function pickSummary(item, kind){
+  const fields = {
+    disease: ['etiology','pathophys','clinical','diagnosis','treatment'],
+    drug: ['class','moa','uses','sideEffects'],
+    concept: ['definition','mechanism','clinicalRelevance','example']
+  }[kind] || [];
+  for (const f of fields) {
+    if (item[f]) return item[f];
+  }
+  return '';
+}
+
+export function renderCards(container, items, kind, onChange){
+  const grid = document.createElement('div');
+  grid.className = 'card-grid';
+  items.forEach(it => {
+    const card = document.createElement('div');
+    card.className = 'card';
+    card.appendChild(createTitleCell(it, onChange));
+    const summary = document.createElement('div');
+    summary.className = 'summary';
+    summary.textContent = pickSummary(it, kind);
+    card.appendChild(summary);
+    grid.appendChild(card);
+  });
+  container.appendChild(grid);
+}

--- a/js/ui/components/chips.js
+++ b/js/ui/components/chips.js
@@ -1,0 +1,49 @@
+export function chipsInput(values = [], onChange) {
+  const box = document.createElement('div');
+  box.className = 'chips';
+
+  function render() {
+    box.innerHTML = '';
+    values.forEach((v, i) => {
+      const chip = document.createElement('span');
+      chip.className = 'chip';
+      chip.textContent = v;
+      const x = document.createElement('button');
+      x.className = 'chip-remove';
+      x.textContent = '×';
+      x.addEventListener('click', () => {
+        values.splice(i, 1);
+        render();
+        onChange && onChange(values);
+      });
+      chip.appendChild(x);
+      box.appendChild(chip);
+    });
+    const input = document.createElement('input');
+    input.className = 'chip-input';
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' && input.value.trim()) {
+        values.push(input.value.trim());
+        input.value = '';
+        render();
+        onChange && onChange(values);
+      }
+    });
+    box.appendChild(input);
+  }
+
+  render();
+  return box;
+}
+
+export function chipList(values = []) {
+  const box = document.createElement('div');
+  box.className = 'chips';
+  values.forEach(v => {
+    const chip = document.createElement('span');
+    chip.className = 'chip';
+    chip.textContent = v;
+    box.appendChild(chip);
+  });
+  return box;
+}

--- a/js/ui/components/editor.js
+++ b/js/ui/components/editor.js
@@ -1,0 +1,53 @@
+import { uid } from '../../utils.js';
+import { upsertItem } from '../../storage/storage.js';
+
+export function openEditor(kind, onSave, existing = null) {
+  const overlay = document.createElement('div');
+  overlay.className = 'modal';
+
+  const form = document.createElement('form');
+  form.className = 'card';
+
+  const title = document.createElement('h2');
+  title.textContent = (existing ? 'Edit ' : 'Add ') + kind;
+  form.appendChild(title);
+
+  const nameLabel = document.createElement('label');
+  nameLabel.textContent = kind === 'concept' ? 'Concept' : 'Name';
+  const nameInput = document.createElement('input');
+  nameInput.className = 'input';
+  nameInput.value = existing ? (existing.name || existing.concept || '') : '';
+  nameLabel.appendChild(nameInput);
+  form.appendChild(nameLabel);
+
+  const saveBtn = document.createElement('button');
+  saveBtn.type = 'submit';
+  saveBtn.className = 'btn';
+  saveBtn.textContent = 'Save';
+  form.appendChild(saveBtn);
+
+  const cancel = document.createElement('button');
+  cancel.type = 'button';
+  cancel.className = 'btn';
+  cancel.textContent = 'Cancel';
+  cancel.addEventListener('click', () => document.body.removeChild(overlay));
+  form.appendChild(cancel);
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const titleKey = kind === 'concept' ? 'concept' : 'name';
+    const item = existing || { id: uid(), kind };
+    item[titleKey] = nameInput.value.trim();
+    if (!item[titleKey]) return;
+    await upsertItem(item);
+    document.body.removeChild(overlay);
+    onSave && onSave();
+  });
+
+  overlay.appendChild(form);
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) document.body.removeChild(overlay);
+  });
+  document.body.appendChild(overlay);
+  nameInput.focus();
+}

--- a/js/ui/components/exams.js
+++ b/js/ui/components/exams.js
@@ -1,0 +1,78 @@
+import { listExams, upsertExam } from '../../storage/storage.js';
+import { state, setExamSession } from '../../state.js';
+
+// render list and import of exams
+export async function renderExams(root, render) {
+  root.innerHTML = '';
+
+  // Import button
+  const fileInput = document.createElement('input');
+  fileInput.type = 'file';
+  fileInput.accept = 'application/json';
+  fileInput.addEventListener('change', async e => {
+    const file = e.target.files[0];
+    if (!file) return;
+    try {
+      const text = await file.text();
+      const exam = JSON.parse(text);
+      exam.id = exam.id || crypto.randomUUID();
+      exam.createdAt = exam.createdAt || Date.now();
+      exam.updatedAt = Date.now();
+      exam.results = exam.results || [];
+      await upsertExam(exam);
+      render();
+    } catch (err) {
+      alert('Invalid exam JSON');
+    }
+  });
+  root.appendChild(fileInput);
+
+  // existing exams list
+  const exams = await listExams();
+  const list = document.createElement('div');
+  exams.forEach(ex => {
+    const row = document.createElement('div');
+    row.className = 'row';
+    const title = document.createElement('span');
+    title.textContent = ex.examTitle;
+    const start = document.createElement('button');
+    start.className = 'btn';
+    start.textContent = 'Start';
+    start.addEventListener('click', () => {
+      setExamSession({ exam: ex, idx: 0, answers: [] });
+      render();
+    });
+    row.appendChild(title);
+    row.appendChild(start);
+    list.appendChild(row);
+  });
+  root.appendChild(list);
+}
+
+export function renderExamRunner(root, render) {
+  const sess = state.examSession;
+  const q = sess.exam.questions[sess.idx];
+  root.innerHTML = '';
+  const h = document.createElement('h2');
+  h.textContent = `Question ${sess.idx + 1} / ${sess.exam.questions.length}`;
+  root.appendChild(h);
+  const stem = document.createElement('p');
+  stem.textContent = q.stem;
+  root.appendChild(stem);
+  q.options.forEach(opt => {
+    const btn = document.createElement('button');
+    btn.className = 'btn';
+    btn.textContent = opt.text;
+    btn.addEventListener('click', () => {
+      sess.answers.push(opt.id);
+      sess.idx++;
+      if (sess.idx >= sess.exam.questions.length) {
+        const correct = sess.exam.questions.filter((qu, i) => sess.answers[i] === qu.answer).length;
+        alert(`Score: ${correct}/${sess.exam.questions.length}`);
+        setExamSession(null);
+      }
+      render();
+    });
+    root.appendChild(btn);
+  });
+}

--- a/js/ui/components/flashcards.js
+++ b/js/ui/components/flashcards.js
@@ -1,0 +1,128 @@
+import { state, setFlashSession } from '../../state.js';
+
+// Render flashcards session. Uses session.pool if provided, else state.cohort
+export function renderFlashcards(root, redraw) {
+  const session = state.flashSession || { idx: 0, pool: state.cohort };
+  const items = session.pool || state.cohort;
+  root.innerHTML = '';
+
+  if (!items.length) {
+    const msg = document.createElement('div');
+    msg.textContent = 'No items in cohort.';
+    root.appendChild(msg);
+    return;
+  }
+
+  if (session.idx >= items.length) {
+    setFlashSession(null);
+    redraw();
+    return;
+  }
+
+  const item = items[session.idx];
+  const { question, answer, details } = buildCard(item);
+
+  const card = document.createElement('section');
+  card.className = 'card flashcard';
+  card.tabIndex = 0;
+
+  const qEl = document.createElement('div');
+  qEl.className = 'flash-question';
+  qEl.textContent = question;
+  card.appendChild(qEl);
+
+  const aEl = document.createElement('div');
+  aEl.className = 'flash-answer';
+  aEl.textContent = answer + (details ? '\n' + details : '');
+  card.appendChild(aEl);
+
+  const controls = document.createElement('div');
+  controls.className = 'row';
+
+  const prev = document.createElement('button');
+  prev.className = 'btn';
+  prev.textContent = 'Prev';
+  prev.disabled = session.idx === 0;
+  prev.addEventListener('click', () => {
+    if (session.idx > 0) {
+      setFlashSession({ idx: session.idx - 1, pool: items });
+      redraw();
+    }
+  });
+  controls.appendChild(prev);
+
+  const reveal = document.createElement('button');
+  reveal.className = 'btn';
+  reveal.textContent = 'Reveal';
+  reveal.addEventListener('click', () => {
+    card.classList.toggle('revealed');
+  });
+  controls.appendChild(reveal);
+
+  const next = document.createElement('button');
+  next.className = 'btn';
+  next.textContent = session.idx < items.length - 1 ? 'Next' : 'Finish';
+  next.addEventListener('click', () => {
+    const idx = session.idx + 1;
+    if (idx >= items.length) {
+      setFlashSession(null);
+    } else {
+      setFlashSession({ idx, pool: items });
+    }
+    redraw();
+  });
+  controls.appendChild(next);
+
+  const exit = document.createElement('button');
+  exit.className = 'btn';
+  exit.textContent = 'End';
+  exit.addEventListener('click', () => {
+    setFlashSession(null);
+    redraw();
+  });
+  controls.appendChild(exit);
+
+  card.appendChild(controls);
+  root.appendChild(card);
+
+  card.focus();
+  card.addEventListener('keydown', (e) => {
+    if (e.code === 'Space') {
+      e.preventDefault();
+      reveal.click();
+    } else if (e.key === 'ArrowRight') {
+      next.click();
+    } else if (e.key === 'ArrowLeft') {
+      prev.click();
+    }
+  });
+}
+
+function buildCard(item) {
+  const mainMap = {
+    disease: ['pathophys', 'clinical', 'treatment'],
+    drug: ['moa', 'uses', 'sideEffects'],
+    concept: ['definition', 'mechanism', 'clinicalRelevance']
+  };
+  const extraMap = {
+    disease: ['mnemonic', 'diagnosis', 'complications'],
+    drug: ['mnemonic', 'contraindications'],
+    concept: ['mnemonic', 'example']
+  };
+
+  const fields = mainMap[item.kind] || [];
+  let questionField = '';
+  for (const f of fields) {
+    if (item[f]) { questionField = item[f]; break; }
+  }
+  let question = questionField || '';
+  const answers = [];
+  question = question.replace(/{{c\d+::(.*?)}}/g, (_m, p1) => { answers.push(p1); return '_____'; });
+  const answer = answers.length ? answers.join(' / ') : (item.name || item.concept || '');
+
+  const detailParts = [];
+  fields.filter(f => f !== fields[0]).forEach(f => { if (item[f]) detailParts.push(item[f]); });
+  (extraMap[item.kind] || []).forEach(f => { if (item[f]) detailParts.push(item[f]); });
+  const details = detailParts.join('\n');
+  return { question, answer, details };
+}

--- a/js/ui/components/linker.js
+++ b/js/ui/components/linker.js
@@ -1,0 +1,3 @@
+export function openLinker() {
+  alert('Linker not implemented yet');
+}

--- a/js/ui/components/map.js
+++ b/js/ui/components/map.js
@@ -1,0 +1,59 @@
+import { listItemsByKind } from '../../storage/storage.js';
+import { showPopup } from './popup.js';
+
+export async function renderMap(root){
+  root.innerHTML = '';
+  const items = [
+    ...(await listItemsByKind('disease')),
+    ...(await listItemsByKind('drug')),
+    ...(await listItemsByKind('concept'))
+  ];
+  const size = 600;
+  const center = size/2;
+  const radius = size/2 - 40;
+  const svg = document.createElementNS('http://www.w3.org/2000/svg','svg');
+  svg.setAttribute('viewBox',`0 0 ${size} ${size}`);
+  svg.classList.add('map-svg');
+  const positions = {};
+  items.forEach((it, idx) => {
+    const angle = (2*Math.PI*idx)/items.length;
+    const x = center + radius*Math.cos(angle);
+    const y = center + radius*Math.sin(angle);
+    positions[it.id] = {x,y};
+  });
+  // edges
+  const drawn = new Set();
+  items.forEach(it => {
+    (it.links||[]).forEach(l => {
+      if (!positions[l.id]) return;
+      const key = it.id < l.id ? it.id + '|' + l.id : l.id + '|' + it.id;
+      if (drawn.has(key)) return;
+      drawn.add(key);
+      const line = document.createElementNS('http://www.w3.org/2000/svg','line');
+      line.setAttribute('x1', positions[it.id].x);
+      line.setAttribute('y1', positions[it.id].y);
+      line.setAttribute('x2', positions[l.id].x);
+      line.setAttribute('y2', positions[l.id].y);
+      line.setAttribute('class','map-edge');
+      svg.appendChild(line);
+    });
+  });
+  // nodes
+  items.forEach(it => {
+    const pos = positions[it.id];
+    const circle = document.createElementNS('http://www.w3.org/2000/svg','circle');
+    circle.setAttribute('cx', pos.x);
+    circle.setAttribute('cy', pos.y);
+    circle.setAttribute('r', 16);
+    circle.setAttribute('class','map-node');
+    circle.addEventListener('click', () => showPopup(it));
+    svg.appendChild(circle);
+    const text = document.createElementNS('http://www.w3.org/2000/svg','text');
+    text.setAttribute('x', pos.x);
+    text.setAttribute('y', pos.y - 20);
+    text.setAttribute('class','map-label');
+    text.textContent = it.name || it.concept || '?';
+    svg.appendChild(text);
+  });
+  root.appendChild(svg);
+}

--- a/js/ui/components/popup.js
+++ b/js/ui/components/popup.js
@@ -1,0 +1,25 @@
+export function showPopup(item){
+  const modal = document.createElement('div');
+  modal.className = 'modal';
+  const card = document.createElement('div');
+  card.className = 'card';
+  const title = document.createElement('h2');
+  title.textContent = item.name || item.concept || 'Item';
+  card.appendChild(title);
+  const kind = document.createElement('div');
+  kind.textContent = `Type: ${item.kind}`;
+  card.appendChild(kind);
+  if (item.mnemonic){
+    const m = document.createElement('div');
+    m.textContent = `Mnemonic: ${item.mnemonic}`;
+    card.appendChild(m);
+  }
+  const close = document.createElement('button');
+  close.className = 'btn';
+  close.textContent = 'Close';
+  close.addEventListener('click', () => modal.remove());
+  card.appendChild(close);
+  modal.appendChild(card);
+  modal.addEventListener('click', e => { if (e.target === modal) modal.remove(); });
+  document.body.appendChild(modal);
+}

--- a/js/ui/components/quiz.js
+++ b/js/ui/components/quiz.js
@@ -1,0 +1,74 @@
+import { state, setQuizSession } from '../../state.js';
+
+function titleOf(item){
+  return item.name || item.concept || '';
+}
+function questionOf(item){
+  return item.definition || item.pathophys || item.clinical || item.moa || item.uses || '';
+}
+
+export function renderQuiz(root, redraw){
+  const sess = state.quizSession;
+  if (!sess) return;
+
+  if (!sess.dict){
+    sess.dict = sess.pool.map(it => ({id:it.id, title:titleOf(it), lower:titleOf(it).toLowerCase()}));
+  }
+
+  const item = sess.pool[sess.idx];
+  if (!item){
+    const done = document.createElement('div');
+    done.textContent = `Score ${sess.score}/${sess.pool.length}`;
+    const btn = document.createElement('button');
+    btn.className = 'btn';
+    btn.textContent = 'Done';
+    btn.addEventListener('click', () => { setQuizSession(null); redraw(); });
+    done.appendChild(document.createElement('br'));
+    done.appendChild(btn);
+    root.appendChild(done);
+    return;
+  }
+
+  const form = document.createElement('form');
+  form.className = 'quiz-form';
+
+  const q = document.createElement('div');
+  q.className = 'quiz-question';
+  q.textContent = questionOf(item);
+  form.appendChild(q);
+
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.autocomplete = 'off';
+  form.appendChild(input);
+
+  const sug = document.createElement('ul');
+  sug.className = 'quiz-suggestions';
+  form.appendChild(sug);
+
+  input.addEventListener('input', () => {
+    const v = input.value.toLowerCase();
+    sug.innerHTML = '';
+    if (!v) return;
+    const starts = sess.dict.filter(d => d.lower.startsWith(v));
+    const contains = sess.dict.filter(d => !d.lower.startsWith(v) && d.lower.includes(v));
+    [...starts, ...contains].slice(0,5).forEach(d => {
+      const li = document.createElement('li');
+      li.textContent = d.title;
+      li.addEventListener('mousedown', () => { input.value = d.title; sug.innerHTML=''; });
+      sug.appendChild(li);
+    });
+  });
+
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    const ans = input.value.trim().toLowerCase();
+    const correct = titleOf(item).toLowerCase();
+    if (ans === correct) sess.score++;
+    sess.idx++;
+    setQuizSession(sess);
+    redraw();
+  });
+
+  root.appendChild(form);
+}

--- a/js/ui/components/review.js
+++ b/js/ui/components/review.js
@@ -1,0 +1,77 @@
+import { state, setReviewConfig, setFlashSession, setQuizSession } from '../../state.js';
+
+// Render Review mode controls
+export function renderReview(root, redraw) {
+  const cfg = state.review;
+  const section = document.createElement('section');
+  section.className = 'review-controls';
+
+  const countLabel = document.createElement('label');
+  countLabel.textContent = 'Count:';
+  const countInput = document.createElement('input');
+  countInput.type = 'number';
+  countInput.min = '1';
+  countInput.value = cfg.count;
+  countInput.addEventListener('change', () => setReviewConfig({ count: Number(countInput.value) }));
+  countLabel.appendChild(countInput);
+  section.appendChild(countLabel);
+
+  const formatLabel = document.createElement('label');
+  formatLabel.textContent = 'Format:';
+  const formatSel = document.createElement('select');
+  ['flashcards','quiz'].forEach(f => {
+    const opt = document.createElement('option');
+    opt.value = f; opt.textContent = f;
+    if (cfg.format === f) opt.selected = true;
+    formatSel.appendChild(opt);
+  });
+  formatSel.addEventListener('change', () => setReviewConfig({ format: formatSel.value }));
+  formatLabel.appendChild(formatSel);
+  section.appendChild(formatLabel);
+
+  const startBtn = document.createElement('button');
+  startBtn.className = 'btn';
+  startBtn.textContent = 'Start Review';
+  startBtn.addEventListener('click', () => {
+    const items = sampleItems(state.cohort, cfg.count);
+    if (!items.length) return;
+    if (cfg.format === 'flashcards') {
+      setFlashSession({ idx: 0, pool: items });
+    } else {
+      setQuizSession({ idx:0, score:0, pool: items });
+    }
+    redraw();
+  });
+  section.appendChild(startBtn);
+
+  root.appendChild(section);
+}
+
+function sampleItems(cohort, count) {
+  const sorted = [...cohort].sort((a,b) => {
+    const ad = (a.sr && a.sr.due) || a.updatedAt || 0;
+    const bd = (b.sr && b.sr.due) || b.updatedAt || 0;
+    return ad - bd;
+  });
+  if (sorted.length <= count) return sorted;
+  const third = Math.ceil(sorted.length / 3);
+  const oldest = sorted.slice(0, third);
+  const middle = sorted.slice(third, third*2);
+  const newest = sorted.slice(third*2);
+  const take = (arr, n) => {
+    const out = [];
+    for (let i=0; i<n && arr.length; i++) {
+      const idx = Math.floor(Math.random()*arr.length);
+      out.push(arr.splice(idx,1)[0]);
+    }
+    return out;
+  };
+  const res = [];
+  const nOld = Math.round(count*0.6);
+  const nMid = Math.round(count*0.3);
+  const nNew = count - nOld - nMid;
+  res.push(...take(oldest, nOld));
+  res.push(...take(middle, nMid));
+  res.push(...take(newest, nNew));
+  return res;
+}

--- a/js/ui/components/stats.js
+++ b/js/ui/components/stats.js
@@ -1,0 +1,11 @@
+export function renderStats(container, items){
+  const wrap = document.createElement('div');
+  wrap.className = 'stats';
+  const total = document.createElement('div');
+  total.textContent = `Total items: ${items.length}`;
+  const fav = document.createElement('div');
+  fav.textContent = `Favorites: ${items.filter(i => i.favorite).length}`;
+  wrap.appendChild(total);
+  wrap.appendChild(fav);
+  container.appendChild(wrap);
+}

--- a/js/ui/components/table.js
+++ b/js/ui/components/table.js
@@ -1,0 +1,132 @@
+import { listBlocks } from '../../storage/storage.js';
+import { createTitleCell } from './titlecell.js';
+import { chipList } from './chips.js';
+
+const columnMap = {
+  disease: [
+    ['etiology', 'Etiology'],
+    ['pathophys', 'Pathophys'],
+    ['clinical', 'Clinical'],
+    ['diagnosis', 'Diagnosis'],
+    ['treatment', 'Treatment'],
+    ['complications', 'Complications'],
+    ['mnemonic', 'Mnemonic'],
+    ['facts', 'Facts']
+  ],
+  drug: [
+    ['class', 'Class'],
+    ['source', 'Source'],
+    ['moa', 'MOA'],
+    ['uses', 'Uses'],
+    ['sideEffects', 'Side Effects'],
+    ['contraindications', 'Contraindications'],
+    ['mnemonic', 'Mnemonic'],
+    ['facts', 'Facts']
+  ],
+  concept: [
+    ['type', 'Type'],
+    ['definition', 'Definition'],
+    ['mechanism', 'Mechanism'],
+    ['clinicalRelevance', 'Clinical Relevance'],
+    ['example', 'Example'],
+    ['mnemonic', 'Mnemonic'],
+    ['facts', 'Facts']
+  ]
+};
+
+export async function renderTable(container, items, kind, onChange) {
+  const blocks = await listBlocks();
+  const blockTitle = (id) => blocks.find(b => b.blockId === id)?.title || id;
+  const groups = new Map(); // block -> week -> items
+  items.forEach(it => {
+    const bs = it.blocks && it.blocks.length ? it.blocks : ['_'];
+    const ws = it.weeks && it.weeks.length ? it.weeks : ['_'];
+    bs.forEach(b => {
+      if (!groups.has(b)) groups.set(b, new Map());
+      const wkMap = groups.get(b);
+      ws.forEach(w => {
+        const arr = wkMap.get(w) || [];
+        arr.push(it);
+        wkMap.set(w, arr);
+      });
+    });
+  });
+
+  const sortedBlocks = Array.from(groups.keys()).sort((a, b) => {
+    if (a === '_' && b !== '_') return 1;
+    if (b === '_' && a !== '_') return -1;
+    return a.localeCompare(b);
+  });
+
+  sortedBlocks.forEach(b => {
+    const blockSec = document.createElement('section');
+    blockSec.className = 'block-section';
+    const h2 = document.createElement('h2');
+    h2.textContent = b === '_' ? 'Unassigned' : `${blockTitle(b)} (${b})`;
+    blockSec.appendChild(h2);
+
+    const wkMap = groups.get(b);
+    const sortedWeeks = Array.from(wkMap.keys()).sort((a, b) => {
+      if (a === '_' && b !== '_') return 1;
+      if (b === '_' && a !== '_') return -1;
+      return Number(a) - Number(b);
+    });
+
+    sortedWeeks.forEach(w => {
+      const weekSec = document.createElement('div');
+      weekSec.className = 'week-section';
+      const h3 = document.createElement('h3');
+      h3.textContent = w === '_' ? 'Unassigned' : `Week ${w}`;
+      weekSec.appendChild(h3);
+
+      const table = document.createElement('table');
+      table.className = 'table';
+
+      const thead = document.createElement('thead');
+      const hr = document.createElement('tr');
+      const thTitle = document.createElement('th');
+      thTitle.textContent = 'Title';
+      hr.appendChild(thTitle);
+      columnMap[kind].forEach(([, label]) => {
+        const th = document.createElement('th');
+        th.textContent = label;
+        hr.appendChild(th);
+      });
+      thead.appendChild(hr);
+      table.appendChild(thead);
+
+      const tbody = document.createElement('tbody');
+      const rows = wkMap.get(w);
+
+      function renderChunk(start = 0) {
+        const slice = rows.slice(start, start + 200);
+        slice.forEach(it => {
+          const tr = document.createElement('tr');
+          const td = document.createElement('td');
+          td.appendChild(createTitleCell(it, onChange));
+          tr.appendChild(td);
+          columnMap[kind].forEach(([field]) => {
+            const td2 = document.createElement('td');
+            if (field === 'facts') {
+              td2.appendChild(chipList(it.facts || []));
+            } else {
+              td2.textContent = it[field] || '';
+            }
+            tr.appendChild(td2);
+          });
+          tbody.appendChild(tr);
+        });
+        if (start + 200 < rows.length) {
+          requestAnimationFrame(() => renderChunk(start + 200));
+        }
+      }
+
+      renderChunk();
+      table.appendChild(tbody);
+      weekSec.appendChild(table);
+      blockSec.appendChild(weekSec);
+    });
+
+    container.appendChild(blockSec);
+  });
+}

--- a/js/ui/components/titlecell.js
+++ b/js/ui/components/titlecell.js
@@ -1,0 +1,53 @@
+import { upsertItem, deleteItem } from '../../storage/storage.js';
+import { openEditor } from './editor.js';
+
+export function createTitleCell(item, onChange) {
+  const wrap = document.createElement('div');
+  wrap.className = 'title-cell';
+
+  const title = document.createElement('div');
+  title.className = 'title';
+  title.textContent = item.name || item.concept || 'Untitled';
+  wrap.appendChild(title);
+
+  const meta = document.createElement('div');
+  meta.className = 'meta';
+  const blocks = (item.blocks || []).join('·');
+  const weeks = (item.weeks || []).map(w => 'W' + w).join('·');
+  meta.textContent = [blocks, weeks].filter(Boolean).join(' • ');
+  wrap.appendChild(meta);
+
+  const actions = document.createElement('div');
+  actions.className = 'actions row';
+
+  const fav = document.createElement('button');
+  fav.className = 'btn';
+  fav.textContent = item.favorite ? '★' : '☆';
+  fav.addEventListener('click', async () => {
+    item.favorite = !item.favorite;
+    await upsertItem(item);
+    fav.textContent = item.favorite ? '★' : '☆';
+    onChange && onChange();
+  });
+  actions.appendChild(fav);
+
+  const edit = document.createElement('button');
+  edit.className = 'btn';
+  edit.textContent = 'Edit';
+  edit.addEventListener('click', () => openEditor(item.kind, onChange, item));
+  actions.appendChild(edit);
+
+  const del = document.createElement('button');
+  del.className = 'btn';
+  del.textContent = 'Del';
+  del.addEventListener('click', async () => {
+    if (confirm('Delete this item?')) {
+      await deleteItem(item.id);
+      onChange && onChange();
+    }
+  });
+  actions.appendChild(del);
+
+  wrap.appendChild(actions);
+  return wrap;
+}

--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -1,0 +1,190 @@
+import { getSettings, saveSettings, listBlocks, upsertBlock, deleteBlock, exportJSON, importJSON, exportAnkiCSV } from '../storage/storage.js';
+
+export async function renderSettings(root) {
+  root.innerHTML = '';
+
+  const settings = await getSettings();
+
+  const settingsCard = document.createElement('section');
+  settingsCard.className = 'card';
+  const heading = document.createElement('h2');
+  heading.textContent = 'Settings';
+  settingsCard.appendChild(heading);
+
+  const dailyLabel = document.createElement('label');
+  dailyLabel.textContent = 'Daily review target:';
+  const dailyInput = document.createElement('input');
+  dailyInput.type = 'number';
+  dailyInput.className = 'input';
+  dailyInput.min = '1';
+  dailyInput.value = settings.dailyCount;
+  dailyInput.addEventListener('change', () => {
+    saveSettings({ dailyCount: Number(dailyInput.value) });
+  });
+  dailyLabel.appendChild(dailyInput);
+  settingsCard.appendChild(dailyLabel);
+
+  root.appendChild(settingsCard);
+
+  const blocksCard = document.createElement('section');
+  blocksCard.className = 'card';
+  const bHeading = document.createElement('h2');
+  bHeading.textContent = 'Blocks';
+  blocksCard.appendChild(bHeading);
+
+  const list = document.createElement('div');
+  list.className = 'block-list';
+  blocksCard.appendChild(list);
+
+  const blocks = await listBlocks();
+  blocks.forEach(b => {
+    const wrap = document.createElement('div');
+    wrap.className = 'block';
+    const title = document.createElement('h3');
+    title.textContent = `${b.blockId} – ${b.title}`;
+    wrap.appendChild(title);
+
+    const del = document.createElement('button');
+    del.className = 'btn';
+    del.textContent = 'Delete';
+    del.addEventListener('click', async () => {
+      if (confirm('Delete block?')) {
+        await deleteBlock(b.blockId);
+        await renderSettings(root);
+      }
+    });
+    wrap.appendChild(del);
+
+    const lecList = document.createElement('ul');
+    b.lectures.forEach(l => {
+      const li = document.createElement('li');
+      li.textContent = `${l.id}: ${l.name} (W${l.week})`;
+      lecList.appendChild(li);
+    });
+    wrap.appendChild(lecList);
+
+    const lecForm = document.createElement('form');
+    lecForm.className = 'row';
+    const idInput = document.createElement('input');
+    idInput.className = 'input';
+    idInput.placeholder = 'id';
+    idInput.type = 'number';
+    const nameInput = document.createElement('input');
+    nameInput.className = 'input';
+    nameInput.placeholder = 'name';
+    const weekInput = document.createElement('input');
+    weekInput.className = 'input';
+    weekInput.placeholder = 'week';
+    weekInput.type = 'number';
+    const addBtn = document.createElement('button');
+    addBtn.className = 'btn';
+    addBtn.type = 'submit';
+    addBtn.textContent = 'Add lecture';
+    lecForm.append(idInput, nameInput, weekInput, addBtn);
+    lecForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const lecture = { id: Number(idInput.value), name: nameInput.value.trim(), week: Number(weekInput.value) };
+      if (!lecture.id || !lecture.name || !lecture.week) return;
+      const updated = { ...b, lectures: [...b.lectures, lecture] };
+      await upsertBlock(updated);
+      await renderSettings(root);
+    });
+    wrap.appendChild(lecForm);
+
+    list.appendChild(wrap);
+  });
+
+  const form = document.createElement('form');
+  form.className = 'row';
+  const id = document.createElement('input');
+  id.className = 'input';
+  id.placeholder = 'ID';
+  const titleInput = document.createElement('input');
+  titleInput.className = 'input';
+  titleInput.placeholder = 'Title';
+  const weeks = document.createElement('input');
+  weeks.className = 'input';
+  weeks.type = 'number';
+  weeks.placeholder = 'Weeks';
+  const add = document.createElement('button');
+  add.className = 'btn';
+  add.type = 'submit';
+  add.textContent = 'Add block';
+  form.append(id, titleInput, weeks, add);
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const def = {
+      blockId: id.value.trim(),
+      title: titleInput.value.trim(),
+      weeks: Number(weeks.value),
+      lectures: [],
+    };
+    if (!def.blockId || !def.title || !def.weeks) return;
+    await upsertBlock(def);
+    await renderSettings(root);
+  });
+  blocksCard.appendChild(form);
+
+  root.appendChild(blocksCard);
+
+  const dataCard = document.createElement('section');
+  dataCard.className = 'card';
+  const dHeading = document.createElement('h2');
+  dHeading.textContent = 'Data';
+  dataCard.appendChild(dHeading);
+
+  const exportBtn = document.createElement('button');
+  exportBtn.className = 'btn';
+  exportBtn.textContent = 'Export DB';
+  exportBtn.addEventListener('click', async () => {
+    const dump = await exportJSON();
+    const blob = new Blob([JSON.stringify(dump, null, 2)], { type: 'application/json' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'sevenn-export.json';
+    a.click();
+    URL.revokeObjectURL(a.href);
+  });
+  dataCard.appendChild(exportBtn);
+
+  const importInput = document.createElement('input');
+  importInput.type = 'file';
+  importInput.accept = 'application/json';
+  importInput.style.display = 'none';
+  importInput.addEventListener('change', async () => {
+    const file = importInput.files[0];
+    if (!file) return;
+    try {
+      const text = await file.text();
+      const json = JSON.parse(text);
+      const res = await importJSON(json);
+      alert(res.message);
+      location.reload();
+    } catch (e) {
+      alert('Import failed');
+    }
+  });
+
+  const importBtn = document.createElement('button');
+  importBtn.className = 'btn';
+  importBtn.textContent = 'Import DB';
+  importBtn.addEventListener('click', () => importInput.click());
+  dataCard.appendChild(importBtn);
+  dataCard.appendChild(importInput);
+
+  const ankiBtn = document.createElement('button');
+  ankiBtn.className = 'btn';
+  ankiBtn.textContent = 'Export Anki CSV';
+  ankiBtn.addEventListener('click', async () => {
+    const dump = await exportJSON();
+    const blob = await exportAnkiCSV('qa', dump.items || []);
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'sevenn-anki.csv';
+    a.click();
+    URL.revokeObjectURL(a.href);
+  });
+  dataCard.appendChild(ankiBtn);
+
+  root.appendChild(dataCard);
+}

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,0 +1,16 @@
+export function uid() {
+  const g = globalThis;
+  return g.crypto?.randomUUID?.() || Math.random().toString(36).slice(2);
+}
+
+export function debounce(fn, delay = 150) {
+  let t;
+  return (...args) => {
+    clearTimeout(t);
+    t = setTimeout(() => fn(...args), delay);
+  };
+}
+
+export function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}

--- a/js/validators.js
+++ b/js/validators.js
@@ -1,0 +1,14 @@
+export function cleanItem(item) {
+  return {
+    ...item,
+    favorite: !!item.favorite,
+    color: item.color || null,
+    facts: item.facts || [],
+    tags: item.tags || [],
+    links: item.links || [],
+    blocks: item.blocks || [],
+    weeks: item.weeks || [],
+    lectures: item.lectures || [],
+    sr: item.sr || { box:0, last:0, due:0, ease:2.5 }
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,642 @@
+{
+  "name": "sevenn",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sevenn",
+      "version": "0.1.0",
+      "devDependencies": {
+        "http-server": "^14.1.1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-server": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "^2.0.1",
+        "chalk": "^4.1.2",
+        "corser": "^2.0.1",
+        "he": "^1.2.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy": "^1.18.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.2.6",
+        "opener": "^1.5.1",
+        "portfinder": "^1.0.28",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0",
+        "url-join": "^4.0.1"
+      },
+      "bin": {
+        "http-server": "bin/http-server"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/portfinder": {
+      "version": "1.0.37",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.37.tgz",
+      "integrity": "sha512-yuGIEjDAYnnOex9ddMnKZEMFE0CcGo6zbfzDklkmT1m5z734ss6JMzN9rNB3+RR7iS+F10D4/BVIaXOyh8PQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.6",
+        "debug": "^4.3.6"
+      },
+      "engines": {
+        "node": ">= 10.12"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/union": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+      "dev": true,
+      "dependencies": {
+        "qs": "^6.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "sevenn",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "start": "http-server -c-1 .",
+    "test": "node --test"
+  },
+  "devDependencies": {
+    "http-server": "^14.1.1"
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# Dependencies for the optional Python prototype
+flask>=2.3

--- a/style.css
+++ b/style.css
@@ -1,0 +1,238 @@
+:root {
+  --bg:#0B0F14;
+  --panel:#0F141B;
+  --muted:#131923;
+  --border:#212936;
+  --text:#E5E7EB;
+  --pink:#FFAFCC;
+  --blue:#BDE0FE;
+  --green:#B9FBC0;
+  --purple:#CDB4DB;
+  --yellow:#FFD6A5;
+  --gray:#94A3B8;
+  --radius:12px;
+  --radius-lg:16px;
+  --pad:12px;
+  --pad-lg:16px;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: system-ui, sans-serif;
+  margin: 0;
+}
+
+.header {
+  padding: var(--pad);
+  background: var(--panel);
+  border-bottom: 1px solid var(--border);
+}
+
+.row {
+  display:flex;
+  gap:8px;
+  align-items:center;
+}
+
+.brand {
+  font-weight: 600;
+}
+
+.tabs .tab {
+  background: none;
+  border: none;
+  color: var(--text);
+  padding: 4px 8px;
+  cursor: pointer;
+  border-radius: var(--radius);
+}
+
+.tab.active {
+  background: var(--muted);
+}
+
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--pad);
+  margin: var(--pad);
+}
+
+.card-grid {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.card-grid .card {
+  flex: 1 1 250px;
+}
+
+.summary {
+  margin-top: 8px;
+}
+
+.stats {
+  margin: var(--pad);
+}
+
+.quiz-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.quiz-question {
+  font-weight: bold;
+}
+
+.quiz-suggestions {
+  list-style: none;
+  margin: 4px 0 0;
+  padding: 0;
+}
+
+.quiz-suggestions li {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  margin-top: 4px;
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.input {
+  background: var(--muted);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 4px 8px;
+}
+
+.btn {
+  background: var(--muted);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th, .table td {
+  border: 1px solid var(--border);
+  padding: 4px 8px;
+  vertical-align: top;
+}
+
+.block-section {
+  margin: var(--pad);
+}
+
+.week-section {
+  margin-left: var(--pad);
+}
+
+.title-cell .title {
+  font-weight: 600;
+}
+
+.title-cell .meta {
+  font-size: 0.85em;
+  color: var(--gray);
+  margin-bottom: 4px;
+}
+
+.chips {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.chip {
+  background: var(--muted);
+  border-radius: var(--radius);
+  padding: 2px 6px;
+}
+
+.chip-remove {
+  background: none;
+  border: none;
+  margin-left: 4px;
+  cursor: pointer;
+  color: var(--text);
+}
+
+.chip-input {
+  background: var(--muted);
+  border: none;
+  color: var(--text);
+  padding: 2px 4px;
+  outline: none;
+}
+
+/* Study Builder */
+.builder {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  padding: var(--pad);
+}
+
+.builder-section {
+  border: 1px solid var(--border);
+  padding: var(--pad);
+  border-radius: var(--radius);
+}
+
+.builder-count {
+  margin-top: var(--pad);
+}
+
+/* Flashcards */
+.flashcard {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+}
+
+.flash-answer {
+  display: none;
+  white-space: pre-wrap;
+}
+
+.flashcard.revealed .flash-answer {
+  display: block;
+}
+
+/* Map */
+.map-svg {
+  width: 100%;
+  height: 600px;
+}
+.map-node {
+  fill: var(--blue);
+  cursor: pointer;
+}
+.map-edge {
+  stroke: var(--gray);
+  stroke-width: 1;
+}
+.map-label {
+  fill: var(--text);
+  font-size: 10px;
+  text-anchor: middle;
+}

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,11 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { uid } from '../js/utils.js';
+
+test('uid generates unique values', () => {
+  const ids = new Set();
+  for (let i=0; i<1000; i++) {
+    ids.add(uid());
+  }
+  assert.equal(ids.size, 1000);
+});


### PR DESCRIPTION
## Summary
- expose a small Flask app that returns JSON greetings at `/hello/<name>`
- render item tables in 200-row chunks to keep large datasets responsive

## Testing
- `npm test`
- `python -m app.main`


------
https://chatgpt.com/codex/tasks/task_e_68c237c4c2ec832291e68e3ee52e8625