### PR TITLE
feat: enhance concept map interactions

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -334,6 +334,10 @@
     }
     return items;
   }
+  async function getItem(id) {
+    const i = await store("items");
+    return await prom2(i.get(id));
+  }
   async function upsertItem(item) {
     const i = await store("items", "readwrite");
     const existing = await prom2(i.get(item.id));
@@ -1790,21 +1794,65 @@
   }
 
   // js/ui/components/popup.js
+  var fieldDefs2 = {
+    disease: [
+      ["etiology", "Etiology"],
+      ["pathophys", "Pathophys"],
+      ["clinical", "Clinical"],
+      ["diagnosis", "Diagnosis"],
+      ["treatment", "Treatment"],
+      ["complications", "Complications"],
+      ["mnemonic", "Mnemonic"]
+    ],
+    drug: [
+      ["class", "Class"],
+      ["source", "Source"],
+      ["moa", "MOA"],
+      ["uses", "Uses"],
+      ["sideEffects", "Side Effects"],
+      ["contraindications", "Contraindications"],
+      ["mnemonic", "Mnemonic"]
+    ],
+    concept: [
+      ["type", "Type"],
+      ["definition", "Definition"],
+      ["mechanism", "Mechanism"],
+      ["clinicalRelevance", "Clinical Relevance"],
+      ["example", "Example"],
+      ["mnemonic", "Mnemonic"]
+    ]
+  };
   function showPopup(item) {
     const modal = document.createElement("div");
     modal.className = "modal";
     const card = document.createElement("div");
     card.className = "card";
+    const kindColors2 = { disease: "var(--purple)", drug: "var(--blue)", concept: "var(--green)" };
+    card.style.borderTop = `3px solid ${item.color || kindColors2[item.kind] || "var(--gray)"}`;
     const title = document.createElement("h2");
     title.textContent = item.name || item.concept || "Item";
     card.appendChild(title);
-    const kind = document.createElement("div");
-    kind.textContent = `Type: ${item.kind}`;
-    card.appendChild(kind);
-    if (item.mnemonic) {
-      const m = document.createElement("div");
-      m.textContent = `Mnemonic: ${item.mnemonic}`;
-      card.appendChild(m);
+    const defs = fieldDefs2[item.kind] || [];
+    defs.forEach(([field, label]) => {
+      const val = item[field];
+      if (!val) return;
+      const sec = document.createElement("div");
+      sec.className = "section";
+      const tl = document.createElement("div");
+      tl.className = "section-title";
+      tl.textContent = label;
+      sec.appendChild(tl);
+      const txt = document.createElement("div");
+      txt.textContent = val;
+      txt.style.whiteSpace = "pre-wrap";
+      sec.appendChild(txt);
+      card.appendChild(sec);
+    });
+    if (item.facts && item.facts.length) {
+      const facts = document.createElement("div");
+      facts.className = "facts";
+      facts.textContent = item.facts.join(", ");
+      card.appendChild(facts);
     }
     const close = document.createElement("button");
     close.className = "btn";
@@ -1826,19 +1874,57 @@
       ...await listItemsByKind("drug"),
       ...await listItemsByKind("concept")
     ];
-    const size = 600;
-    const center = size / 2;
-    const radius = size / 2 - 40;
+    const size = 2e3;
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     svg.setAttribute("viewBox", `0 0 ${size} ${size}`);
     svg.classList.add("map-svg");
+    const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+    svg.appendChild(g);
+    let panX = 0, panY = 0;
+    let dragging = false;
+    let last = { x: 0, y: 0 };
+    svg.addEventListener("mousedown", (e) => {
+      if (e.target === svg) {
+        dragging = true;
+        last = { x: e.clientX, y: e.clientY };
+        svg.style.cursor = "grabbing";
+      }
+    });
+    window.addEventListener("mousemove", (e) => {
+      if (!dragging) return;
+      panX += e.clientX - last.x;
+      panY += e.clientY - last.y;
+      last = { x: e.clientX, y: e.clientY };
+      g.setAttribute("transform", `translate(${panX},${panY})`);
+    });
+    window.addEventListener("mouseup", () => {
+      dragging = false;
+      svg.style.cursor = "grab";
+    });
     const positions = {};
+    const center = size / 2;
+    const radius = size / 2 - 200;
     items.forEach((it, idx) => {
       const angle = 2 * Math.PI * idx / items.length;
       const x = center + radius * Math.cos(angle);
       const y = center + radius * Math.sin(angle);
       positions[it.id] = { x, y };
     });
+    const defs = document.createElementNS("http://www.w3.org/2000/svg", "defs");
+    const marker = document.createElementNS("http://www.w3.org/2000/svg", "marker");
+    marker.setAttribute("id", "arrow");
+    marker.setAttribute("viewBox", "0 0 10 10");
+    marker.setAttribute("refX", "10");
+    marker.setAttribute("refY", "5");
+    marker.setAttribute("markerWidth", "6");
+    marker.setAttribute("markerHeight", "6");
+    marker.setAttribute("orient", "auto");
+    const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    path.setAttribute("d", "M0,0 L10,5 L0,10 Z");
+    path.setAttribute("fill", "inherit");
+    marker.appendChild(path);
+    defs.appendChild(marker);
+    svg.appendChild(defs);
     const drawn = /* @__PURE__ */ new Set();
     items.forEach((it) => {
       (it.links || []).forEach((l) => {
@@ -1852,7 +1938,14 @@
         line.setAttribute("x2", positions[l.id].x);
         line.setAttribute("y2", positions[l.id].y);
         line.setAttribute("class", "map-edge");
-        svg.appendChild(line);
+        applyLineStyle(line, l);
+        line.dataset.a = it.id;
+        line.dataset.b = l.id;
+        line.addEventListener("click", (e) => {
+          e.stopPropagation();
+          openLineMenu(e, line, it.id, l.id);
+        });
+        g.appendChild(line);
       });
     });
     items.forEach((it) => {
@@ -1862,16 +1955,99 @@
       circle.setAttribute("cy", pos.y);
       circle.setAttribute("r", 16);
       circle.setAttribute("class", "map-node");
+      const kindColors2 = { disease: "var(--purple)", drug: "var(--blue)" };
+      const fill = kindColors2[it.kind] || it.color || "var(--gray)";
+      circle.setAttribute("fill", fill);
       circle.addEventListener("click", () => showPopup(it));
-      svg.appendChild(circle);
+      g.appendChild(circle);
       const text = document.createElementNS("http://www.w3.org/2000/svg", "text");
       text.setAttribute("x", pos.x);
       text.setAttribute("y", pos.y - 20);
       text.setAttribute("class", "map-label");
       text.textContent = it.name || it.concept || "?";
-      svg.appendChild(text);
+      g.appendChild(text);
     });
     root.appendChild(svg);
+  }
+  function applyLineStyle(line, info) {
+    const color = info.color || "var(--gray)";
+    line.setAttribute("stroke", color);
+    if (info.style === "dashed") line.setAttribute("stroke-dasharray", "4,4");
+    else line.removeAttribute("stroke-dasharray");
+    if (info.style === "arrow") line.setAttribute("marker-end", "url(#arrow)");
+    else line.removeAttribute("marker-end");
+    let title = line.querySelector("title");
+    if (!title) {
+      title = document.createElementNS("http://www.w3.org/2000/svg", "title");
+      line.appendChild(title);
+    }
+    title.textContent = info.name || "";
+  }
+  async function openLineMenu(evt, line, aId, bId) {
+    const existing = await getItem(aId);
+    const link = existing.links.find((l) => l.id === bId) || {};
+    const menu = document.createElement("div");
+    menu.className = "line-menu";
+    menu.style.left = evt.pageX + "px";
+    menu.style.top = evt.pageY + "px";
+    const colorLabel = document.createElement("label");
+    colorLabel.textContent = "Color";
+    const colorInput = document.createElement("input");
+    colorInput.type = "color";
+    colorInput.value = link.color || "#888888";
+    colorLabel.appendChild(colorInput);
+    menu.appendChild(colorLabel);
+    const typeLabel = document.createElement("label");
+    typeLabel.textContent = "Style";
+    const typeSel = document.createElement("select");
+    ["solid", "dashed", "arrow"].forEach((t) => {
+      const opt = document.createElement("option");
+      opt.value = t;
+      opt.textContent = t;
+      typeSel.appendChild(opt);
+    });
+    typeSel.value = link.style || "solid";
+    typeLabel.appendChild(typeSel);
+    menu.appendChild(typeLabel);
+    const nameLabel = document.createElement("label");
+    nameLabel.textContent = "Label";
+    const nameInput = document.createElement("input");
+    nameInput.type = "text";
+    nameInput.value = link.name || "";
+    nameLabel.appendChild(nameInput);
+    menu.appendChild(nameLabel);
+    const btn = document.createElement("button");
+    btn.className = "btn";
+    btn.textContent = "Save";
+    btn.addEventListener("click", async () => {
+      const patch = { color: colorInput.value, style: typeSel.value, name: nameInput.value };
+      await updateLink(aId, bId, patch);
+      applyLineStyle(line, patch);
+      document.body.removeChild(menu);
+    });
+    menu.appendChild(btn);
+    document.body.appendChild(menu);
+    const closer = (e) => {
+      if (!menu.contains(e.target)) {
+        document.body.removeChild(menu);
+        document.removeEventListener("mousedown", closer);
+      }
+    };
+    setTimeout(() => document.addEventListener("mousedown", closer), 0);
+  }
+  async function updateLink(aId, bId, patch) {
+    const a = await getItem(aId);
+    const b = await getItem(bId);
+    if (!a || !b) return;
+    const apply = (item, otherId) => {
+      item.links = item.links || [];
+      const l = item.links.find((x) => x.id === otherId);
+      if (l) Object.assign(l, patch);
+    };
+    apply(a, bId);
+    apply(b, aId);
+    await upsertItem(a);
+    await upsertItem(b);
   }
 
   // js/main.js

