### PR TITLE
feat: dark theme with new study cards

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -640,7 +640,7 @@ var Sevenn = (() => {
     const overlay = document.createElement("div");
     overlay.className = "modal";
     const form = document.createElement("form");
-    form.className = "card";
+    form.className = "card modal-form";
     const title = document.createElement("h2");
     title.textContent = (existing ? "Edit " : "Add ") + kind;
     form.appendChild(title);
@@ -673,6 +673,7 @@ var Sevenn = (() => {
     colorLabel.textContent = "Color";
     const colorInput = document.createElement("input");
     colorInput.type = "color";
+    colorInput.className = "input";
     colorInput.value = existing?.color || "#ffffff";
     colorLabel.appendChild(colorInput);
     form.appendChild(colorLabel);
@@ -680,13 +681,16 @@ var Sevenn = (() => {
     saveBtn.type = "submit";
     saveBtn.className = "btn";
     saveBtn.textContent = "Save";
-    form.appendChild(saveBtn);
     const cancel = document.createElement("button");
     cancel.type = "button";
     cancel.className = "btn";
     cancel.textContent = "Cancel";
     cancel.addEventListener("click", () => document.body.removeChild(overlay));
-    form.appendChild(cancel);
+    const actions = document.createElement("div");
+    actions.className = "modal-actions";
+    actions.appendChild(cancel);
+    actions.appendChild(saveBtn);
+    form.appendChild(actions);
     form.addEventListener("submit", async (e) => {
       e.preventDefault();
       const titleKey = kind === "concept" ? "concept" : "name";
@@ -1123,18 +1127,28 @@ var Sevenn = (() => {
       return;
     }
     const item = items[session.idx];
-    const { question, answer, details } = buildCard(item);
     const card = document.createElement("section");
     card.className = "card flashcard";
     card.tabIndex = 0;
-    const qEl = document.createElement("div");
-    qEl.className = "flash-question";
-    qEl.textContent = question;
-    card.appendChild(qEl);
-    const aEl = document.createElement("div");
-    aEl.className = "flash-answer";
-    aEl.textContent = answer + (details ? "\n" + details : "");
-    card.appendChild(aEl);
+    const title = document.createElement("h2");
+    title.textContent = item.name || item.concept || "";
+    card.appendChild(title);
+    sectionsFor(item).forEach(([label, field]) => {
+      const sec = document.createElement("div");
+      sec.className = "flash-section";
+      const head = document.createElement("div");
+      head.className = "flash-heading";
+      head.textContent = label;
+      const body = document.createElement("div");
+      body.className = "flash-body";
+      body.textContent = item[field] || "";
+      sec.appendChild(head);
+      sec.appendChild(body);
+      sec.addEventListener("click", () => {
+        sec.classList.toggle("revealed");
+      });
+      card.appendChild(sec);
+    });
     const controls = document.createElement("div");
     controls.className = "row";
     const prev = document.createElement("button");
@@ -1148,13 +1162,6 @@ var Sevenn = (() => {
       }
     });
     controls.appendChild(prev);
-    const reveal = document.createElement("button");
-    reveal.className = "btn";
-    reveal.textContent = "Reveal";
-    reveal.addEventListener("click", () => {
-      card.classList.toggle("revealed");
-    });
-    controls.appendChild(reveal);
     const next = document.createElement("button");
     next.className = "btn";
     next.textContent = session.idx < items.length - 1 ? "Next" : "Finish";
@@ -1180,51 +1187,40 @@ var Sevenn = (() => {
     root.appendChild(card);
     card.focus();
     card.addEventListener("keydown", (e) => {
-      if (e.code === "Space") {
-        e.preventDefault();
-        reveal.click();
-      } else if (e.key === "ArrowRight") {
+      if (e.key === "ArrowRight") {
         next.click();
       } else if (e.key === "ArrowLeft") {
         prev.click();
       }
     });
   }
-  function buildCard(item) {
-    const mainMap = {
-      disease: ["pathophys", "clinical", "treatment"],
-      drug: ["moa", "uses", "sideEffects"],
-      concept: ["definition", "mechanism", "clinicalRelevance"]
+  function sectionsFor(item) {
+    const map = {
+      disease: [
+        ["Etiology", "etiology"],
+        ["Pathophys", "pathophys"],
+        ["Clinical Presentation", "clinical"],
+        ["Diagnosis", "diagnosis"],
+        ["Treatment", "treatment"],
+        ["Complications", "complications"],
+        ["Mnemonic", "mnemonic"]
+      ],
+      drug: [
+        ["Mechanism", "moa"],
+        ["Uses", "uses"],
+        ["Side Effects", "sideEffects"],
+        ["Contraindications", "contraindications"],
+        ["Mnemonic", "mnemonic"]
+      ],
+      concept: [
+        ["Definition", "definition"],
+        ["Mechanism", "mechanism"],
+        ["Clinical Relevance", "clinicalRelevance"],
+        ["Example", "example"],
+        ["Mnemonic", "mnemonic"]
+      ]
     };
-    const extraMap = {
-      disease: ["mnemonic", "diagnosis", "complications"],
-      drug: ["mnemonic", "contraindications"],
-      concept: ["mnemonic", "example"]
-    };
-    const fields = mainMap[item.kind] || [];
-    let questionField = "";
-    for (const f of fields) {
-      if (item[f]) {
-        questionField = item[f];
-        break;
-      }
-    }
-    let question = questionField || "";
-    const answers = [];
-    question = question.replace(/{{c\d+::(.*?)}}/g, (_m, p1) => {
-      answers.push(p1);
-      return "_____";
-    });
-    const answer = answers.length ? answers.join(" / ") : item.name || item.concept || "";
-    const detailParts = [];
-    fields.filter((f) => f !== fields[0]).forEach((f) => {
-      if (item[f]) detailParts.push(item[f]);
-    });
-    (extraMap[item.kind] || []).forEach((f) => {
-      if (item[f]) detailParts.push(item[f]);
-    });
-    const details = detailParts.join("\n");
-    return { question, answer, details };
+    return map[item.kind] || [];
   }
 
   // js/ui/components/review.js
@@ -1303,9 +1299,6 @@ var Sevenn = (() => {
   function titleOf2(item) {
     return item.name || item.concept || "";
   }
-  function questionOf(item) {
-    return item.definition || item.pathophys || item.clinical || item.moa || item.uses || "";
-  }
   function renderQuiz(root, redraw) {
     const sess = state.quizSession;
     if (!sess) return;
@@ -1330,10 +1323,22 @@ var Sevenn = (() => {
     }
     const form = document.createElement("form");
     form.className = "quiz-form";
-    const q = document.createElement("div");
-    q.className = "quiz-question";
-    q.textContent = questionOf(item);
-    form.appendChild(q);
+    const info = document.createElement("div");
+    info.className = "quiz-info";
+    sectionsFor2(item).forEach(([label, field]) => {
+      if (!item[field]) return;
+      const sec = document.createElement("div");
+      sec.className = "section";
+      const head = document.createElement("div");
+      head.className = "section-title";
+      head.textContent = label;
+      const body = document.createElement("div");
+      body.textContent = item[field];
+      sec.appendChild(head);
+      sec.appendChild(body);
+      info.appendChild(sec);
+    });
+    form.appendChild(info);
     const input = document.createElement("input");
     input.type = "text";
     input.autocomplete = "off";
@@ -1367,6 +1372,34 @@ var Sevenn = (() => {
       redraw();
     });
     root.appendChild(form);
+  }
+  function sectionsFor2(item) {
+    const map = {
+      disease: [
+        ["Etiology", "etiology"],
+        ["Pathophys", "pathophys"],
+        ["Clinical Presentation", "clinical"],
+        ["Diagnosis", "diagnosis"],
+        ["Treatment", "treatment"],
+        ["Complications", "complications"],
+        ["Mnemonic", "mnemonic"]
+      ],
+      drug: [
+        ["Mechanism", "moa"],
+        ["Uses", "uses"],
+        ["Side Effects", "sideEffects"],
+        ["Contraindications", "contraindications"],
+        ["Mnemonic", "mnemonic"]
+      ],
+      concept: [
+        ["Definition", "definition"],
+        ["Mechanism", "mechanism"],
+        ["Clinical Relevance", "clinicalRelevance"],
+        ["Example", "example"],
+        ["Mnemonic", "mnemonic"]
+      ]
+    };
+    return map[item.kind] || [];
   }
 
   // js/ui/components/exams.js

--- a/js/ui/components/editor.js
+++ b/js/ui/components/editor.js
@@ -38,7 +38,7 @@ export function openEditor(kind, onSave, existing = null) {
   overlay.className = 'modal';
 
   const form = document.createElement('form');
-  form.className = 'card';
+  form.className = 'card modal-form';
 
   const title = document.createElement('h2');
   title.textContent = (existing ? 'Edit ' : 'Add ') + kind;
@@ -75,6 +75,7 @@ export function openEditor(kind, onSave, existing = null) {
   colorLabel.textContent = 'Color';
   const colorInput = document.createElement('input');
   colorInput.type = 'color';
+  colorInput.className = 'input';
   colorInput.value = existing?.color || '#ffffff';
   colorLabel.appendChild(colorInput);
   form.appendChild(colorLabel);
@@ -83,14 +84,18 @@ export function openEditor(kind, onSave, existing = null) {
   saveBtn.type = 'submit';
   saveBtn.className = 'btn';
   saveBtn.textContent = 'Save';
-  form.appendChild(saveBtn);
 
   const cancel = document.createElement('button');
   cancel.type = 'button';
   cancel.className = 'btn';
   cancel.textContent = 'Cancel';
   cancel.addEventListener('click', () => document.body.removeChild(overlay));
-  form.appendChild(cancel);
+
+  const actions = document.createElement('div');
+  actions.className = 'modal-actions';
+  actions.appendChild(cancel);
+  actions.appendChild(saveBtn);
+  form.appendChild(actions);
 
   form.addEventListener('submit', async (e) => {
     e.preventDefault();

--- a/js/ui/components/flashcards.js
+++ b/js/ui/components/flashcards.js
@@ -20,21 +20,29 @@ export function renderFlashcards(root, redraw) {
   }
 
   const item = items[session.idx];
-  const { question, answer, details } = buildCard(item);
 
   const card = document.createElement('section');
   card.className = 'card flashcard';
   card.tabIndex = 0;
 
-  const qEl = document.createElement('div');
-  qEl.className = 'flash-question';
-  qEl.textContent = question;
-  card.appendChild(qEl);
+  const title = document.createElement('h2');
+  title.textContent = item.name || item.concept || '';
+  card.appendChild(title);
 
-  const aEl = document.createElement('div');
-  aEl.className = 'flash-answer';
-  aEl.textContent = answer + (details ? '\n' + details : '');
-  card.appendChild(aEl);
+  sectionsFor(item).forEach(([label, field]) => {
+    const sec = document.createElement('div');
+    sec.className = 'flash-section';
+    const head = document.createElement('div');
+    head.className = 'flash-heading';
+    head.textContent = label;
+    const body = document.createElement('div');
+    body.className = 'flash-body';
+    body.textContent = item[field] || '';
+    sec.appendChild(head);
+    sec.appendChild(body);
+    sec.addEventListener('click', () => { sec.classList.toggle('revealed'); });
+    card.appendChild(sec);
+  });
 
   const controls = document.createElement('div');
   controls.className = 'row';
@@ -50,14 +58,6 @@ export function renderFlashcards(root, redraw) {
     }
   });
   controls.appendChild(prev);
-
-  const reveal = document.createElement('button');
-  reveal.className = 'btn';
-  reveal.textContent = 'Reveal';
-  reveal.addEventListener('click', () => {
-    card.classList.toggle('revealed');
-  });
-  controls.appendChild(reveal);
 
   const next = document.createElement('button');
   next.className = 'btn';
@@ -87,10 +87,7 @@ export function renderFlashcards(root, redraw) {
 
   card.focus();
   card.addEventListener('keydown', (e) => {
-    if (e.code === 'Space') {
-      e.preventDefault();
-      reveal.click();
-    } else if (e.key === 'ArrowRight') {
+    if (e.key === 'ArrowRight') {
       next.click();
     } else if (e.key === 'ArrowLeft') {
       prev.click();
@@ -98,31 +95,31 @@ export function renderFlashcards(root, redraw) {
   });
 }
 
-function buildCard(item) {
-  const mainMap = {
-    disease: ['pathophys', 'clinical', 'treatment'],
-    drug: ['moa', 'uses', 'sideEffects'],
-    concept: ['definition', 'mechanism', 'clinicalRelevance']
+function sectionsFor(item) {
+  const map = {
+    disease: [
+      ['Etiology', 'etiology'],
+      ['Pathophys', 'pathophys'],
+      ['Clinical Presentation', 'clinical'],
+      ['Diagnosis', 'diagnosis'],
+      ['Treatment', 'treatment'],
+      ['Complications', 'complications'],
+      ['Mnemonic', 'mnemonic']
+    ],
+    drug: [
+      ['Mechanism', 'moa'],
+      ['Uses', 'uses'],
+      ['Side Effects', 'sideEffects'],
+      ['Contraindications', 'contraindications'],
+      ['Mnemonic', 'mnemonic']
+    ],
+    concept: [
+      ['Definition', 'definition'],
+      ['Mechanism', 'mechanism'],
+      ['Clinical Relevance', 'clinicalRelevance'],
+      ['Example', 'example'],
+      ['Mnemonic', 'mnemonic']
+    ]
   };
-  const extraMap = {
-    disease: ['mnemonic', 'diagnosis', 'complications'],
-    drug: ['mnemonic', 'contraindications'],
-    concept: ['mnemonic', 'example']
-  };
-
-  const fields = mainMap[item.kind] || [];
-  let questionField = '';
-  for (const f of fields) {
-    if (item[f]) { questionField = item[f]; break; }
-  }
-  let question = questionField || '';
-  const answers = [];
-  question = question.replace(/{{c\d+::(.*?)}}/g, (_m, p1) => { answers.push(p1); return '_____'; });
-  const answer = answers.length ? answers.join(' / ') : (item.name || item.concept || '');
-
-  const detailParts = [];
-  fields.filter(f => f !== fields[0]).forEach(f => { if (item[f]) detailParts.push(item[f]); });
-  (extraMap[item.kind] || []).forEach(f => { if (item[f]) detailParts.push(item[f]); });
-  const details = detailParts.join('\n');
-  return { question, answer, details };
+  return map[item.kind] || [];
 }

--- a/js/ui/components/quiz.js
+++ b/js/ui/components/quiz.js
@@ -3,9 +3,6 @@ import { state, setQuizSession } from '../../state.js';
 function titleOf(item){
   return item.name || item.concept || '';
 }
-function questionOf(item){
-  return item.definition || item.pathophys || item.clinical || item.moa || item.uses || '';
-}
 
 export function renderQuiz(root, redraw){
   const sess = state.quizSession;
@@ -32,10 +29,22 @@ export function renderQuiz(root, redraw){
   const form = document.createElement('form');
   form.className = 'quiz-form';
 
-  const q = document.createElement('div');
-  q.className = 'quiz-question';
-  q.textContent = questionOf(item);
-  form.appendChild(q);
+  const info = document.createElement('div');
+  info.className = 'quiz-info';
+  sectionsFor(item).forEach(([label, field]) => {
+    if (!item[field]) return;
+    const sec = document.createElement('div');
+    sec.className = 'section';
+    const head = document.createElement('div');
+    head.className = 'section-title';
+    head.textContent = label;
+    const body = document.createElement('div');
+    body.textContent = item[field];
+    sec.appendChild(head);
+    sec.appendChild(body);
+    info.appendChild(sec);
+  });
+  form.appendChild(info);
 
   const input = document.createElement('input');
   input.type = 'text';
@@ -71,4 +80,33 @@ export function renderQuiz(root, redraw){
   });
 
   root.appendChild(form);
+}
+
+function sectionsFor(item){
+  const map = {
+    disease: [
+      ['Etiology','etiology'],
+      ['Pathophys','pathophys'],
+      ['Clinical Presentation','clinical'],
+      ['Diagnosis','diagnosis'],
+      ['Treatment','treatment'],
+      ['Complications','complications'],
+      ['Mnemonic','mnemonic']
+    ],
+    drug: [
+      ['Mechanism','moa'],
+      ['Uses','uses'],
+      ['Side Effects','sideEffects'],
+      ['Contraindications','contraindications'],
+      ['Mnemonic','mnemonic']
+    ],
+    concept: [
+      ['Definition','definition'],
+      ['Mechanism','mechanism'],
+      ['Clinical Relevance','clinicalRelevance'],
+      ['Example','example'],
+      ['Mnemonic','mnemonic']
+    ]
+  };
+  return map[item.kind] || [];
 }

--- a/style.css
+++ b/style.css
@@ -1,3 +1,5 @@
+
+/* Modern dark theme */
 :root {
   --bg:#0B0F14;
   --panel:#0F141B;
@@ -14,6 +16,10 @@
   --radius-lg:16px;
   --pad:12px;
   --pad-lg:16px;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
@@ -110,6 +116,12 @@ body {
   cursor: pointer;
 }
 
+.quiz-info {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+}
+
 .input {
   background: var(--muted);
   color: var(--text);
@@ -139,6 +151,35 @@ body {
 .modal .card {
   width: 90%;
   max-width: 500px;
+}
+
+/* Cleaner modal form layout */
+.modal-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+}
+
+.modal-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.modal-form .input {
+  width: 100%;
+}
+
+.modal-form textarea.input {
+  min-height: 80px;
+  resize: vertical;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--pad);
+  margin-top: var(--pad);
 }
 
 .block-section {
@@ -200,6 +241,25 @@ body {
   display: flex;
   flex-direction: column;
   gap: var(--pad);
+}
+
+.flash-section {
+  margin-top: var(--pad);
+  cursor: pointer;
+}
+
+.flash-heading {
+  font-weight: 600;
+}
+
+.flash-body {
+  display: none;
+  margin-top: 4px;
+  white-space: pre-wrap;
+}
+
+.flash-section.revealed .flash-body {
+  display: block;
 }
 
 /* Browse cards */


### PR DESCRIPTION
## Summary
- restore dark color scheme
- show collapsible sections on flashcards
- quiz displays all card details with name hidden
- rebuild bundle for updated UI

## Testing
- `npx esbuild js/main.js --bundle --format=iife --global-name=Sevenn --outfile=bundle.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3a56ce788832296144b40a3562a7b