### PR TITLE
Refine deck browsing and streamline item actions

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -1,4 +1,4 @@
-var Sevenn = (() => {
+(() => {
   // js/state.js
   var state = {
     tab: "Diseases",
@@ -683,45 +683,38 @@ var Sevenn = (() => {
     const blockTitle = document.createElement("div");
     blockTitle.textContent = "Blocks";
     blockWrap.appendChild(blockTitle);
-
     const blockRow = document.createElement("div");
     blockRow.className = "tag-row";
     const blockChecks = /* @__PURE__ */ new Map();
     blocks.forEach((b) => {
       const lbl = document.createElement("label");
       lbl.className = "tag-label";
-
       const cb = document.createElement("input");
       cb.type = "checkbox";
       cb.checked = existing?.blocks?.includes(b.blockId);
       lbl.appendChild(cb);
       lbl.appendChild(document.createTextNode(b.blockId));
-
       blockRow.appendChild(lbl);
       blockChecks.set(b.blockId, cb);
     });
     blockWrap.appendChild(blockRow);
-
     form.appendChild(blockWrap);
     const weekWrap = document.createElement("div");
     weekWrap.className = "tag-wrap";
     const weekTitle = document.createElement("div");
     weekTitle.textContent = "Weeks";
     weekWrap.appendChild(weekTitle);
-
     const weekRow = document.createElement("div");
     weekRow.className = "tag-row";
     const weekChecks = /* @__PURE__ */ new Map();
     for (let w = 1; w <= 8; w++) {
       const lbl = document.createElement("label");
       lbl.className = "tag-label";
-
       const cb = document.createElement("input");
       cb.type = "checkbox";
       cb.checked = existing?.weeks?.includes(w);
       lbl.appendChild(cb);
       lbl.appendChild(document.createTextNode("W" + w));
-
       weekRow.appendChild(lbl);
       weekChecks.set(w, cb);
     }
@@ -733,7 +726,6 @@ var Sevenn = (() => {
     lectureInput.className = "input";
     lectureInput.value = existing?.lectures?.map((l) => l.id).join(", ") || "";
     lecLabel.appendChild(lectureInput);
-
     form.appendChild(lecLabel);
     const saveBtn = document.createElement("button");
     saveBtn.type = "submit";
@@ -765,7 +757,6 @@ var Sevenn = (() => {
       });
       item.blocks = Array.from(blockChecks.entries()).filter(([, cb]) => cb.checked).map(([id]) => id);
       item.weeks = Array.from(weekChecks.entries()).filter(([, cb]) => cb.checked).map(([w]) => Number(w));
-
       const ids = lectureInput.value.split(",").map((s) => Number(s.trim())).filter(Boolean);
       item.lectures = ids.map((id) => {
         for (const b of blocks) {
@@ -773,7 +764,6 @@ var Sevenn = (() => {
           if (l) return { blockId: b.blockId, id, name: l.name, week: l.week };
         }
         return { id };
-
       });
       item.color = colorInput.value;
       await upsertItem(item);
@@ -894,11 +884,6 @@ var Sevenn = (() => {
 
   // js/ui/components/cardlist.js
   var kindColors = { disease: "var(--pink)", drug: "var(--blue)", concept: "var(--green)" };
-  var collapsedPref = {
-    disease: ["pathophys", "clinical"],
-    drug: ["moa", "uses"],
-    concept: ["definition", "mechanism"]
-  };
   var fieldDefs = {
     disease: [
       ["etiology", "Etiology", "\u{1F9EC}"],
@@ -936,26 +921,30 @@ var Sevenn = (() => {
     const header = document.createElement("div");
     header.className = "card-header";
     const mainBtn = document.createElement("button");
-    mainBtn.className = "header-main";
+    mainBtn.className = "card-title-btn";
+    mainBtn.textContent = item.name || item.concept || "Untitled";
     mainBtn.setAttribute("aria-expanded", expanded.has(item.id));
     mainBtn.addEventListener("click", () => {
       if (expanded.has(item.id)) expanded.delete(item.id);
       else expanded.add(item.id);
-      renderBody();
       card.classList.toggle("expanded");
       mainBtn.setAttribute("aria-expanded", expanded.has(item.id));
     });
-    const badge = document.createElement("span");
-    badge.className = `kind-badge ${item.kind}`;
-    badge.textContent = item.kind.charAt(0).toUpperCase() + item.kind.slice(1);
-    mainBtn.appendChild(badge);
-    const title = document.createElement("span");
-    title.className = "card-title";
-    title.textContent = item.name || item.concept || "Untitled";
-    mainBtn.appendChild(title);
     header.appendChild(mainBtn);
-    const actions = document.createElement("div");
-    actions.className = "card-actions";
+    const settings = document.createElement("div");
+    settings.className = "card-settings";
+    const gear = document.createElement("button");
+    gear.className = "icon-btn";
+    gear.textContent = "\u2699\uFE0F";
+    const menu = document.createElement("div");
+    menu.className = "card-menu hidden";
+    gear.addEventListener("click", (e) => {
+      e.stopPropagation();
+      menu.classList.toggle("hidden");
+    });
+    settings.appendChild(gear);
+    settings.appendChild(menu);
+    header.appendChild(settings);
     const fav = document.createElement("button");
     fav.className = "icon-btn";
     fav.textContent = item.favorite ? "\u2605" : "\u2606";
@@ -968,7 +957,7 @@ var Sevenn = (() => {
       fav.textContent = item.favorite ? "\u2605" : "\u2606";
       onChange && onChange();
     });
-    actions.appendChild(fav);
+    menu.appendChild(fav);
     const link = document.createElement("button");
     link.className = "icon-btn";
     link.textContent = "\u{1FAA2}";
@@ -978,7 +967,7 @@ var Sevenn = (() => {
       e.stopPropagation();
       openLinker(item, onChange);
     });
-    actions.appendChild(link);
+    menu.appendChild(link);
     const edit = document.createElement("button");
     edit.className = "icon-btn";
     edit.textContent = "\u270F\uFE0F";
@@ -988,7 +977,7 @@ var Sevenn = (() => {
       e.stopPropagation();
       openEditor(item.kind, onChange, item);
     });
-    actions.appendChild(edit);
+    menu.appendChild(edit);
     const copy = document.createElement("button");
     copy.className = "icon-btn";
     copy.textContent = "\u{1F4CB}";
@@ -998,7 +987,7 @@ var Sevenn = (() => {
       e.stopPropagation();
       navigator.clipboard && navigator.clipboard.writeText(item.name || item.concept || "");
     });
-    actions.appendChild(copy);
+    menu.appendChild(copy);
     const del = document.createElement("button");
     del.className = "icon-btn";
     del.textContent = "\u{1F5D1}\uFE0F";
@@ -1011,41 +1000,38 @@ var Sevenn = (() => {
         onChange && onChange();
       }
     });
-    actions.appendChild(del);
-    header.appendChild(actions);
+    menu.appendChild(del);
     card.appendChild(header);
-    const identifiers = document.createElement("div");
-    identifiers.className = "identifiers";
-    (item.blocks || []).forEach((b) => {
-      const chip = document.createElement("span");
-      chip.className = "chip";
-      chip.textContent = b;
-      identifiers.appendChild(chip);
-    });
-    (item.weeks || []).forEach((w) => {
-      const chip = document.createElement("span");
-      chip.className = "chip";
-      chip.textContent = "W" + w;
-      identifiers.appendChild(chip);
-    });
-    if (item.lectures) {
-      item.lectures.forEach((l) => {
-        const chip = document.createElement("span");
-        chip.className = "chip";
-        chip.textContent = "\u{1F4DA} " + (l.name || l.id);
-        identifiers.appendChild(chip);
-      });
-    }
-    card.appendChild(identifiers);
     const body = document.createElement("div");
     body.className = "card-body";
     card.appendChild(body);
     function renderBody() {
       body.innerHTML = "";
+      const identifiers = document.createElement("div");
+      identifiers.className = "identifiers";
+      (item.blocks || []).forEach((b) => {
+        const chip = document.createElement("span");
+        chip.className = "chip";
+        chip.textContent = b;
+        identifiers.appendChild(chip);
+      });
+      (item.weeks || []).forEach((w) => {
+        const chip = document.createElement("span");
+        chip.className = "chip";
+        chip.textContent = "W" + w;
+        identifiers.appendChild(chip);
+      });
+      if (item.lectures) {
+        item.lectures.forEach((l) => {
+          const chip = document.createElement("span");
+          chip.className = "chip";
+          chip.textContent = "\u{1F4DA} " + (l.name || l.id);
+          identifiers.appendChild(chip);
+        });
+      }
+      body.appendChild(identifiers);
       const defs = fieldDefs[item.kind] || [];
-      const showAll = expanded.has(item.id);
-      const fields = showAll ? defs : defs.filter((d) => collapsedPref[item.kind].includes(d[0]));
-      fields.forEach(([f, label, icon]) => {
+      defs.forEach(([f, label, icon]) => {
         if (!item[f]) return;
         const sec = document.createElement("div");
         sec.className = "section";
@@ -1159,10 +1145,51 @@ var Sevenn = (() => {
     decks.forEach((cards, lecture) => {
       const deck = document.createElement("div");
       deck.className = "deck";
-      deck.textContent = `${lecture} (${cards.length})`;
-      deck.addEventListener("click", () => openDeck(lecture, cards));
+      const title = document.createElement("div");
+      title.className = "deck-title";
+      title.textContent = lecture;
+      const meta = document.createElement("div");
+      meta.className = "deck-meta";
+      const blocks = Array.from(new Set(cards.flatMap((c) => c.blocks || []))).join(", ");
+      const weeks = Array.from(new Set(cards.flatMap((c) => c.weeks || []))).join(", ");
+      meta.textContent = `${blocks}${blocks && weeks ? " \u2022 " : ""}${weeks ? "Week " + weeks : ""}`;
+      deck.appendChild(title);
+      deck.appendChild(meta);
+      deck.addEventListener("click", () => {
+        stopPreview(deck);
+        openDeck(lecture, cards);
+      });
+      let hoverTimer;
+      deck.addEventListener("mouseenter", () => {
+        hoverTimer = setTimeout(() => startPreview(deck, cards), 1e3);
+      });
+      deck.addEventListener("mouseleave", () => {
+        clearTimeout(hoverTimer);
+        stopPreview(deck);
+      });
       list.appendChild(deck);
     });
+    function startPreview(deckEl, cards) {
+      if (deckEl._preview) return;
+      const overlay = document.createElement("div");
+      overlay.className = "deck-preview";
+      deckEl.appendChild(overlay);
+      let i = 0;
+      overlay.textContent = cards[i].name || cards[i].concept || "";
+      const interval = setInterval(() => {
+        i = (i + 1) % cards.length;
+        overlay.textContent = cards[i].name || cards[i].concept || "";
+      }, 800);
+      deckEl._preview = { overlay, interval };
+    }
+    function stopPreview(deckEl) {
+      const prev = deckEl._preview;
+      if (prev) {
+        clearInterval(prev.interval);
+        prev.overlay.remove();
+        deckEl._preview = null;
+      }
+    }
     function openDeck(title, cards) {
       list.classList.add("hidden");
       viewer.classList.remove("hidden");
@@ -1205,7 +1232,12 @@ var Sevenn = (() => {
         const current = cards[idx];
         (current.links || []).forEach((l) => {
           const item = items.find((it) => it.id === l.id);
-          if (item) relatedWrap.appendChild(createItemCard(item, onChange));
+          if (item) {
+            const el = createItemCard(item, onChange);
+            el.classList.add("related-card");
+            relatedWrap.appendChild(el);
+            requestAnimationFrame(() => el.classList.add("visible"));
+          }
         });
       }
       prev.addEventListener("click", () => {

--- a/js/ui/components/cardlist.js
+++ b/js/ui/components/cardlist.js
@@ -5,11 +5,6 @@ import { confirmModal } from './confirm.js';
 import { openLinker } from './linker.js';
 
 const kindColors = { disease: 'var(--pink)', drug: 'var(--blue)', concept: 'var(--green)' };
-const collapsedPref = {
-  disease: ['pathophys','clinical'],
-  drug: ['moa','uses'],
-  concept: ['definition','mechanism']
-};
 const fieldDefs = {
   disease: [
     ['etiology','Etiology','🧬'],
@@ -51,28 +46,27 @@ export function createItemCard(item, onChange){
   header.className = 'card-header';
 
   const mainBtn = document.createElement('button');
-  mainBtn.className = 'header-main';
+  mainBtn.className = 'card-title-btn';
+  mainBtn.textContent = item.name || item.concept || 'Untitled';
   mainBtn.setAttribute('aria-expanded', expanded.has(item.id));
   mainBtn.addEventListener('click', () => {
     if (expanded.has(item.id)) expanded.delete(item.id); else expanded.add(item.id);
-    renderBody();
     card.classList.toggle('expanded');
     mainBtn.setAttribute('aria-expanded', expanded.has(item.id));
   });
-
-  const badge = document.createElement('span');
-  badge.className = `kind-badge ${item.kind}`;
-  badge.textContent = item.kind.charAt(0).toUpperCase() + item.kind.slice(1);
-  mainBtn.appendChild(badge);
-
-  const title = document.createElement('span');
-  title.className = 'card-title';
-  title.textContent = item.name || item.concept || 'Untitled';
-  mainBtn.appendChild(title);
   header.appendChild(mainBtn);
 
-  const actions = document.createElement('div');
-  actions.className = 'card-actions';
+  const settings = document.createElement('div');
+  settings.className = 'card-settings';
+  const gear = document.createElement('button');
+  gear.className = 'icon-btn';
+  gear.textContent = '⚙️';
+  const menu = document.createElement('div');
+  menu.className = 'card-menu hidden';
+  gear.addEventListener('click', e => { e.stopPropagation(); menu.classList.toggle('hidden'); });
+  settings.appendChild(gear);
+  settings.appendChild(menu);
+  header.appendChild(settings);
 
   const fav = document.createElement('button');
   fav.className = 'icon-btn';
@@ -86,7 +80,7 @@ export function createItemCard(item, onChange){
     fav.textContent = item.favorite ? '★' : '☆';
     onChange && onChange();
   });
-  actions.appendChild(fav);
+  menu.appendChild(fav);
 
   const link = document.createElement('button');
   link.className = 'icon-btn';
@@ -94,7 +88,7 @@ export function createItemCard(item, onChange){
   link.title = 'Links';
   link.setAttribute('aria-label','Manage links');
   link.addEventListener('click', e => { e.stopPropagation(); openLinker(item, onChange); });
-  actions.appendChild(link);
+  menu.appendChild(link);
 
   const edit = document.createElement('button');
   edit.className = 'icon-btn';
@@ -102,7 +96,7 @@ export function createItemCard(item, onChange){
   edit.title = 'Edit';
   edit.setAttribute('aria-label','Edit');
   edit.addEventListener('click', e => { e.stopPropagation(); openEditor(item.kind, onChange, item); });
-  actions.appendChild(edit);
+  menu.appendChild(edit);
 
   const copy = document.createElement('button');
   copy.className = 'icon-btn';
@@ -113,7 +107,7 @@ export function createItemCard(item, onChange){
     e.stopPropagation();
     navigator.clipboard && navigator.clipboard.writeText(item.name || item.concept || '');
   });
-  actions.appendChild(copy);
+  menu.appendChild(copy);
 
   const del = document.createElement('button');
   del.className = 'icon-btn';
@@ -127,34 +121,9 @@ export function createItemCard(item, onChange){
       onChange && onChange();
     }
   });
-  actions.appendChild(del);
+  menu.appendChild(del);
 
-  header.appendChild(actions);
   card.appendChild(header);
-
-  const identifiers = document.createElement('div');
-  identifiers.className = 'identifiers';
-  (item.blocks || []).forEach(b => {
-    const chip = document.createElement('span');
-    chip.className = 'chip';
-    chip.textContent = b;
-    identifiers.appendChild(chip);
-  });
-  (item.weeks || []).forEach(w => {
-    const chip = document.createElement('span');
-    chip.className = 'chip';
-    chip.textContent = 'W' + w;
-    identifiers.appendChild(chip);
-  });
-  if (item.lectures) {
-    item.lectures.forEach(l => {
-      const chip = document.createElement('span');
-      chip.className = 'chip';
-      chip.textContent = '📚 ' + (l.name || l.id);
-      identifiers.appendChild(chip);
-    });
-  }
-  card.appendChild(identifiers);
 
   const body = document.createElement('div');
   body.className = 'card-body';
@@ -162,10 +131,32 @@ export function createItemCard(item, onChange){
 
   function renderBody(){
     body.innerHTML = '';
+    const identifiers = document.createElement('div');
+    identifiers.className = 'identifiers';
+    (item.blocks || []).forEach(b => {
+      const chip = document.createElement('span');
+      chip.className = 'chip';
+      chip.textContent = b;
+      identifiers.appendChild(chip);
+    });
+    (item.weeks || []).forEach(w => {
+      const chip = document.createElement('span');
+      chip.className = 'chip';
+      chip.textContent = 'W' + w;
+      identifiers.appendChild(chip);
+    });
+    if (item.lectures) {
+      item.lectures.forEach(l => {
+        const chip = document.createElement('span');
+        chip.className = 'chip';
+        chip.textContent = '📚 ' + (l.name || l.id);
+        identifiers.appendChild(chip);
+      });
+    }
+    body.appendChild(identifiers);
+
     const defs = fieldDefs[item.kind] || [];
-    const showAll = expanded.has(item.id);
-    const fields = showAll ? defs : defs.filter(d => collapsedPref[item.kind].includes(d[0]));
-    fields.forEach(([f,label,icon]) => {
+    defs.forEach(([f,label,icon]) => {
       if (!item[f]) return;
       const sec = document.createElement('div');
       sec.className = 'section';

--- a/js/ui/components/cards.js
+++ b/js/ui/components/cards.js
@@ -32,10 +32,50 @@ export function renderCards(container, items, onChange){
   decks.forEach((cards, lecture) => {
     const deck = document.createElement('div');
     deck.className = 'deck';
-    deck.textContent = `${lecture} (${cards.length})`;
-    deck.addEventListener('click', () => openDeck(lecture, cards));
+    const title = document.createElement('div');
+    title.className = 'deck-title';
+    title.textContent = lecture;
+    const meta = document.createElement('div');
+    meta.className = 'deck-meta';
+    const blocks = Array.from(new Set(cards.flatMap(c => c.blocks || []))).join(', ');
+    const weeks = Array.from(new Set(cards.flatMap(c => c.weeks || []))).join(', ');
+    meta.textContent = `${blocks}${blocks && weeks ? ' • ' : ''}${weeks ? 'Week ' + weeks : ''}`;
+    deck.appendChild(title);
+    deck.appendChild(meta);
+    deck.addEventListener('click', () => { stopPreview(deck); openDeck(lecture, cards); });
+    let hoverTimer;
+    deck.addEventListener('mouseenter', () => {
+      hoverTimer = setTimeout(() => startPreview(deck, cards), 1000);
+    });
+    deck.addEventListener('mouseleave', () => {
+      clearTimeout(hoverTimer);
+      stopPreview(deck);
+    });
     list.appendChild(deck);
   });
+
+  function startPreview(deckEl, cards){
+    if (deckEl._preview) return;
+    const overlay = document.createElement('div');
+    overlay.className = 'deck-preview';
+    deckEl.appendChild(overlay);
+    let i = 0;
+    overlay.textContent = cards[i].name || cards[i].concept || '';
+    const interval = setInterval(() => {
+      i = (i + 1) % cards.length;
+      overlay.textContent = cards[i].name || cards[i].concept || '';
+    }, 800);
+    deckEl._preview = { overlay, interval };
+  }
+
+  function stopPreview(deckEl){
+    const prev = deckEl._preview;
+    if (prev){
+      clearInterval(prev.interval);
+      prev.overlay.remove();
+      deckEl._preview = null;
+    }
+  }
 
   function openDeck(title, cards){
     list.classList.add('hidden');
@@ -88,7 +128,12 @@ export function renderCards(container, items, onChange){
       const current = cards[idx];
       (current.links || []).forEach(l => {
         const item = items.find(it => it.id === l.id);
-        if (item) relatedWrap.appendChild(createItemCard(item, onChange));
+        if (item) {
+          const el = createItemCard(item, onChange);
+          el.classList.add('related-card');
+          relatedWrap.appendChild(el);
+          requestAnimationFrame(() => el.classList.add('visible'));
+        }
       });
     }
 

--- a/style.css
+++ b/style.css
@@ -29,6 +29,20 @@ body {
   font-size: 18px;
 }
 
+button {
+  background: var(--muted);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 6px 12px;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.3);
+}
+
 .header {
   padding: var(--pad);
   background: var(--panel);
@@ -48,11 +62,11 @@ body {
 
 .tabs .tab {
   background: var(--muted);
-  border: none;
   color: var(--text);
   padding: 6px 12px;
   cursor: pointer;
   border-radius: var(--radius);
+  border: 1px solid var(--border);
 }
 
 .tab.active {
@@ -132,7 +146,7 @@ body {
 .btn {
   background: var(--blue);
   color: #000;
-  border: none;
+  border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 6px 12px;
   cursor: pointer;
@@ -324,59 +338,54 @@ body {
 .item-card .card-header {
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
   padding: var(--pad);
   cursor: pointer;
 }
 
-.header-main {
+.card-title-btn {
   background: none;
   border: none;
   color: inherit;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap:4px;
-  text-align: left;
+  text-align:left;
   flex:1;
+  font-size:1.25rem;
+  font-weight:600;
+  cursor:pointer;
 }
 
-.kind-badge {
-  border-radius: var(--radius);
-  padding: 2px 6px;
-  font-size: 12px;
-  color: #000;
-}
-.kind-badge.disease { background: var(--pink); }
-.kind-badge.drug { background: var(--blue); }
-.kind-badge.concept { background: var(--green); }
+.card-settings { position:relative; }
 
-.card-title {
-  font-weight: 600;
-  line-height: 1.2;
-  display:block;
-  max-height: 2.4em;
-  overflow: hidden;
+.card-menu {
+  position:absolute;
+  right:0;
+  top:100%;
+  background:var(--panel);
+  border:1px solid var(--border);
+  border-radius:var(--radius);
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  padding:4px;
+  z-index:5;
 }
+
+.card-menu.hidden { display:none; }
 
 .identifiers {
   display:flex;
   gap:4px;
   flex-wrap:wrap;
-  padding: 0 var(--pad) var(--pad);
-}
-
-.card-actions {
-  display:flex;
-  gap:4px;
+  margin-bottom:var(--pad);
 }
 
 .icon-btn {
-  background:none;
-  border:none;
+  background: var(--muted);
+  border: 1px solid var(--border);
   cursor:pointer;
   color: var(--text);
   padding:2px;
+  border-radius: var(--radius);
 }
 
 .card-body {
@@ -431,11 +440,36 @@ body {
   padding:var(--pad-lg);
   cursor:pointer;
   box-shadow:0 2px 4px rgba(0,0,0,0.2);
-}
-.deck-viewer {
   position:relative;
+  width:200px;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  text-align:center;
+}
+.deck-title { font-weight:600; margin-bottom:4px; }
+.deck-meta { font-size:0.85rem; color:var(--gray); }
+.deck-preview {
+  position:absolute;
+  inset:0;
+  background:rgba(0,0,0,0.8);
+  color:#fff;
+  display:flex;
+  align-items:center;
+  justify-content:center;
   text-align:center;
   padding:var(--pad);
+  border-radius:inherit;
+}
+.deck-viewer {
+  position: relative;
+  text-align: center;
+  padding: var(--pad);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 70vh;
 }
 .deck-card {
   max-width:400px;
@@ -446,25 +480,58 @@ body {
   top:50%;
   transform:translateY(-50%);
   background:var(--muted);
-  border:none;
   color:var(--text);
   padding:8px;
   border-radius:var(--radius);
   cursor:pointer;
+  border:1px solid var(--border);
 }
 .deck-prev { left:var(--pad); }
 .deck-next { right:var(--pad); }
+.deck-prev:hover, .deck-next:hover {
+  transform:translateY(calc(-50% - 2px));
+}
 .deck-related {
   display:flex;
   flex-wrap:wrap;
   gap:var(--pad);
   justify-content:center;
   margin-top:var(--pad);
+  opacity:0;
+  transform:translateY(-10px);
+  transition:opacity 0.3s ease, transform 0.3s ease;
+}
+.deck-related:not(.hidden) {
+  opacity:1;
+  transform:translateY(0);
+}
+.deck-related .related-card {
+  opacity:0;
+  transform:scale(0.95);
+  transition:opacity 0.3s ease, transform 0.3s ease;
+}
+.deck-related .related-card.visible {
+  opacity:1;
+  transform:scale(1);
 }
 .deck-close {
   margin-top:var(--pad);
 }
 .hidden { display:none !important; }
+
+.title-cell{
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  margin-bottom:var(--pad);
+}
+.title-cell .title{
+  font-size:1.25rem;
+  font-weight:600;
+}
+.title-cell .actions{
+  margin-top:4px;
+}
 
 /* Map */
 .map-svg {


### PR DESCRIPTION
## Summary
- Display decks as card-like tiles with block/week info and hover previews
- Move item card actions into a gear dropdown and toggle details by title
- Add supporting styles for new layouts and hover preview overlay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4475101888322880b60330b8f58a1