--- a/js/ui/components/map.js
+++ b/js/ui/components/map.js
@@ -1,4 +1,4 @@
-import { listItemsByKind } from '../../storage/storage.js';
+import { listItemsByKind, getItem, upsertItem } from '../../storage/storage.js';
 import { showPopup } from './popup.js';
 
 export async function renderMap(root){
@@ -8,20 +8,63 @@ export async function renderMap(root){
     ...(await listItemsByKind('drug')),
     ...(await listItemsByKind('concept'))
   ];
-  const size = 600;
-  const center = size/2;
-  const radius = size/2 - 40;
+  const size = 2000;
   const svg = document.createElementNS('http://www.w3.org/2000/svg','svg');
   svg.setAttribute('viewBox',`0 0 ${size} ${size}`);
   svg.classList.add('map-svg');
+
+  const g = document.createElementNS('http://www.w3.org/2000/svg','g');
+  svg.appendChild(g);
+
+  // panning state
+  let panX = 0, panY = 0;
+  let dragging = false;
+  let last = { x:0, y:0 };
+  svg.addEventListener('mousedown', e => {
+    if (e.target === svg) {
+      dragging = true;
+      last = { x: e.clientX, y: e.clientY };
+      svg.style.cursor = 'grabbing';
+    }
+  });
+  window.addEventListener('mousemove', e => {
+    if (!dragging) return;
+    panX += e.clientX - last.x;
+    panY += e.clientY - last.y;
+    last = { x: e.clientX, y: e.clientY };
+    g.setAttribute('transform',`translate(${panX},${panY})`);
+  });
+  window.addEventListener('mouseup', () => {
+    dragging = false;
+    svg.style.cursor = 'grab';
+  });
+
   const positions = {};
+  const center = size/2;
+  const radius = size/2 - 200;
   items.forEach((it, idx) => {
     const angle = (2*Math.PI*idx)/items.length;
     const x = center + radius*Math.cos(angle);
     const y = center + radius*Math.sin(angle);
     positions[it.id] = {x,y};
   });
-  // edges
+
+  const defs = document.createElementNS('http://www.w3.org/2000/svg','defs');
+  const marker = document.createElementNS('http://www.w3.org/2000/svg','marker');
+  marker.setAttribute('id','arrow');
+  marker.setAttribute('viewBox','0 0 10 10');
+  marker.setAttribute('refX','10');
+  marker.setAttribute('refY','5');
+  marker.setAttribute('markerWidth','6');
+  marker.setAttribute('markerHeight','6');
+  marker.setAttribute('orient','auto');
+  const path = document.createElementNS('http://www.w3.org/2000/svg','path');
+  path.setAttribute('d','M0,0 L10,5 L0,10 Z');
+  path.setAttribute('fill','inherit');
+  marker.appendChild(path);
+  defs.appendChild(marker);
+  svg.appendChild(defs);
+
   const drawn = new Set();
   items.forEach(it => {
     (it.links||[]).forEach(l => {
@@ -35,10 +78,14 @@ export async function renderMap(root){
       line.setAttribute('x2', positions[l.id].x);
       line.setAttribute('y2', positions[l.id].y);
       line.setAttribute('class','map-edge');
-      svg.appendChild(line);
+      applyLineStyle(line, l);
+      line.dataset.a = it.id;
+      line.dataset.b = l.id;
+      line.addEventListener('click', e => { e.stopPropagation(); openLineMenu(e, line, it.id, l.id); });
+      g.appendChild(line);
     });
   });
-  // nodes
+
   items.forEach(it => {
     const pos = positions[it.id];
     const circle = document.createElementNS('http://www.w3.org/2000/svg','circle');
@@ -46,14 +93,105 @@ export async function renderMap(root){
     circle.setAttribute('cy', pos.y);
     circle.setAttribute('r', 16);
     circle.setAttribute('class','map-node');
+    const kindColors = { disease: 'var(--purple)', drug: 'var(--blue)' };
+    const fill = kindColors[it.kind] || it.color || 'var(--gray)';
+    circle.setAttribute('fill', fill);
     circle.addEventListener('click', () => showPopup(it));
-    svg.appendChild(circle);
+    g.appendChild(circle);
     const text = document.createElementNS('http://www.w3.org/2000/svg','text');
     text.setAttribute('x', pos.x);
     text.setAttribute('y', pos.y - 20);
     text.setAttribute('class','map-label');
     text.textContent = it.name || it.concept || '?';
-    svg.appendChild(text);
+    g.appendChild(text);
   });
+
   root.appendChild(svg);
+}
+
+function applyLineStyle(line, info){
+  const color = info.color || 'var(--gray)';
+  line.setAttribute('stroke', color);
+  if (info.style === 'dashed') line.setAttribute('stroke-dasharray','4,4');
+  else line.removeAttribute('stroke-dasharray');
+  if (info.style === 'arrow') line.setAttribute('marker-end','url(#arrow)');
+  else line.removeAttribute('marker-end');
+  let title = line.querySelector('title');
+  if (!title) {
+    title = document.createElementNS('http://www.w3.org/2000/svg','title');
+    line.appendChild(title);
+  }
+  title.textContent = info.name || '';
+}
+
+async function openLineMenu(evt, line, aId, bId){
+  const existing = await getItem(aId);
+  const link = existing.links.find(l => l.id === bId) || {};
+  const menu = document.createElement('div');
+  menu.className = 'line-menu';
+  menu.style.left = evt.pageX + 'px';
+  menu.style.top = evt.pageY + 'px';
+
+  const colorLabel = document.createElement('label');
+  colorLabel.textContent = 'Color';
+  const colorInput = document.createElement('input');
+  colorInput.type = 'color';
+  colorInput.value = link.color || '#888888';
+  colorLabel.appendChild(colorInput);
+  menu.appendChild(colorLabel);
+
+  const typeLabel = document.createElement('label');
+  typeLabel.textContent = 'Style';
+  const typeSel = document.createElement('select');
+  ['solid','dashed','arrow'].forEach(t => {
+    const opt = document.createElement('option');
+    opt.value = t; opt.textContent = t;
+    typeSel.appendChild(opt);
+  });
+  typeSel.value = link.style || 'solid';
+  typeLabel.appendChild(typeSel);
+  menu.appendChild(typeLabel);
+
+  const nameLabel = document.createElement('label');
+  nameLabel.textContent = 'Label';
+  const nameInput = document.createElement('input');
+  nameInput.type = 'text';
+  nameInput.value = link.name || '';
+  nameLabel.appendChild(nameInput);
+  menu.appendChild(nameLabel);
+
+  const btn = document.createElement('button');
+  btn.className = 'btn';
+  btn.textContent = 'Save';
+  btn.addEventListener('click', async () => {
+    const patch = { color: colorInput.value, style: typeSel.value, name: nameInput.value };
+    await updateLink(aId, bId, patch);
+    applyLineStyle(line, patch);
+    document.body.removeChild(menu);
+  });
+  menu.appendChild(btn);
+
+  document.body.appendChild(menu);
+  const closer = e => {
+    if (!menu.contains(e.target)) {
+      document.body.removeChild(menu);
+      document.removeEventListener('mousedown', closer);
+    }
+  };
+  setTimeout(() => document.addEventListener('mousedown', closer), 0);
+}
+
+async function updateLink(aId, bId, patch){
+  const a = await getItem(aId);
+  const b = await getItem(bId);
+  if (!a || !b) return;
+  const apply = (item, otherId) => {
+    item.links = item.links || [];
+    const l = item.links.find(x => x.id === otherId);
+    if (l) Object.assign(l, patch);
+  };
+  apply(a, bId);
+  apply(b, aId);
+  await upsertItem(a);
+  await upsertItem(b);
 }

--- a/js/ui/components/popup.js
+++ b/js/ui/components/popup.js
@@ -1,24 +1,74 @@
+const fieldDefs = {
+  disease: [
+    ['etiology','Etiology'],
+    ['pathophys','Pathophys'],
+    ['clinical','Clinical'],
+    ['diagnosis','Diagnosis'],
+    ['treatment','Treatment'],
+    ['complications','Complications'],
+    ['mnemonic','Mnemonic']
+  ],
+  drug: [
+    ['class','Class'],
+    ['source','Source'],
+    ['moa','MOA'],
+    ['uses','Uses'],
+    ['sideEffects','Side Effects'],
+    ['contraindications','Contraindications'],
+    ['mnemonic','Mnemonic']
+  ],
+  concept: [
+    ['type','Type'],
+    ['definition','Definition'],
+    ['mechanism','Mechanism'],
+    ['clinicalRelevance','Clinical Relevance'],
+    ['example','Example'],
+    ['mnemonic','Mnemonic']
+  ]
+};
+
 export function showPopup(item){
   const modal = document.createElement('div');
   modal.className = 'modal';
   const card = document.createElement('div');
   card.className = 'card';
+  const kindColors = { disease: 'var(--purple)', drug: 'var(--blue)', concept: 'var(--green)' };
+  card.style.borderTop = `3px solid ${item.color || kindColors[item.kind] || 'var(--gray)'}`;
+
   const title = document.createElement('h2');
   title.textContent = item.name || item.concept || 'Item';
   card.appendChild(title);
-  const kind = document.createElement('div');
-  kind.textContent = `Type: ${item.kind}`;
-  card.appendChild(kind);
-  if (item.mnemonic){
-    const m = document.createElement('div');
-    m.textContent = `Mnemonic: ${item.mnemonic}`;
-    card.appendChild(m);
+
+  const defs = fieldDefs[item.kind] || [];
+  defs.forEach(([field,label]) => {
+    const val = item[field];
+    if (!val) return;
+    const sec = document.createElement('div');
+    sec.className = 'section';
+    const tl = document.createElement('div');
+    tl.className = 'section-title';
+    tl.textContent = label;
+    sec.appendChild(tl);
+    const txt = document.createElement('div');
+    txt.textContent = val;
+    txt.style.whiteSpace = 'pre-wrap';
+    sec.appendChild(txt);
+    card.appendChild(sec);
+  });
+
+  if (item.facts && item.facts.length){
+    const facts = document.createElement('div');
+    facts.className = 'facts';
+    facts.textContent = item.facts.join(', ');
+    card.appendChild(facts);
   }
+
   const close = document.createElement('button');
   close.className = 'btn';
   close.textContent = 'Close';
   close.addEventListener('click', () => modal.remove());
   card.appendChild(close);
+
   modal.appendChild(card);
   modal.addEventListener('click', e => { if (e.target === modal) modal.remove(); });
   document.body.appendChild(modal);

--- a/style.css
+++ b/style.css
@@ -587,17 +587,37 @@ button:hover {
 .map-svg {
   width: 100%;
   height: 600px;
+  cursor: grab;
 }
 .map-node {
-  fill: var(--blue);
   cursor: pointer;
 }
 .map-edge {
   stroke: var(--gray);
-  stroke-width: 1;
+  stroke-width: 2;
+  cursor: pointer;
 }
 .map-label {
   fill: var(--text);
   font-size: 10px;
   text-anchor: middle;
+}
+
+.line-menu {
+  position: absolute;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  padding: 8px;
+  border-radius: var(--radius);
+  color: var(--text);
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.line-menu label {
+  display: flex;
+  flex-direction: column;
+  font-size: 12px;
+  gap: 2px;
 }


### PR DESCRIPTION
## Summary
- make map canvas pannable and color nodes by type or custom color
- allow editing edge color, style, and label with tooltip support
- show full card details when clicking a node

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4649e83a08322b894d15325c78056