### PR TITLE
Refine deck browsing with scalable cards and fan previews

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -1,4 +1,4 @@
-var Sevenn = (() => {
+(() => {
   // js/state.js
   var state = {
     tab: "Diseases",
@@ -683,45 +683,38 @@ var Sevenn = (() => {
     const blockTitle = document.createElement("div");
     blockTitle.textContent = "Blocks";
     blockWrap.appendChild(blockTitle);
-
     const blockRow = document.createElement("div");
     blockRow.className = "tag-row";
     const blockChecks = /* @__PURE__ */ new Map();
     blocks.forEach((b) => {
       const lbl = document.createElement("label");
       lbl.className = "tag-label";
-
       const cb = document.createElement("input");
       cb.type = "checkbox";
       cb.checked = existing?.blocks?.includes(b.blockId);
       lbl.appendChild(cb);
       lbl.appendChild(document.createTextNode(b.blockId));
-
       blockRow.appendChild(lbl);
       blockChecks.set(b.blockId, cb);
     });
     blockWrap.appendChild(blockRow);
-
     form.appendChild(blockWrap);
     const weekWrap = document.createElement("div");
     weekWrap.className = "tag-wrap";
     const weekTitle = document.createElement("div");
     weekTitle.textContent = "Weeks";
     weekWrap.appendChild(weekTitle);
-
     const weekRow = document.createElement("div");
     weekRow.className = "tag-row";
     const weekChecks = /* @__PURE__ */ new Map();
     for (let w = 1; w <= 8; w++) {
       const lbl = document.createElement("label");
       lbl.className = "tag-label";
-
       const cb = document.createElement("input");
       cb.type = "checkbox";
       cb.checked = existing?.weeks?.includes(w);
       lbl.appendChild(cb);
       lbl.appendChild(document.createTextNode("W" + w));
-
       weekRow.appendChild(lbl);
       weekChecks.set(w, cb);
     }
@@ -733,7 +726,6 @@ var Sevenn = (() => {
     lectureInput.className = "input";
     lectureInput.value = existing?.lectures?.map((l) => l.id).join(", ") || "";
     lecLabel.appendChild(lectureInput);
-
     form.appendChild(lecLabel);
     const saveBtn = document.createElement("button");
     saveBtn.type = "submit";
@@ -765,7 +757,6 @@ var Sevenn = (() => {
       });
       item.blocks = Array.from(blockChecks.entries()).filter(([, cb]) => cb.checked).map(([id]) => id);
       item.weeks = Array.from(weekChecks.entries()).filter(([, cb]) => cb.checked).map(([w]) => Number(w));
-
       const ids = lectureInput.value.split(",").map((s) => Number(s.trim())).filter(Boolean);
       item.lectures = ids.map((id) => {
         for (const b of blocks) {
@@ -773,7 +764,6 @@ var Sevenn = (() => {
           if (l) return { blockId: b.blockId, id, name: l.name, week: l.week };
         }
         return { id };
-
       });
       item.color = colorInput.value;
       await upsertItem(item);
@@ -894,11 +884,6 @@ var Sevenn = (() => {
 
   // js/ui/components/cardlist.js
   var kindColors = { disease: "var(--pink)", drug: "var(--blue)", concept: "var(--green)" };
-  var collapsedPref = {
-    disease: ["pathophys", "clinical"],
-    drug: ["moa", "uses"],
-    concept: ["definition", "mechanism"]
-  };
   var fieldDefs = {
     disease: [
       ["etiology", "Etiology", "\u{1F9EC}"],
@@ -936,26 +921,30 @@ var Sevenn = (() => {
     const header = document.createElement("div");
     header.className = "card-header";
     const mainBtn = document.createElement("button");
-    mainBtn.className = "header-main";
+    mainBtn.className = "card-title-btn";
+    mainBtn.textContent = item.name || item.concept || "Untitled";
     mainBtn.setAttribute("aria-expanded", expanded.has(item.id));
     mainBtn.addEventListener("click", () => {
       if (expanded.has(item.id)) expanded.delete(item.id);
       else expanded.add(item.id);
-      renderBody();
       card.classList.toggle("expanded");
       mainBtn.setAttribute("aria-expanded", expanded.has(item.id));
     });
-    const badge = document.createElement("span");
-    badge.className = `kind-badge ${item.kind}`;
-    badge.textContent = item.kind.charAt(0).toUpperCase() + item.kind.slice(1);
-    mainBtn.appendChild(badge);
-    const title = document.createElement("span");
-    title.className = "card-title";
-    title.textContent = item.name || item.concept || "Untitled";
-    mainBtn.appendChild(title);
     header.appendChild(mainBtn);
-    const actions = document.createElement("div");
-    actions.className = "card-actions";
+    const settings = document.createElement("div");
+    settings.className = "card-settings";
+    const gear = document.createElement("button");
+    gear.className = "icon-btn";
+    gear.textContent = "\u2699\uFE0F";
+    const menu = document.createElement("div");
+    menu.className = "card-menu hidden";
+    gear.addEventListener("click", (e) => {
+      e.stopPropagation();
+      menu.classList.toggle("hidden");
+    });
+    settings.appendChild(gear);
+    settings.appendChild(menu);
+    header.appendChild(settings);
     const fav = document.createElement("button");
     fav.className = "icon-btn";
     fav.textContent = item.favorite ? "\u2605" : "\u2606";
@@ -968,7 +957,7 @@ var Sevenn = (() => {
       fav.textContent = item.favorite ? "\u2605" : "\u2606";
       onChange && onChange();
     });
-    actions.appendChild(fav);
+    menu.appendChild(fav);
     const link = document.createElement("button");
     link.className = "icon-btn";
     link.textContent = "\u{1FAA2}";
@@ -978,7 +967,7 @@ var Sevenn = (() => {
       e.stopPropagation();
       openLinker(item, onChange);
     });
-    actions.appendChild(link);
+    menu.appendChild(link);
     const edit = document.createElement("button");
     edit.className = "icon-btn";
     edit.textContent = "\u270F\uFE0F";
@@ -988,7 +977,7 @@ var Sevenn = (() => {
       e.stopPropagation();
       openEditor(item.kind, onChange, item);
     });
-    actions.appendChild(edit);
+    menu.appendChild(edit);
     const copy = document.createElement("button");
     copy.className = "icon-btn";
     copy.textContent = "\u{1F4CB}";
@@ -998,7 +987,7 @@ var Sevenn = (() => {
       e.stopPropagation();
       navigator.clipboard && navigator.clipboard.writeText(item.name || item.concept || "");
     });
-    actions.appendChild(copy);
+    menu.appendChild(copy);
     const del = document.createElement("button");
     del.className = "icon-btn";
     del.textContent = "\u{1F5D1}\uFE0F";
@@ -1011,41 +1000,38 @@ var Sevenn = (() => {
         onChange && onChange();
       }
     });
-    actions.appendChild(del);
-    header.appendChild(actions);
+    menu.appendChild(del);
     card.appendChild(header);
-    const identifiers = document.createElement("div");
-    identifiers.className = "identifiers";
-    (item.blocks || []).forEach((b) => {
-      const chip = document.createElement("span");
-      chip.className = "chip";
-      chip.textContent = b;
-      identifiers.appendChild(chip);
-    });
-    (item.weeks || []).forEach((w) => {
-      const chip = document.createElement("span");
-      chip.className = "chip";
-      chip.textContent = "W" + w;
-      identifiers.appendChild(chip);
-    });
-    if (item.lectures) {
-      item.lectures.forEach((l) => {
-        const chip = document.createElement("span");
-        chip.className = "chip";
-        chip.textContent = "\u{1F4DA} " + (l.name || l.id);
-        identifiers.appendChild(chip);
-      });
-    }
-    card.appendChild(identifiers);
     const body = document.createElement("div");
     body.className = "card-body";
     card.appendChild(body);
     function renderBody() {
       body.innerHTML = "";
+      const identifiers = document.createElement("div");
+      identifiers.className = "identifiers";
+      (item.blocks || []).forEach((b) => {
+        const chip = document.createElement("span");
+        chip.className = "chip";
+        chip.textContent = b;
+        identifiers.appendChild(chip);
+      });
+      (item.weeks || []).forEach((w) => {
+        const chip = document.createElement("span");
+        chip.className = "chip";
+        chip.textContent = "W" + w;
+        identifiers.appendChild(chip);
+      });
+      if (item.lectures) {
+        item.lectures.forEach((l) => {
+          const chip = document.createElement("span");
+          chip.className = "chip";
+          chip.textContent = "\u{1F4DA} " + (l.name || l.id);
+          identifiers.appendChild(chip);
+        });
+      }
+      body.appendChild(identifiers);
       const defs = fieldDefs[item.kind] || [];
-      const showAll = expanded.has(item.id);
-      const fields = showAll ? defs : defs.filter((d) => collapsedPref[item.kind].includes(d[0]));
-      fields.forEach(([f, label, icon]) => {
+      defs.forEach(([f, label, icon]) => {
         if (!item[f]) return;
         const sec = document.createElement("div");
         sec.className = "section";
@@ -1057,6 +1043,7 @@ var Sevenn = (() => {
         sec.appendChild(tl);
         const txt = document.createElement("div");
         txt.textContent = item[f];
+        txt.style.whiteSpace = "pre-wrap";
         sec.appendChild(txt);
         body.appendChild(sec);
       });
@@ -1074,6 +1061,16 @@ var Sevenn = (() => {
     }
     renderBody();
     if (expanded.has(item.id)) card.classList.add("expanded");
+    function fit() {
+      const headerH = header.offsetHeight;
+      const maxH = card.clientHeight - headerH - 4;
+      let size = parseFloat(getComputedStyle(body).fontSize);
+      while (body.scrollHeight > maxH && size > 12) {
+        size -= 1;
+        body.style.fontSize = size + "px";
+      }
+    }
+    requestAnimationFrame(fit);
     return card;
   }
   async function renderCardList(container, items, kind, onChange) {
@@ -1159,10 +1156,60 @@ var Sevenn = (() => {
     decks.forEach((cards, lecture) => {
       const deck = document.createElement("div");
       deck.className = "deck";
-      deck.textContent = `${lecture} (${cards.length})`;
-      deck.addEventListener("click", () => openDeck(lecture, cards));
+      const title = document.createElement("div");
+      title.className = "deck-title";
+      title.textContent = lecture;
+      const meta = document.createElement("div");
+      meta.className = "deck-meta";
+      const blocks = Array.from(new Set(cards.flatMap((c) => c.blocks || []))).join(", ");
+      const weeks = Array.from(new Set(cards.flatMap((c) => c.weeks || []))).join(", ");
+      meta.textContent = `${blocks}${blocks && weeks ? " \u2022 " : ""}${weeks ? "Week " + weeks : ""}`;
+      deck.appendChild(title);
+      deck.appendChild(meta);
+      deck.addEventListener("click", () => {
+        stopPreview(deck);
+        openDeck(lecture, cards);
+      });
+      let hoverTimer;
+      deck.addEventListener("mouseenter", () => {
+        hoverTimer = setTimeout(() => startPreview(deck, cards), 3e3);
+      });
+      deck.addEventListener("mouseleave", () => {
+        clearTimeout(hoverTimer);
+        stopPreview(deck);
+      });
       list.appendChild(deck);
     });
+    function startPreview(deckEl, cards) {
+      if (deckEl._preview) return;
+      deckEl.classList.add("pop");
+      const fan = document.createElement("div");
+      fan.className = "deck-fan";
+      deckEl.appendChild(fan);
+      const show = cards.slice(0, 5);
+      const spread = 20;
+      const offset = (show.length - 1) * spread / 2;
+      show.forEach((c, i) => {
+        const mini = document.createElement("div");
+        mini.className = "fan-card";
+        mini.textContent = c.name || c.concept || "";
+        fan.appendChild(mini);
+        const angle = -offset + i * spread;
+        mini.style.transform = `rotate(${angle}deg) translateY(-80px)`;
+        setTimeout(() => {
+          mini.style.opacity = 1;
+        }, i * 100);
+      });
+      deckEl._preview = { fan };
+    }
+    function stopPreview(deckEl) {
+      const prev = deckEl._preview;
+      if (prev) {
+        prev.fan.remove();
+        deckEl.classList.remove("pop");
+        deckEl._preview = null;
+      }
+    }
     function openDeck(title, cards) {
       list.classList.add("hidden");
       viewer.classList.remove("hidden");
@@ -1205,7 +1252,12 @@ var Sevenn = (() => {
         const current = cards[idx];
         (current.links || []).forEach((l) => {
           const item = items.find((it) => it.id === l.id);
-          if (item) relatedWrap.appendChild(createItemCard(item, onChange));
+          if (item) {
+            const el = createItemCard(item, onChange);
+            el.classList.add("related-card");
+            relatedWrap.appendChild(el);
+            requestAnimationFrame(() => el.classList.add("visible"));
+          }
         });
       }
       prev.addEventListener("click", () => {

--- a/js/ui/components/cardlist.js
+++ b/js/ui/components/cardlist.js
@@ -5,11 +5,6 @@ import { confirmModal } from './confirm.js';
 import { openLinker } from './linker.js';
 
 const kindColors = { disease: 'var(--pink)', drug: 'var(--blue)', concept: 'var(--green)' };
-const collapsedPref = {
-  disease: ['pathophys','clinical'],
-  drug: ['moa','uses'],
-  concept: ['definition','mechanism']
-};
 const fieldDefs = {
   disease: [
     ['etiology','Etiology','🧬'],
@@ -51,28 +46,27 @@ export function createItemCard(item, onChange){
   header.className = 'card-header';
 
   const mainBtn = document.createElement('button');
-  mainBtn.className = 'header-main';
+  mainBtn.className = 'card-title-btn';
+  mainBtn.textContent = item.name || item.concept || 'Untitled';
   mainBtn.setAttribute('aria-expanded', expanded.has(item.id));
   mainBtn.addEventListener('click', () => {
     if (expanded.has(item.id)) expanded.delete(item.id); else expanded.add(item.id);
-    renderBody();
     card.classList.toggle('expanded');
     mainBtn.setAttribute('aria-expanded', expanded.has(item.id));
   });
-
-  const badge = document.createElement('span');
-  badge.className = `kind-badge ${item.kind}`;
-  badge.textContent = item.kind.charAt(0).toUpperCase() + item.kind.slice(1);
-  mainBtn.appendChild(badge);
-
-  const title = document.createElement('span');
-  title.className = 'card-title';
-  title.textContent = item.name || item.concept || 'Untitled';
-  mainBtn.appendChild(title);
   header.appendChild(mainBtn);
 
-  const actions = document.createElement('div');
-  actions.className = 'card-actions';
+  const settings = document.createElement('div');
+  settings.className = 'card-settings';
+  const gear = document.createElement('button');
+  gear.className = 'icon-btn';
+  gear.textContent = '⚙️';
+  const menu = document.createElement('div');
+  menu.className = 'card-menu hidden';
+  gear.addEventListener('click', e => { e.stopPropagation(); menu.classList.toggle('hidden'); });
+  settings.appendChild(gear);
+  settings.appendChild(menu);
+  header.appendChild(settings);
 
   const fav = document.createElement('button');
   fav.className = 'icon-btn';
@@ -86,7 +80,7 @@ export function createItemCard(item, onChange){
     fav.textContent = item.favorite ? '★' : '☆';
     onChange && onChange();
   });
-  actions.appendChild(fav);
+  menu.appendChild(fav);
 
   const link = document.createElement('button');
   link.className = 'icon-btn';
@@ -94,7 +88,7 @@ export function createItemCard(item, onChange){
   link.title = 'Links';
   link.setAttribute('aria-label','Manage links');
   link.addEventListener('click', e => { e.stopPropagation(); openLinker(item, onChange); });
-  actions.appendChild(link);
+  menu.appendChild(link);
 
   const edit = document.createElement('button');
   edit.className = 'icon-btn';
@@ -102,7 +96,7 @@ export function createItemCard(item, onChange){
   edit.title = 'Edit';
   edit.setAttribute('aria-label','Edit');
   edit.addEventListener('click', e => { e.stopPropagation(); openEditor(item.kind, onChange, item); });
-  actions.appendChild(edit);
+  menu.appendChild(edit);
 
   const copy = document.createElement('button');
   copy.className = 'icon-btn';
@@ -113,7 +107,7 @@ export function createItemCard(item, onChange){
     e.stopPropagation();
     navigator.clipboard && navigator.clipboard.writeText(item.name || item.concept || '');
   });
-  actions.appendChild(copy);
+  menu.appendChild(copy);
 
   const del = document.createElement('button');
   del.className = 'icon-btn';
@@ -127,34 +121,9 @@ export function createItemCard(item, onChange){
       onChange && onChange();
     }
   });
-  actions.appendChild(del);
+  menu.appendChild(del);
 
-  header.appendChild(actions);
   card.appendChild(header);
-
-  const identifiers = document.createElement('div');
-  identifiers.className = 'identifiers';
-  (item.blocks || []).forEach(b => {
-    const chip = document.createElement('span');
-    chip.className = 'chip';
-    chip.textContent = b;
-    identifiers.appendChild(chip);
-  });
-  (item.weeks || []).forEach(w => {
-    const chip = document.createElement('span');
-    chip.className = 'chip';
-    chip.textContent = 'W' + w;
-    identifiers.appendChild(chip);
-  });
-  if (item.lectures) {
-    item.lectures.forEach(l => {
-      const chip = document.createElement('span');
-      chip.className = 'chip';
-      chip.textContent = '📚 ' + (l.name || l.id);
-      identifiers.appendChild(chip);
-    });
-  }
-  card.appendChild(identifiers);
 
   const body = document.createElement('div');
   body.className = 'card-body';
@@ -162,10 +131,32 @@ export function createItemCard(item, onChange){
 
   function renderBody(){
     body.innerHTML = '';
+    const identifiers = document.createElement('div');
+    identifiers.className = 'identifiers';
+    (item.blocks || []).forEach(b => {
+      const chip = document.createElement('span');
+      chip.className = 'chip';
+      chip.textContent = b;
+      identifiers.appendChild(chip);
+    });
+    (item.weeks || []).forEach(w => {
+      const chip = document.createElement('span');
+      chip.className = 'chip';
+      chip.textContent = 'W' + w;
+      identifiers.appendChild(chip);
+    });
+    if (item.lectures) {
+      item.lectures.forEach(l => {
+        const chip = document.createElement('span');
+        chip.className = 'chip';
+        chip.textContent = '📚 ' + (l.name || l.id);
+        identifiers.appendChild(chip);
+      });
+    }
+    body.appendChild(identifiers);
+
     const defs = fieldDefs[item.kind] || [];
-    const showAll = expanded.has(item.id);
-    const fields = showAll ? defs : defs.filter(d => collapsedPref[item.kind].includes(d[0]));
-    fields.forEach(([f,label,icon]) => {
+    defs.forEach(([f,label,icon]) => {
       if (!item[f]) return;
       const sec = document.createElement('div');
       sec.className = 'section';
@@ -177,6 +168,7 @@ export function createItemCard(item, onChange){
       sec.appendChild(tl);
       const txt = document.createElement('div');
       txt.textContent = item[f];
+      txt.style.whiteSpace = 'pre-wrap';
       sec.appendChild(txt);
       body.appendChild(sec);
     });
@@ -195,6 +187,17 @@ export function createItemCard(item, onChange){
 
   renderBody();
   if (expanded.has(item.id)) card.classList.add('expanded');
+
+  function fit(){
+    const headerH = header.offsetHeight;
+    const maxH = card.clientHeight - headerH - 4;
+    let size = parseFloat(getComputedStyle(body).fontSize);
+    while(body.scrollHeight > maxH && size > 12){
+      size -= 1;
+      body.style.fontSize = size + 'px';
+    }
+  }
+  requestAnimationFrame(fit);
   return card;
 }
 

--- a/style.css
+++ b/style.css
@@ -29,6 +29,20 @@ body {
   font-size: 18px;
 }
 
+button {
+  background: var(--muted);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 6px 12px;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.3);
+}
+
 .header {
   padding: var(--pad);
   background: var(--panel);
@@ -48,11 +62,11 @@ body {
 
 .tabs .tab {
   background: var(--muted);
-  border: none;
   color: var(--text);
   padding: 6px 12px;
   cursor: pointer;
   border-radius: var(--radius);
+  border: 1px solid var(--border);
 }
 
 .tab.active {
@@ -132,7 +146,7 @@ body {
 .btn {
   background: var(--blue);
   color: #000;
-  border: none;
+  border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 6px 12px;
   cursor: pointer;
@@ -319,69 +333,71 @@ body {
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  width: 260px;
+  height: 180px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 .item-card .card-header {
   display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
+  justify-content: center;
+  align-items: center;
   padding: var(--pad);
-  cursor: pointer;
+  position: relative;
 }
 
-.header-main {
+.card-title-btn {
   background: none;
   border: none;
   color: inherit;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap:4px;
-  text-align: left;
+  text-align:center;
   flex:1;
+  font-size:1.5rem;
+  font-weight:700;
+  cursor:pointer;
 }
 
-.kind-badge {
-  border-radius: var(--radius);
-  padding: 2px 6px;
-  font-size: 12px;
-  color: #000;
-}
-.kind-badge.disease { background: var(--pink); }
-.kind-badge.drug { background: var(--blue); }
-.kind-badge.concept { background: var(--green); }
+.card-settings { position:absolute; right:var(--pad); top:50%; transform:translateY(-50%); }
 
-.card-title {
-  font-weight: 600;
-  line-height: 1.2;
-  display:block;
-  max-height: 2.4em;
-  overflow: hidden;
+.card-menu {
+  position:absolute;
+  right:0;
+  top:100%;
+  background:var(--panel);
+  border:1px solid var(--border);
+  border-radius:var(--radius);
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  padding:4px;
+  z-index:5;
 }
+
+.card-menu.hidden { display:none; }
 
 .identifiers {
   display:flex;
   gap:4px;
   flex-wrap:wrap;
-  padding: 0 var(--pad) var(--pad);
-}
-
-.card-actions {
-  display:flex;
-  gap:4px;
+  margin-bottom:var(--pad);
 }
 
 .icon-btn {
-  background:none;
-  border:none;
+  background: var(--muted);
+  border: 1px solid var(--border);
   cursor:pointer;
   color: var(--text);
   padding:2px;
+  border-radius: var(--radius);
 }
 
 .card-body {
   padding: 0 var(--pad) var(--pad);
   display:none;
+  flex:1;
+  overflow:auto;
 }
 
 .item-card.expanded .card-body {
@@ -398,6 +414,11 @@ body {
   font-size:12px;
   text-transform:uppercase;
   opacity:0.7;
+}
+
+.section div {
+  white-space:pre-wrap;
+  word-break:break-word;
 }
 
 .facts {
@@ -431,11 +452,52 @@ body {
   padding:var(--pad-lg);
   cursor:pointer;
   box-shadow:0 2px 4px rgba(0,0,0,0.2);
+  position:relative;
+  width:200px;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  text-align:center;
+  transition:transform 0.3s ease;
+}
+.deck-title { font-weight:600; margin-bottom:4px; }
+.deck-meta { font-size:0.85rem; color:var(--gray); }
+.deck.pop { transform:scale(1.05); z-index:2; }
+.deck-fan {
+  position:absolute;
+  top:50%;
+  left:50%;
+  transform:translate(-50%,-50%);
+  pointer-events:none;
+}
+.deck-fan .fan-card {
+  position:absolute;
+  width:70px;
+  height:90px;
+  background:var(--panel);
+  border:1px solid var(--border);
+  border-radius:var(--radius);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-size:0.65rem;
+  color:var(--text);
+  opacity:0;
+  transform-origin:bottom center;
+  transition:opacity 0.3s ease, transform 0.3s ease;
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
 }
 .deck-viewer {
-  position:relative;
-  text-align:center;
-  padding:var(--pad);
+  position: relative;
+  text-align: center;
+  padding: var(--pad);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 70vh;
 }
 .deck-card {
   max-width:400px;
@@ -446,25 +508,58 @@ body {
   top:50%;
   transform:translateY(-50%);
   background:var(--muted);
-  border:none;
   color:var(--text);
   padding:8px;
   border-radius:var(--radius);
   cursor:pointer;
+  border:1px solid var(--border);
 }
 .deck-prev { left:var(--pad); }
 .deck-next { right:var(--pad); }
+.deck-prev:hover, .deck-next:hover {
+  transform:translateY(calc(-50% - 2px));
+}
 .deck-related {
   display:flex;
   flex-wrap:wrap;
   gap:var(--pad);
   justify-content:center;
   margin-top:var(--pad);
+  opacity:0;
+  transform:translateY(-10px);
+  transition:opacity 0.3s ease, transform 0.3s ease;
+}
+.deck-related:not(.hidden) {
+  opacity:1;
+  transform:translateY(0);
+}
+.deck-related .related-card {
+  opacity:0;
+  transform:scale(0.95);
+  transition:opacity 0.3s ease, transform 0.3s ease;
+}
+.deck-related .related-card.visible {
+  opacity:1;
+  transform:scale(1);
 }
 .deck-close {
   margin-top:var(--pad);
 }
 .hidden { display:none !important; }
+
+.title-cell{
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  margin-bottom:var(--pad);
+}
+.title-cell .title{
+  font-size:1.25rem;
+  font-weight:600;
+}
+.title-cell .actions{
+  margin-top:4px;
+}
 
 /* Map */
 .map-svg {


### PR DESCRIPTION
## Summary
- Enforce uniform card dimensions with centered titles and dynamic font sizing to keep details contained
- Fan out a sample of cards from each lecture tile after a 3‑second hover for a richer preview

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4475101888322880b60330b8f58a1