### PR TITLE
Refine deck selection and card action menus

### DIFF
--- a/js/ui/components/cardlist.js
+++ b/js/ui/components/cardlist.js
@@ -129,7 +129,27 @@ export function createItemCard(item, onChange){
   });
   actions.appendChild(del);
 
-  header.appendChild(actions);
+  const gear = document.createElement('button');
+  gear.className = 'icon-btn card-gear';
+  gear.textContent = '⚙️';
+  gear.title = 'More Actions';
+  gear.setAttribute('aria-label','More Actions');
+
+  const menu = document.createElement('div');
+  menu.className = 'card-menu hidden';
+  menu.appendChild(actions);
+
+  gear.addEventListener('click', e => {
+    e.stopPropagation();
+    menu.classList.toggle('hidden');
+  });
+
+  document.addEventListener('click', e => {
+    if (!menu.contains(e.target) && e.target !== gear) menu.classList.add('hidden');
+  });
+
+  header.appendChild(gear);
+  header.appendChild(menu);
   card.appendChild(header);
 
   const identifiers = document.createElement('div');

--- a/js/ui/components/cards.js
+++ b/js/ui/components/cards.js
@@ -11,13 +11,13 @@ export function renderCards(container, items, onChange){
   items.forEach(it => {
     if (it.lectures && it.lectures.length){
       it.lectures.forEach(l => {
-        const key = l.name || `Lecture ${l.id}`;
-        if (!decks.has(key)) decks.set(key, []);
-        decks.get(key).push(it);
+        const key = `${l.blockId}|${l.id}`;
+        if (!decks.has(key)) decks.set(key, { lecture: l, cards: [] });
+        decks.get(key).cards.push(it);
       });
     } else {
-      if (!decks.has('Unassigned')) decks.set('Unassigned', []);
-      decks.get('Unassigned').push(it);
+      if (!decks.has('Unassigned')) decks.set('Unassigned', { lecture: { name:'Unassigned', blockId:'', week:'' }, cards: [] });
+      decks.get('Unassigned').cards.push(it);
     }
   });
 
@@ -29,13 +29,55 @@ export function renderCards(container, items, onChange){
   viewer.className = 'deck-viewer hidden';
   container.appendChild(viewer);
 
-  decks.forEach((cards, lecture) => {
+  decks.forEach(({lecture, cards}) => {
     const deck = document.createElement('div');
     deck.className = 'deck';
-    deck.textContent = `${lecture} (${cards.length})`;
-    deck.addEventListener('click', () => openDeck(lecture, cards));
+
+    const nameEl = document.createElement('div');
+    nameEl.className = 'deck-name';
+    nameEl.textContent = lecture.name || `Lecture ${lecture.id}`;
+    deck.appendChild(nameEl);
+
+    const metaEl = document.createElement('div');
+    metaEl.className = 'deck-meta';
+    const blk = lecture.blockId || '';
+    const wk = lecture.week != null ? `Week ${lecture.week}` : '';
+    metaEl.textContent = [blk, wk].filter(Boolean).join(' · ');
+    deck.appendChild(metaEl);
+
+    deck.addEventListener('click', () => openDeck(nameEl.textContent, cards));
+
+    let previewTimer;
+    deck.addEventListener('mouseenter', () => {
+      previewTimer = setTimeout(() => showPreview(deck, cards), 1500);
+    });
+    deck.addEventListener('mouseleave', () => {
+      clearTimeout(previewTimer);
+      hidePreview(deck);
+    });
+
     list.appendChild(deck);
   });
+
+  function showPreview(deck, cards){
+    const preview = document.createElement('div');
+    preview.className = 'deck-preview';
+    cards.forEach((c,i) => {
+      const pc = document.createElement('div');
+      pc.className = 'preview-card';
+      pc.textContent = c.name || c.concept || 'Untitled';
+      pc.style.animationDelay = `${i * 0.05}s`;
+      preview.appendChild(pc);
+    });
+    deck.appendChild(preview);
+    deck.classList.add('previewing');
+  }
+
+  function hidePreview(deck){
+    const p = deck.querySelector('.deck-preview');
+    if (p) p.remove();
+    deck.classList.remove('previewing');
+  }
 
   function openDeck(title, cards){
     list.classList.add('hidden');
@@ -88,7 +130,12 @@ export function renderCards(container, items, onChange){
       const current = cards[idx];
       (current.links || []).forEach(l => {
         const item = items.find(it => it.id === l.id);
-        if (item) relatedWrap.appendChild(createItemCard(item, onChange));
+        if (item) {
+          const el = createItemCard(item, onChange);
+          el.classList.add('related-card');
+          relatedWrap.appendChild(el);
+          requestAnimationFrame(() => el.classList.add('visible'));
+        }
       });
     }
 

--- a/style.css
+++ b/style.css
@@ -29,6 +29,20 @@ body {
   font-size: 18px;
 }
 
+button {
+  background: var(--muted);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 6px 12px;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.3);
+}
+
 .header {
   padding: var(--pad);
   background: var(--panel);
@@ -48,11 +62,11 @@ body {
 
 .tabs .tab {
   background: var(--muted);
-  border: none;
   color: var(--text);
   padding: 6px 12px;
   cursor: pointer;
   border-radius: var(--radius);
+  border: 1px solid var(--border);
 }
 
 .tab.active {
@@ -132,7 +146,7 @@ body {
 .btn {
   background: var(--blue);
   color: #000;
-  border: none;
+  border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 6px 12px;
   cursor: pointer;
@@ -327,6 +341,7 @@ body {
   align-items: flex-start;
   padding: var(--pad);
   cursor: pointer;
+  position: relative;
 }
 
 .header-main {
@@ -357,6 +372,7 @@ body {
   display:block;
   max-height: 2.4em;
   overflow: hidden;
+  font-size:1.3rem;
 }
 
 .identifiers {
@@ -369,14 +385,32 @@ body {
 .card-actions {
   display:flex;
   gap:4px;
+  flex-direction:column;
 }
 
+.card-menu {
+  position:absolute;
+  top:100%;
+  right:0;
+  background:var(--panel);
+  border:1px solid var(--border);
+  border-radius:var(--radius);
+  padding:4px;
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  z-index:10;
+}
+
+.card-menu.hidden { display:none; }
+
 .icon-btn {
-  background:none;
-  border:none;
+  background: var(--muted);
+  border: 1px solid var(--border);
   cursor:pointer;
   color: var(--text);
   padding:2px;
+  border-radius: var(--radius);
 }
 
 .card-body {
@@ -431,11 +465,62 @@ body {
   padding:var(--pad-lg);
   cursor:pointer;
   box-shadow:0 2px 4px rgba(0,0,0,0.2);
+  width:160px;
+  height:120px;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  justify-content:center;
+  text-align:center;
+  position:relative;
+  overflow:hidden;
+}
+.deck-name {
+  font-weight:600;
+  margin-bottom:4px;
+}
+.deck-meta {
+  font-size:0.85rem;
+  opacity:0.8;
+}
+.deck-preview {
+  position:absolute;
+  inset:0;
+  background:var(--panel);
+  border:1px solid var(--border);
+  border-radius:var(--radius);
+  padding:4px;
+  display:flex;
+  flex-wrap:wrap;
+  gap:4px;
+  overflow:auto;
+  opacity:0;
+  pointer-events:none;
+  transition:opacity 0.3s ease;
+}
+.deck.previewing .deck-preview { opacity:1; }
+.preview-card {
+  background:var(--muted);
+  border-radius:var(--radius);
+  padding:2px 4px;
+  font-size:0.75rem;
+  opacity:0;
+  transform:scale(0.9);
+  animation:deck-pop 0.3s forwards;
+}
+
+@keyframes deck-pop {
+  to { opacity:1; transform:scale(1); }
 }
 .deck-viewer {
-  position:relative;
-  text-align:center;
-  padding:var(--pad);
+  position: relative;
+  text-align: center;
+  padding: var(--pad);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 70vh;
 }
 .deck-card {
   max-width:400px;
@@ -446,25 +531,58 @@ body {
   top:50%;
   transform:translateY(-50%);
   background:var(--muted);
-  border:none;
   color:var(--text);
   padding:8px;
   border-radius:var(--radius);
   cursor:pointer;
+  border:1px solid var(--border);
 }
 .deck-prev { left:var(--pad); }
 .deck-next { right:var(--pad); }
+.deck-prev:hover, .deck-next:hover {
+  transform:translateY(calc(-50% - 2px));
+}
 .deck-related {
   display:flex;
   flex-wrap:wrap;
   gap:var(--pad);
   justify-content:center;
   margin-top:var(--pad);
+  opacity:0;
+  transform:translateY(-10px);
+  transition:opacity 0.3s ease, transform 0.3s ease;
+}
+.deck-related:not(.hidden) {
+  opacity:1;
+  transform:translateY(0);
+}
+.deck-related .related-card {
+  opacity:0;
+  transform:scale(0.95);
+  transition:opacity 0.3s ease, transform 0.3s ease;
+}
+.deck-related .related-card.visible {
+  opacity:1;
+  transform:scale(1);
 }
 .deck-close {
   margin-top:var(--pad);
 }
 .hidden { display:none !important; }
+
+.title-cell{
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  margin-bottom:var(--pad);
+}
+.title-cell .title{
+  font-size:1.25rem;
+  font-weight:600;
+}
+.title-cell .actions{
+  margin-top:4px;
+}
 
 /* Map */
 .map-svg {


### PR DESCRIPTION
## Summary
- Show each deck as a card with lecture title and block/week metadata
- Hovering a deck previews its cards while entry actions move into a gear dropdown
- Enlarge entry titles for clearer card toggling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4475101888322880b60330b8f58a1