### PR TITLE
Enhance UI styling and card animations

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -1205,7 +1205,12 @@ var Sevenn = (() => {
         const current = cards[idx];
         (current.links || []).forEach((l) => {
           const item = items.find((it) => it.id === l.id);
-          if (item) relatedWrap.appendChild(createItemCard(item, onChange));
+          if (item) {
+            const el = createItemCard(item, onChange);
+            el.classList.add("related-card");
+            relatedWrap.appendChild(el);
+            requestAnimationFrame(() => el.classList.add("visible"));
+          }
         });
       }
       prev.addEventListener("click", () => {

--- a/js/ui/components/cards.js
+++ b/js/ui/components/cards.js
@@ -88,7 +88,12 @@ export function renderCards(container, items, onChange){
       const current = cards[idx];
       (current.links || []).forEach(l => {
         const item = items.find(it => it.id === l.id);
-        if (item) relatedWrap.appendChild(createItemCard(item, onChange));
+        if (item) {
+          const el = createItemCard(item, onChange);
+          el.classList.add('related-card');
+          relatedWrap.appendChild(el);
+          requestAnimationFrame(() => el.classList.add('visible'));
+        }
       });
     }
 

--- a/style.css
+++ b/style.css
@@ -29,6 +29,20 @@ body {
   font-size: 18px;
 }
 
+button {
+  background: var(--muted);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 6px 12px;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.3);
+}
+
 .header {
   padding: var(--pad);
   background: var(--panel);
@@ -48,11 +62,11 @@ body {
 
 .tabs .tab {
   background: var(--muted);
-  border: none;
   color: var(--text);
   padding: 6px 12px;
   cursor: pointer;
   border-radius: var(--radius);
+  border: 1px solid var(--border);
 }
 
 .tab.active {
@@ -132,7 +146,7 @@ body {
 .btn {
   background: var(--blue);
   color: #000;
-  border: none;
+  border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 6px 12px;
   cursor: pointer;
@@ -357,6 +371,7 @@ body {
   display:block;
   max-height: 2.4em;
   overflow: hidden;
+  font-size:1.1rem;
 }
 
 .identifiers {
@@ -372,11 +387,12 @@ body {
 }
 
 .icon-btn {
-  background:none;
-  border:none;
+  background: var(--muted);
+  border: 1px solid var(--border);
   cursor:pointer;
   color: var(--text);
   padding:2px;
+  border-radius: var(--radius);
 }
 
 .card-body {
@@ -433,9 +449,14 @@ body {
   box-shadow:0 2px 4px rgba(0,0,0,0.2);
 }
 .deck-viewer {
-  position:relative;
-  text-align:center;
-  padding:var(--pad);
+  position: relative;
+  text-align: center;
+  padding: var(--pad);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 70vh;
 }
 .deck-card {
   max-width:400px;
@@ -446,25 +467,58 @@ body {
   top:50%;
   transform:translateY(-50%);
   background:var(--muted);
-  border:none;
   color:var(--text);
   padding:8px;
   border-radius:var(--radius);
   cursor:pointer;
+  border:1px solid var(--border);
 }
 .deck-prev { left:var(--pad); }
 .deck-next { right:var(--pad); }
+.deck-prev:hover, .deck-next:hover {
+  transform:translateY(calc(-50% - 2px));
+}
 .deck-related {
   display:flex;
   flex-wrap:wrap;
   gap:var(--pad);
   justify-content:center;
   margin-top:var(--pad);
+  opacity:0;
+  transform:translateY(-10px);
+  transition:opacity 0.3s ease, transform 0.3s ease;
+}
+.deck-related:not(.hidden) {
+  opacity:1;
+  transform:translateY(0);
+}
+.deck-related .related-card {
+  opacity:0;
+  transform:scale(0.95);
+  transition:opacity 0.3s ease, transform 0.3s ease;
+}
+.deck-related .related-card.visible {
+  opacity:1;
+  transform:scale(1);
 }
 .deck-close {
   margin-top:var(--pad);
 }
 .hidden { display:none !important; }
+
+.title-cell{
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  margin-bottom:var(--pad);
+}
+.title-cell .title{
+  font-size:1.25rem;
+  font-weight:600;
+}
+.title-cell .actions{
+  margin-top:4px;
+}
 
 /* Map */
 .map-svg {


### PR DESCRIPTION
## Summary
- Add consistent borders and hover effects for all buttons
- Increase entry title size and layout spacing for cleaner cards
- Center deck viewer and animate related cards for a sleeker presentation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4475101888322880b60330b8f58a1