### PR TITLE
feat: redesign interface with modern theme

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -640,7 +640,7 @@ var Sevenn = (() => {
     const overlay = document.createElement("div");
     overlay.className = "modal";
     const form = document.createElement("form");
-    form.className = "card";
+    form.className = "card modal-form";
     const title = document.createElement("h2");
     title.textContent = (existing ? "Edit " : "Add ") + kind;
     form.appendChild(title);
@@ -673,6 +673,7 @@ var Sevenn = (() => {
     colorLabel.textContent = "Color";
     const colorInput = document.createElement("input");
     colorInput.type = "color";
+    colorInput.className = "input";
     colorInput.value = existing?.color || "#ffffff";
     colorLabel.appendChild(colorInput);
     form.appendChild(colorLabel);
@@ -680,13 +681,16 @@ var Sevenn = (() => {
     saveBtn.type = "submit";
     saveBtn.className = "btn";
     saveBtn.textContent = "Save";
-    form.appendChild(saveBtn);
     const cancel = document.createElement("button");
     cancel.type = "button";
     cancel.className = "btn";
     cancel.textContent = "Cancel";
     cancel.addEventListener("click", () => document.body.removeChild(overlay));
-    form.appendChild(cancel);
+    const actions = document.createElement("div");
+    actions.className = "modal-actions";
+    actions.appendChild(cancel);
+    actions.appendChild(saveBtn);
+    form.appendChild(actions);
     form.addEventListener("submit", async (e) => {
       e.preventDefault();
       const titleKey = kind === "concept" ? "concept" : "name";

--- a/js/ui/components/editor.js
+++ b/js/ui/components/editor.js
@@ -38,7 +38,7 @@ export function openEditor(kind, onSave, existing = null) {
   overlay.className = 'modal';
 
   const form = document.createElement('form');
-  form.className = 'card';
+  form.className = 'card modal-form';
 
   const title = document.createElement('h2');
   title.textContent = (existing ? 'Edit ' : 'Add ') + kind;
@@ -75,6 +75,7 @@ export function openEditor(kind, onSave, existing = null) {
   colorLabel.textContent = 'Color';
   const colorInput = document.createElement('input');
   colorInput.type = 'color';
+  colorInput.className = 'input';
   colorInput.value = existing?.color || '#ffffff';
   colorLabel.appendChild(colorInput);
   form.appendChild(colorLabel);
@@ -83,14 +84,18 @@ export function openEditor(kind, onSave, existing = null) {
   saveBtn.type = 'submit';
   saveBtn.className = 'btn';
   saveBtn.textContent = 'Save';
-  form.appendChild(saveBtn);
 
   const cancel = document.createElement('button');
   cancel.type = 'button';
   cancel.className = 'btn';
   cancel.textContent = 'Cancel';
   cancel.addEventListener('click', () => document.body.removeChild(overlay));
-  form.appendChild(cancel);
+
+  const actions = document.createElement('div');
+  actions.className = 'modal-actions';
+  actions.appendChild(cancel);
+  actions.appendChild(saveBtn);
+  form.appendChild(actions);
 
   form.addEventListener('submit', async (e) => {
     e.preventDefault();

--- a/style.css
+++ b/style.css
@@ -1,19 +1,25 @@
+
+/* Modern light theme */
 :root {
-  --bg:#0B0F14;
-  --panel:#0F141B;
-  --muted:#131923;
-  --border:#212936;
-  --text:#E5E7EB;
-  --pink:#FFAFCC;
-  --blue:#BDE0FE;
-  --green:#B9FBC0;
-  --purple:#CDB4DB;
-  --yellow:#FFD6A5;
-  --gray:#94A3B8;
-  --radius:12px;
-  --radius-lg:16px;
-  --pad:12px;
-  --pad-lg:16px;
+  --bg: #f8fafc;
+  --panel: #ffffff;
+  --muted: #f1f5f9;
+  --border: #e2e8f0;
+  --text: #0f172a;
+  --pink: #fbcfe8;
+  --blue: #bfdbfe;
+  --green: #bbf7d0;
+  --purple: #e9d5ff;
+  --yellow: #fde68a;
+  --gray: #94a3b8;
+  --radius: 12px;
+  --radius-lg: 16px;
+  --pad: 12px;
+  --pad-lg: 16px;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
@@ -139,6 +145,35 @@ body {
 .modal .card {
   width: 90%;
   max-width: 500px;
+}
+
+/* Cleaner modal form layout */
+.modal-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+}
+
+.modal-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.modal-form .input {
+  width: 100%;
+}
+
+.modal-form textarea.input {
+  min-height: 80px;
+  resize: vertical;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--pad);
+  margin-top: var(--pad);
 }
 
 .block-section {


### PR DESCRIPTION
## Summary
- switch to a light, minimal color palette
- clean up item editor with vertical layout and action bar
- rebuild bundle for new UI

## Testing
- `npx esbuild js/main.js --bundle --format=iife --global-name=Sevenn --outfile=bundle.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3a56ce788832296144b40a3562a7b