### PR TITLE
Add interactive concept map editing

### DIFF
--- a/js/storage/storage.js
+++ b/js/storage/storage.js
@@ -129,11 +129,23 @@ export async function upsertItem(item) {
     const other = await prom(i.get(link.id));
     if (other) {
       other.links = other.links || [];
-      if (!other.links.find(l => l.id === next.id)) {
-        other.links.push({ id: next.id, type: link.type });
-        other.tokens = buildTokens(other);
-        await prom(i.put(other));
+      const existingLink = other.links.find(l => l.id === next.id);
+      if (existingLink) {
+        existingLink.type = link.type;
+        existingLink.color = link.color;
+        existingLink.style = link.style;
+        existingLink.label = link.label;
+      } else {
+        other.links.push({
+          id: next.id,
+          type: link.type,
+          color: link.color,
+          style: link.style,
+          label: link.label
+        });
       }
+      other.tokens = buildTokens(other);
+      await prom(i.put(other));
     }
   }
   await prom(i.put(next));

--- a/js/types.js
+++ b/js/types.js
@@ -1,5 +1,6 @@
 /** @typedef {"disease"|"drug"|"concept"} Kind */
 /** @typedef {"assoc"|"treats"|"causes"|"mech"|"contra"} LinkType */
+/** @typedef {"solid"|"dashed"|"arrow"|"inhibit"} LinkStyle */
 
 /** @typedef {{ box:number, last:number, due:number, ease:number }} SR */
 
@@ -14,7 +15,7 @@
  * @property {string|null} color         // pastel override or null
  * @property {string[]} facts            // chips
  * @property {string[]} tags             // chips
- * @property {{id:string, type:LinkType}[]} links
+ * @property {{id:string, type:LinkType, color?:string, style?:LinkStyle, label?:string}[]} links
  * @property {string[]} blocks           // ["F1","MSK"]
  * @property {number[]} weeks            // [1,3]
  * @property {LectureRef[]} lectures     // chosen by number → resolves name+week

--- a/js/ui/components/map.js
+++ b/js/ui/components/map.js
@@ -1,4 +1,4 @@
-import { listItemsByKind } from '../../storage/storage.js';
+import { listItemsByKind, upsertItem } from '../../storage/storage.js';
 import { showPopup } from './popup.js';
 
 export async function renderMap(root){
@@ -14,6 +14,20 @@ export async function renderMap(root){
   const svg = document.createElementNS('http://www.w3.org/2000/svg','svg');
   svg.setAttribute('viewBox',`0 0 ${size} ${size}`);
   svg.classList.add('map-svg');
+
+  const g = document.createElementNS('http://www.w3.org/2000/svg','g');
+  svg.appendChild(g);
+
+  const defs = document.createElementNS('http://www.w3.org/2000/svg','defs');
+  defs.innerHTML = `
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="10" refY="5" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L10,5 L0,10 z" fill="context-stroke" />
+    </marker>
+    <marker id="bar" markerWidth="10" markerHeight="10" refX="10" refY="5" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,10" stroke="context-stroke" stroke-width="2" />
+    </marker>`;
+  svg.appendChild(defs);
+
   const positions = {};
   items.forEach((it, idx) => {
     const angle = (2*Math.PI*idx)/items.length;
@@ -35,7 +49,22 @@ export async function renderMap(root){
       line.setAttribute('x2', positions[l.id].x);
       line.setAttribute('y2', positions[l.id].y);
       line.setAttribute('class','map-edge');
-      svg.appendChild(line);
+      line.dataset.source = it.id;
+      line.dataset.target = l.id;
+      if (l.color) line.setAttribute('stroke', l.color);
+      if (l.style === 'dashed') line.setAttribute('stroke-dasharray','4');
+      if (l.style === 'arrow') line.setAttribute('marker-end','url(#arrow)');
+      if (l.style === 'inhibit') line.setAttribute('marker-end','url(#bar)');
+      if (l.label) {
+        const title = document.createElementNS('http://www.w3.org/2000/svg','title');
+        title.textContent = l.label;
+        line.appendChild(title);
+      }
+      line.addEventListener('click', e => {
+        e.stopPropagation();
+        editLine(line, e);
+      });
+      g.appendChild(line);
     });
   });
   // nodes
@@ -46,14 +75,95 @@ export async function renderMap(root){
     circle.setAttribute('cy', pos.y);
     circle.setAttribute('r', 16);
     circle.setAttribute('class','map-node');
+    const color = it.color || (it.kind === 'disease' ? 'var(--purple)' : it.kind === 'drug' ? 'var(--blue)' : 'var(--green)');
+    circle.style.fill = color;
     circle.addEventListener('click', () => showPopup(it));
-    svg.appendChild(circle);
+    g.appendChild(circle);
     const text = document.createElementNS('http://www.w3.org/2000/svg','text');
     text.setAttribute('x', pos.x);
     text.setAttribute('y', pos.y - 20);
     text.setAttribute('class','map-label');
     text.textContent = it.name || it.concept || '?';
-    svg.appendChild(text);
+    g.appendChild(text);
   });
   root.appendChild(svg);
+
+  // dragging/panning
+  let isDrag = false, lastX = 0, lastY = 0, offsetX = 0, offsetY = 0;
+  svg.addEventListener('mousedown', e => {
+    if (e.target !== svg) return;
+    isDrag = true;
+    lastX = e.clientX;
+    lastY = e.clientY;
+    svg.classList.add('dragging');
+  });
+  window.addEventListener('mousemove', e => {
+    if (!isDrag) return;
+    offsetX += e.clientX - lastX;
+    offsetY += e.clientY - lastY;
+    lastX = e.clientX;
+    lastY = e.clientY;
+    g.setAttribute('transform', `translate(${offsetX},${offsetY})`);
+  });
+  window.addEventListener('mouseup', () => {
+    isDrag = false;
+    svg.classList.remove('dragging');
+  });
+
+  function editLine(line, evt){
+    const srcId = line.dataset.source;
+    const tgtId = line.dataset.target;
+    const srcItem = items.find(it => it.id === srcId);
+    if (!srcItem) return;
+    const link = srcItem.links.find(l => l.id === tgtId);
+    const menu = document.createElement('div');
+    menu.className = 'line-editor';
+    menu.style.left = evt.clientX + 'px';
+    menu.style.top = evt.clientY + 'px';
+
+    const colorIn = document.createElement('input');
+    colorIn.type = 'color';
+    colorIn.value = link.color || '#ffffff';
+    const styleSel = document.createElement('select');
+    ['solid','dashed','arrow','inhibit'].forEach(s => {
+      const opt = document.createElement('option');
+      opt.value = s;
+      opt.textContent = s;
+      styleSel.appendChild(opt);
+    });
+    styleSel.value = link.style || 'solid';
+    const labelIn = document.createElement('input');
+    labelIn.type = 'text';
+    labelIn.placeholder = 'Label';
+    labelIn.value = link.label || '';
+    const save = document.createElement('button');
+    save.className = 'btn';
+    save.textContent = 'Save';
+    const cancel = document.createElement('button');
+    cancel.className = 'btn';
+    cancel.textContent = 'Cancel';
+    menu.append(colorIn, styleSel, labelIn, save, cancel);
+    document.body.appendChild(menu);
+
+    cancel.addEventListener('click', () => menu.remove());
+    save.addEventListener('click', async () => {
+      link.color = colorIn.value;
+      link.style = styleSel.value;
+      link.label = labelIn.value;
+      line.setAttribute('stroke', link.color);
+      line.removeAttribute('stroke-dasharray');
+      line.removeAttribute('marker-end');
+      if (link.style === 'dashed') line.setAttribute('stroke-dasharray','4');
+      if (link.style === 'arrow') line.setAttribute('marker-end','url(#arrow)');
+      if (link.style === 'inhibit') line.setAttribute('marker-end','url(#bar)');
+      let title = line.querySelector('title');
+      if (!title){
+        title = document.createElementNS('http://www.w3.org/2000/svg','title');
+        line.appendChild(title);
+      }
+      title.textContent = link.label;
+      await upsertItem(srcItem);
+      menu.remove();
+    });
+  }
 }

