### PR TITLE
feat: tagging and linking with nested study builder

### DIFF
--- a/js/ui/components/cardlist.js
+++ b/js/ui/components/cardlist.js
@@ -93,7 +93,7 @@ export function createItemCard(item, onChange){
   link.textContent = '🪢';
   link.title = 'Links';
   link.setAttribute('aria-label','Manage links');
-  link.addEventListener('click', e => { e.stopPropagation(); openLinker(); });
+  link.addEventListener('click', e => { e.stopPropagation(); openLinker(item, onChange); });
   actions.appendChild(link);
 
   const edit = document.createElement('button');

--- a/js/ui/components/editor.js
+++ b/js/ui/components/editor.js
@@ -1,5 +1,5 @@
 import { uid } from '../../utils.js';
-import { upsertItem } from '../../storage/storage.js';
+import { upsertItem, listBlocks } from '../../storage/storage.js';
 
 const fieldMap = {
   disease: [
@@ -33,12 +33,12 @@ const fieldMap = {
   ]
 };
 
-export function openEditor(kind, onSave, existing = null) {
+export async function openEditor(kind, onSave, existing = null) {
   const overlay = document.createElement('div');
   overlay.className = 'modal';
 
   const form = document.createElement('form');
-  form.className = 'card';
+  form.className = 'card modal-form';
 
   const title = document.createElement('h2');
   title.textContent = (existing ? 'Edit ' : 'Add ') + kind;
@@ -75,22 +75,84 @@ export function openEditor(kind, onSave, existing = null) {
   colorLabel.textContent = 'Color';
   const colorInput = document.createElement('input');
   colorInput.type = 'color';
+  colorInput.className = 'input';
   colorInput.value = existing?.color || '#ffffff';
   colorLabel.appendChild(colorInput);
   form.appendChild(colorLabel);
+
+  // tagging: blocks, weeks, lectures
+  const blocks = await listBlocks();
+
+  const blockWrap = document.createElement('div');
+  blockWrap.className = 'tag-wrap';
+  const blockTitle = document.createElement('div');
+  blockTitle.textContent = 'Blocks';
+  blockWrap.appendChild(blockTitle);
+  const blockChecks = new Map();
+  blocks.forEach(b => {
+    const lbl = document.createElement('label');
+    lbl.className = 'row';
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.checked = existing?.blocks?.includes(b.blockId);
+    lbl.appendChild(cb);
+    lbl.appendChild(document.createTextNode(b.blockId));
+    blockWrap.appendChild(lbl);
+    blockChecks.set(b.blockId, cb);
+  });
+  form.appendChild(blockWrap);
+
+  const weekWrap = document.createElement('div');
+  weekWrap.className = 'tag-wrap';
+  const weekTitle = document.createElement('div');
+  weekTitle.textContent = 'Weeks';
+  weekWrap.appendChild(weekTitle);
+  const weekChecks = new Map();
+  for (let w = 1; w <= 8; w++) {
+    const lbl = document.createElement('label');
+    lbl.className = 'row';
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.checked = existing?.weeks?.includes(w);
+    lbl.appendChild(cb);
+    lbl.appendChild(document.createTextNode('W' + w));
+    weekWrap.appendChild(lbl);
+    weekChecks.set(w, cb);
+  }
+  form.appendChild(weekWrap);
+
+  const lecLabel = document.createElement('label');
+  lecLabel.textContent = 'Lectures';
+  const lectureSel = document.createElement('select');
+  lectureSel.multiple = true;
+  blocks.forEach(b => {
+    (b.lectures || []).forEach(l => {
+      const opt = document.createElement('option');
+      opt.value = `${b.blockId}|${l.id}|${l.name}|${l.week}`;
+      opt.textContent = `${b.title || b.blockId}: ${l.name} (W${l.week})`;
+      if (existing?.lectures?.some(e => e.id === l.id && e.blockId === b.blockId)) opt.selected = true;
+      lectureSel.appendChild(opt);
+    });
+  });
+  lecLabel.appendChild(lectureSel);
+  form.appendChild(lecLabel);
 
   const saveBtn = document.createElement('button');
   saveBtn.type = 'submit';
   saveBtn.className = 'btn';
   saveBtn.textContent = 'Save';
-  form.appendChild(saveBtn);
 
   const cancel = document.createElement('button');
   cancel.type = 'button';
   cancel.className = 'btn';
   cancel.textContent = 'Cancel';
   cancel.addEventListener('click', () => document.body.removeChild(overlay));
-  form.appendChild(cancel);
+
+  const actions = document.createElement('div');
+  actions.className = 'modal-actions';
+  actions.appendChild(cancel);
+  actions.appendChild(saveBtn);
+  form.appendChild(actions);
 
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
@@ -105,6 +167,12 @@ export function openEditor(kind, onSave, existing = null) {
       } else {
         item[field] = v;
       }
+    });
+    item.blocks = Array.from(blockChecks.entries()).filter(([,cb]) => cb.checked).map(([id]) => id);
+    item.weeks = Array.from(weekChecks.entries()).filter(([,cb]) => cb.checked).map(([w]) => Number(w));
+    item.lectures = Array.from(lectureSel.selectedOptions).map(opt => {
+      const [blockId, id, name, week] = opt.value.split('|');
+      return { blockId, id: Number(id), name, week: Number(week) };
     });
     item.color = colorInput.value;
     await upsertItem(item);

--- a/js/ui/components/flashcards.js
+++ b/js/ui/components/flashcards.js
@@ -20,21 +20,29 @@ export function renderFlashcards(root, redraw) {
   }
 
   const item = items[session.idx];
-  const { question, answer, details } = buildCard(item);
 
   const card = document.createElement('section');
   card.className = 'card flashcard';
   card.tabIndex = 0;
 
-  const qEl = document.createElement('div');
-  qEl.className = 'flash-question';
-  qEl.textContent = question;
-  card.appendChild(qEl);
+  const title = document.createElement('h2');
+  title.textContent = item.name || item.concept || '';
+  card.appendChild(title);
 
-  const aEl = document.createElement('div');
-  aEl.className = 'flash-answer';
-  aEl.textContent = answer + (details ? '\n' + details : '');
-  card.appendChild(aEl);
+  sectionsFor(item).forEach(([label, field]) => {
+    const sec = document.createElement('div');
+    sec.className = 'flash-section';
+    const head = document.createElement('div');
+    head.className = 'flash-heading';
+    head.textContent = label;
+    const body = document.createElement('div');
+    body.className = 'flash-body';
+    body.textContent = item[field] || '';
+    sec.appendChild(head);
+    sec.appendChild(body);
+    sec.addEventListener('click', () => { sec.classList.toggle('revealed'); });
+    card.appendChild(sec);
+  });
 
   const controls = document.createElement('div');
   controls.className = 'row';
@@ -50,14 +58,6 @@ export function renderFlashcards(root, redraw) {
     }
   });
   controls.appendChild(prev);
-
-  const reveal = document.createElement('button');
-  reveal.className = 'btn';
-  reveal.textContent = 'Reveal';
-  reveal.addEventListener('click', () => {
-    card.classList.toggle('revealed');
-  });
-  controls.appendChild(reveal);
 
   const next = document.createElement('button');
   next.className = 'btn';
@@ -87,10 +87,7 @@ export function renderFlashcards(root, redraw) {
 
   card.focus();
   card.addEventListener('keydown', (e) => {
-    if (e.code === 'Space') {
-      e.preventDefault();
-      reveal.click();
-    } else if (e.key === 'ArrowRight') {
+    if (e.key === 'ArrowRight') {
       next.click();
     } else if (e.key === 'ArrowLeft') {
       prev.click();
@@ -98,31 +95,31 @@ export function renderFlashcards(root, redraw) {
   });
 }
 
-function buildCard(item) {
-  const mainMap = {
-    disease: ['pathophys', 'clinical', 'treatment'],
-    drug: ['moa', 'uses', 'sideEffects'],
-    concept: ['definition', 'mechanism', 'clinicalRelevance']
+function sectionsFor(item) {
+  const map = {
+    disease: [
+      ['Etiology', 'etiology'],
+      ['Pathophys', 'pathophys'],
+      ['Clinical Presentation', 'clinical'],
+      ['Diagnosis', 'diagnosis'],
+      ['Treatment', 'treatment'],
+      ['Complications', 'complications'],
+      ['Mnemonic', 'mnemonic']
+    ],
+    drug: [
+      ['Mechanism', 'moa'],
+      ['Uses', 'uses'],
+      ['Side Effects', 'sideEffects'],
+      ['Contraindications', 'contraindications'],
+      ['Mnemonic', 'mnemonic']
+    ],
+    concept: [
+      ['Definition', 'definition'],
+      ['Mechanism', 'mechanism'],
+      ['Clinical Relevance', 'clinicalRelevance'],
+      ['Example', 'example'],
+      ['Mnemonic', 'mnemonic']
+    ]
   };
-  const extraMap = {
-    disease: ['mnemonic', 'diagnosis', 'complications'],
-    drug: ['mnemonic', 'contraindications'],
-    concept: ['mnemonic', 'example']
-  };
-
-  const fields = mainMap[item.kind] || [];
-  let questionField = '';
-  for (const f of fields) {
-    if (item[f]) { questionField = item[f]; break; }
-  }
-  let question = questionField || '';
-  const answers = [];
-  question = question.replace(/{{c\d+::(.*?)}}/g, (_m, p1) => { answers.push(p1); return '_____'; });
-  const answer = answers.length ? answers.join(' / ') : (item.name || item.concept || '');
-
-  const detailParts = [];
-  fields.filter(f => f !== fields[0]).forEach(f => { if (item[f]) detailParts.push(item[f]); });
-  (extraMap[item.kind] || []).forEach(f => { if (item[f]) detailParts.push(item[f]); });
-  const details = detailParts.join('\n');
-  return { question, answer, details };
+  return map[item.kind] || [];
 }

--- a/js/ui/components/linker.js
+++ b/js/ui/components/linker.js
@@ -1,3 +1,100 @@
-export function openLinker() {
-  alert('Linker not implemented yet');
+import { listItemsByKind, upsertItem } from '../../storage/storage.js';
+
+// Modal for linking items together
+export async function openLinker(item, onSave) {
+  const overlay = document.createElement('div');
+  overlay.className = 'modal';
+
+  const card = document.createElement('div');
+  card.className = 'card';
+
+  const title = document.createElement('h2');
+  title.textContent = `Links for ${item.name || item.concept || ''}`;
+  card.appendChild(title);
+
+  const all = [
+    ...(await listItemsByKind('disease')),
+    ...(await listItemsByKind('drug')),
+    ...(await listItemsByKind('concept'))
+  ];
+  const idMap = new Map(all.map(i => [i.id, i]));
+  const links = new Set((item.links || []).map(l => l.id));
+
+  const list = document.createElement('div');
+  list.className = 'link-list';
+  card.appendChild(list);
+
+  function renderList() {
+    list.innerHTML = '';
+    links.forEach(id => {
+      const row = document.createElement('div');
+      row.className = 'row';
+      const label = document.createElement('span');
+      const it = idMap.get(id);
+      label.textContent = it ? (it.name || it.concept || id) : id;
+      row.appendChild(label);
+      const btn = document.createElement('button');
+      btn.className = 'btn';
+      btn.textContent = 'Remove';
+      btn.addEventListener('click', () => { links.delete(id); renderList(); });
+      row.appendChild(btn);
+      list.appendChild(row);
+    });
+  }
+  renderList();
+
+  const input = document.createElement('input');
+  input.className = 'input';
+  input.placeholder = 'Search items...';
+  card.appendChild(input);
+
+  const sug = document.createElement('ul');
+  sug.className = 'quiz-suggestions';
+  card.appendChild(sug);
+
+  input.addEventListener('input', () => {
+    const v = input.value.toLowerCase();
+    sug.innerHTML = '';
+    if (!v) return;
+    all.filter(it => it.id !== item.id && (it.name || it.concept || '').toLowerCase().includes(v))
+      .slice(0,5)
+      .forEach(it => {
+        const li = document.createElement('li');
+        li.textContent = it.name || it.concept || '';
+        li.addEventListener('mousedown', () => {
+          links.add(it.id);
+          input.value = '';
+          sug.innerHTML = '';
+          renderList();
+        });
+        sug.appendChild(li);
+      });
+  });
+
+  const actions = document.createElement('div');
+  actions.className = 'modal-actions';
+  const cancel = document.createElement('button');
+  cancel.type = 'button';
+  cancel.className = 'btn';
+  cancel.textContent = 'Close';
+  cancel.addEventListener('click', () => document.body.removeChild(overlay));
+  const save = document.createElement('button');
+  save.type = 'button';
+  save.className = 'btn';
+  save.textContent = 'Save';
+  save.addEventListener('click', async () => {
+    item.links = Array.from(links).map(id => ({ id, type: 'assoc' }));
+    await upsertItem(item);
+    document.body.removeChild(overlay);
+    onSave && onSave();
+  });
+  actions.appendChild(cancel);
+  actions.appendChild(save);
+  card.appendChild(actions);
+
+  overlay.appendChild(card);
+  overlay.addEventListener('click', e => { if (e.target === overlay) document.body.removeChild(overlay); });
+  document.body.appendChild(overlay);
+  input.focus();
 }
+

--- a/js/ui/components/quiz.js
+++ b/js/ui/components/quiz.js
@@ -3,9 +3,6 @@ import { state, setQuizSession } from '../../state.js';
 function titleOf(item){
   return item.name || item.concept || '';
 }
-function questionOf(item){
-  return item.definition || item.pathophys || item.clinical || item.moa || item.uses || '';
-}
 
 export function renderQuiz(root, redraw){
   const sess = state.quizSession;
@@ -32,10 +29,22 @@ export function renderQuiz(root, redraw){
   const form = document.createElement('form');
   form.className = 'quiz-form';
 
-  const q = document.createElement('div');
-  q.className = 'quiz-question';
-  q.textContent = questionOf(item);
-  form.appendChild(q);
+  const info = document.createElement('div');
+  info.className = 'quiz-info';
+  sectionsFor(item).forEach(([label, field]) => {
+    if (!item[field]) return;
+    const sec = document.createElement('div');
+    sec.className = 'section';
+    const head = document.createElement('div');
+    head.className = 'section-title';
+    head.textContent = label;
+    const body = document.createElement('div');
+    body.textContent = item[field];
+    sec.appendChild(head);
+    sec.appendChild(body);
+    info.appendChild(sec);
+  });
+  form.appendChild(info);
 
   const input = document.createElement('input');
   input.type = 'text';
@@ -71,4 +80,33 @@ export function renderQuiz(root, redraw){
   });
 
   root.appendChild(form);
+}
+
+function sectionsFor(item){
+  const map = {
+    disease: [
+      ['Etiology','etiology'],
+      ['Pathophys','pathophys'],
+      ['Clinical Presentation','clinical'],
+      ['Diagnosis','diagnosis'],
+      ['Treatment','treatment'],
+      ['Complications','complications'],
+      ['Mnemonic','mnemonic']
+    ],
+    drug: [
+      ['Mechanism','moa'],
+      ['Uses','uses'],
+      ['Side Effects','sideEffects'],
+      ['Contraindications','contraindications'],
+      ['Mnemonic','mnemonic']
+    ],
+    concept: [
+      ['Definition','definition'],
+      ['Mechanism','mechanism'],
+      ['Clinical Relevance','clinicalRelevance'],
+      ['Example','example'],
+      ['Mnemonic','mnemonic']
+    ]
+  };
+  return map[item.kind] || [];
 }

--- a/style.css
+++ b/style.css
@@ -1,19 +1,25 @@
+
+/* Modern dark theme */
 :root {
   --bg:#0B0F14;
-  --panel:#0F141B;
-  --muted:#131923;
-  --border:#212936;
-  --text:#E5E7EB;
-  --pink:#FFAFCC;
-  --blue:#BDE0FE;
-  --green:#B9FBC0;
-  --purple:#CDB4DB;
-  --yellow:#FFD6A5;
+  --panel:#1B1F27;
+  --muted:#242B37;
+  --border:#2E3644;
+  --text:#F1F5F9;
+  --pink:#FF90C2;
+  --blue:#A6D9FF;
+  --green:#A4FBC4;
+  --purple:#DAB8FF;
+  --yellow:#FFE3A3;
   --gray:#94A3B8;
   --radius:12px;
   --radius-lg:16px;
   --pad:12px;
   --pad-lg:16px;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
@@ -110,6 +116,12 @@ body {
   cursor: pointer;
 }
 
+.quiz-info {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+}
+
 .input {
   background: var(--muted);
   color: var(--text);
@@ -141,6 +153,35 @@ body {
   max-width: 500px;
 }
 
+/* Cleaner modal form layout */
+.modal-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+}
+
+.modal-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.modal-form .input {
+  width: 100%;
+}
+
+.modal-form textarea.input {
+  min-height: 80px;
+  resize: vertical;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--pad);
+  margin-top: var(--pad);
+}
+
 .block-section {
   margin: var(--pad);
 }
@@ -159,6 +200,11 @@ body {
   background: var(--muted);
   border-radius: var(--radius);
   padding: 2px 6px;
+}
+
+.chip.active {
+  background: var(--blue);
+  color: #000;
 }
 
 .chip-remove {
@@ -191,6 +237,11 @@ body {
   border-radius: var(--radius);
 }
 
+.builder-sub {
+  margin-left: var(--pad);
+  margin-top: 4px;
+}
+
 .builder-count {
   margin-top: var(--pad);
 }
@@ -200,6 +251,25 @@ body {
   display: flex;
   flex-direction: column;
   gap: var(--pad);
+}
+
+.flash-section {
+  margin-top: var(--pad);
+  cursor: pointer;
+}
+
+.flash-heading {
+  font-weight: 600;
+}
+
+.flash-body {
+  display: none;
+  margin-top: 4px;
+  white-space: pre-wrap;
+}
+
+.flash-section.revealed .flash-body {
+  display: block;
 }
 
 /* Browse cards */


### PR DESCRIPTION
## Summary
- soften dark theme with grey panels and brighter accents
- tag entries by block, week and lecture in the editor
- manage inter-item links with a new modal
- rebuild study builder with nested block/week/lecture filters

## Testing
- `npx --yes esbuild js/main.js --bundle --format=iife --global-name=Sevenn --outfile=bundle.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3a56ce788832296144b40a3562a7b