### PR TITLE
feat: enhance block tagging and settings

### DIFF
--- a/js/storage/storage.js
+++ b/js/storage/storage.js
@@ -40,7 +40,12 @@ export async function saveSettings(patch) {
 export async function listBlocks() {
   try {
     const b = await store('blocks');
-    return await prom(b.getAll());
+    const all = await prom(b.getAll());
+    return all.sort((a,b)=>{
+      const ao = a.order ?? a.createdAt;
+      const bo = b.order ?? b.createdAt;
+      return bo - ao;
+    });
   } catch (err) {
     console.warn('listBlocks failed', err);
     return [];
@@ -54,6 +59,8 @@ export async function upsertBlock(def) {
   const next = {
     ...def,
     lectures: def.lectures || [],
+    color: def.color || existing?.color || null,
+    order: def.order || existing?.order || now,
     createdAt: existing?.createdAt || now,
     updatedAt: now
   };

--- a/js/types.js
+++ b/js/types.js
@@ -41,6 +41,7 @@
 /** @typedef {Disease|Drug|Concept} Item */
 
 /** @typedef {{ blockId:string, title:string, weeks:number,
+ *              color?:string, order:number,
  *              lectures:{id:number, name:string, week:number}[],
  *              createdAt:number, updatedAt:number }} BlockDef */
 

--- a/js/ui/components/table.js
+++ b/js/ui/components/table.js
@@ -37,25 +37,27 @@ const columnMap = {
 export async function renderTable(container, items, kind, onChange) {
   const blocks = await listBlocks();
   const blockTitle = (id) => blocks.find(b => b.blockId === id)?.title || id;
+  const orderMap = new Map(blocks.map((b,i)=>[b.blockId,i]));
   const groups = new Map(); // block -> week -> items
   items.forEach(it => {
-    const bs = it.blocks && it.blocks.length ? it.blocks : ['_'];
-    const ws = it.weeks && it.weeks.length ? it.weeks : ['_'];
-    bs.forEach(b => {
-      if (!groups.has(b)) groups.set(b, new Map());
-      const wkMap = groups.get(b);
-      ws.forEach(w => {
-        const arr = wkMap.get(w) || [];
-        arr.push(it);
-        wkMap.set(w, arr);
-      });
+    let block = '_';
+    let best = Infinity;
+    (it.blocks || []).forEach(id => {
+      const ord = orderMap.has(id) ? orderMap.get(id) : Infinity;
+      if (ord < best) { block = id; best = ord; }
     });
+    const week = it.weeks && it.weeks.length ? Math.max(...it.weeks) : '_';
+    if (!groups.has(block)) groups.set(block, new Map());
+    const wkMap = groups.get(block);
+    const arr = wkMap.get(week) || [];
+    arr.push(it);
+    wkMap.set(week, arr);
   });
 
   const sortedBlocks = Array.from(groups.keys()).sort((a, b) => {
-    if (a === '_' && b !== '_') return 1;
-    if (b === '_' && a !== '_') return -1;
-    return a.localeCompare(b);
+    const ao = orderMap.has(a) ? orderMap.get(a) : Infinity;
+    const bo = orderMap.has(b) ? orderMap.get(b) : Infinity;
+    return ao - bo;
   });
 
   sortedBlocks.forEach(b => {
@@ -63,6 +65,8 @@ export async function renderTable(container, items, kind, onChange) {
     blockSec.className = 'block-section';
     const h2 = document.createElement('h2');
     h2.textContent = b === '_' ? 'Unassigned' : `${blockTitle(b)} (${b})`;
+    const bdef = blocks.find(bl => bl.blockId === b);
+    if (bdef?.color) h2.style.background = bdef.color;
     blockSec.appendChild(h2);
 
     const wkMap = groups.get(b);


### PR DESCRIPTION
## Summary
- allow blocks to be ordered and colored in settings
- show latest block/week per entry and color headers
- streamline tagging editor with block→week→lecture selection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c48d4f07a883229162c1526fdb84b0