--- a/js/ui/components/popup.js
+++ b/js/ui/components/popup.js
@@ -1,19 +1,9 @@
+import { createItemCard } from './cardlist.js';
+
 export function showPopup(item){
   const modal = document.createElement('div');
   modal.className = 'modal';
-  const card = document.createElement('div');
-  card.className = 'card';
-  const title = document.createElement('h2');
-  title.textContent = item.name || item.concept || 'Item';
-  card.appendChild(title);
-  const kind = document.createElement('div');
-  kind.textContent = `Type: ${item.kind}`;
-  card.appendChild(kind);
-  if (item.mnemonic){
-    const m = document.createElement('div');
-    m.textContent = `Mnemonic: ${item.mnemonic}`;
-    card.appendChild(m);
-  }
+  const card = createItemCard(item);
   const close = document.createElement('button');
   close.className = 'btn';
   close.textContent = 'Close';

--- a/style.css
+++ b/style.css
@@ -587,9 +587,12 @@ button:hover {
 .map-svg {
   width: 100%;
   height: 600px;
+  cursor: grab;
+}
+.map-svg.dragging {
+  cursor: grabbing;
 }
 .map-node {
-  fill: var(--blue);
   cursor: pointer;
 }
 .map-edge {
@@ -600,4 +603,15 @@ button:hover {
   fill: var(--text);
   font-size: 10px;
   text-anchor: middle;
+}
+.line-editor {
+  position: absolute;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--pad);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  z-index: 1000;
 }


### PR DESCRIPTION
## Summary
- make map view draggable for easier navigation
- color-code nodes and support custom colors per item
- allow editing link color, style, and label with hover tooltips
- show full item card when clicking nodes

## Testing
- `npx --yes esbuild js/main.js --bundle --format=iife --global-name=Sevenn --outfile=bundle.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4649e83a08322b894d15325c78056