### PR TITLE
Emphasize highly connected concepts in map view

### DIFF
--- a/js/ui/components/map.js
+++ b/js/ui/components/map.js
@@ -57,7 +57,8 @@ export async function renderMap(root){
       nodeDrag.circle.setAttribute('cx', x);
       nodeDrag.circle.setAttribute('cy', y);
       nodeDrag.label.setAttribute('x', x);
-      nodeDrag.label.setAttribute('y', y - 28 * scale);
+      const baseR = Number(nodeDrag.circle.dataset.radius) || 20;
+      nodeDrag.label.setAttribute('y', y - (baseR + 8) * scale);
       updateEdges(nodeDrag.id);
       nodeWasDragged = true;
       return;
@@ -103,6 +104,10 @@ export async function renderMap(root){
 
   const positions = {};
   const itemMap = Object.fromEntries(items.map(it => [it.id, it]));
+  const linkCounts = Object.fromEntries(items.map(it => [it.id, (it.links || []).length]));
+  const maxLinks = Math.max(1, ...Object.values(linkCounts));
+  const minRadius = 20;
+  const maxRadius = 40;
 
   const center = size/2;
   const newItems = [];
@@ -110,11 +115,14 @@ export async function renderMap(root){
     if (it.mapPos) positions[it.id] = { ...it.mapPos };
     else newItems.push(it);
   });
+  newItems.sort((a,b) => linkCounts[b.id] - linkCounts[a.id]);
   const step = (2*Math.PI) / Math.max(newItems.length,1);
   newItems.forEach((it, idx) => {
     const angle = idx * step;
-    const x = center + 100*Math.cos(angle);
-    const y = center + 100*Math.sin(angle);
+    const degree = linkCounts[it.id];
+    const dist = 100 - (degree / maxLinks) * 50;
+    const x = center + dist*Math.cos(angle);
+    const y = center + dist*Math.sin(angle);
     positions[it.id] = { x, y };
     it.mapPos = positions[it.id];
   });
@@ -201,7 +209,11 @@ export async function renderMap(root){
     const circle = document.createElementNS('http://www.w3.org/2000/svg','circle');
     circle.setAttribute('cx', pos.x);
     circle.setAttribute('cy', pos.y);
-    circle.setAttribute('r', 20);
+    // Scale radius between minRadius and maxRadius based on relative link count
+    const normalized = (linkCounts[it.id] || 0) / maxLinks;
+    const baseR = minRadius + normalized * (maxRadius - minRadius);
+    circle.setAttribute('r', baseR);
+    circle.dataset.radius = baseR;
     circle.setAttribute('class','map-node');
 
     circle.dataset.id = it.id;
@@ -223,7 +235,7 @@ export async function renderMap(root){
     g.appendChild(circle);
     text = document.createElementNS('http://www.w3.org/2000/svg','text');
     text.setAttribute('x', pos.x);
-    text.setAttribute('y', pos.y - 28);
+    text.setAttribute('y', pos.y - (baseR + 8));
     text.setAttribute('class','map-label');
     text.dataset.id = it.id;
     text.textContent = it.name || it.concept || '?';
@@ -240,13 +252,18 @@ function adjustScale(){
   const vb = svg.getAttribute('viewBox').split(' ').map(Number);
   const unit = vb[2] / svg.clientWidth; // units per pixel
   const scale = Math.pow(unit, 0.8);
-  const offset = 28 * scale;
-  document.querySelectorAll('.map-node').forEach(c => c.setAttribute('r', 20 * scale));
+  document.querySelectorAll('.map-node').forEach(c => {
+    const baseR = Number(c.dataset.radius) || 20;
+    c.setAttribute('r', baseR * scale);
+  });
   document.querySelectorAll('.map-label').forEach(t => {
     t.setAttribute('font-size', 12 * scale);
     const id = t.dataset.id;
     const c = document.querySelector(`circle[data-id='${id}']`);
-    if (c) t.setAttribute('y', Number(c.getAttribute('cy')) - offset);
+    if (c) {
+      const baseR = Number(c.dataset.radius) || 20;
+      t.setAttribute('y', Number(c.getAttribute('cy')) - (baseR + 8) * scale);
+    }
   });
   document.querySelectorAll('.map-edge').forEach(l => l.setAttribute('stroke-width', 4 * Math.pow(unit, -0.2)));
 


### PR DESCRIPTION
## Summary
- Scale map node radius by number of links so highly connected concepts stand out
- Position new nodes closer to center based on connection count for cluster gravity
- Adjust label and node scaling to respect per-node sizes
- Normalize node size using map-wide min/max link counts for subtle yet visible differences

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c47faadaa88322a1e10d0d4d7220f0