### PR TITLE
Persist map node positions and fix drag detachment

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -237,6 +237,7 @@ var Sevenn = (() => {
       blocks: item.blocks || [],
       weeks: item.weeks || [],
       lectures: item.lectures || [],
+      mapPos: item.mapPos || null,
       sr: item.sr || { box: 0, last: 0, due: 0, ease: 2.5 }
     };
   }
@@ -2194,12 +2195,13 @@ var Sevenn = (() => {
         const nodeScale = Math.pow(unit, 0.8);
         const x = viewBox.x + (e.clientX - rect.left) / svg.clientWidth * viewBox.w - nodeDrag.offset.x;
         const y = viewBox.y + (e.clientY - rect.top) / svg.clientHeight * viewBox.h - nodeDrag.offset.y;
-        positions[nodeDrag.id] = { x, y };
+        nodeDrag.pos.x = x;
+        nodeDrag.pos.y = y;
         nodeDrag.circle.setAttribute("cx", x);
         nodeDrag.circle.setAttribute("cy", y);
         nodeDrag.label.setAttribute("x", x);
         const baseR = Number(nodeDrag.circle.dataset.radius) || 20;
-        nodeDrag.label.setAttribute("y", y - (baseR + 8) * scale);
+        nodeDrag.label.setAttribute("y", y - (baseR + 8) * nodeScale);
         updateEdges(nodeDrag.id);
         nodeWasDragged = true;
         return;
@@ -2214,7 +2216,7 @@ var Sevenn = (() => {
     window.addEventListener("mouseup", async () => {
       if (nodeDrag) {
         const it = itemMap[nodeDrag.id];
-        it.mapPos = positions[nodeDrag.id];
+        it.mapPos = { ...nodeDrag.pos };
         await upsertItem(it);
         nodeDrag = null;
       }
@@ -2355,7 +2357,7 @@ var Sevenn = (() => {
         const rect = svg.getBoundingClientRect();
         const mouseX = viewBox.x + (e.clientX - rect.left) / svg.clientWidth * viewBox.w;
         const mouseY = viewBox.y + (e.clientY - rect.top) / svg.clientHeight * viewBox.h;
-        nodeDrag = { id: it.id, circle, label: text, offset: { x: mouseX - pos.x, y: mouseY - pos.y } };
+        nodeDrag = { id: it.id, circle, label: text, pos, offset: { x: mouseX - pos.x, y: mouseY - pos.y } };
         nodeWasDragged = false;
         svg.style.cursor = "grabbing";
       });

--- a/js/ui/components/map.js
+++ b/js/ui/components/map.js
@@ -53,13 +53,14 @@ export async function renderMap(root){
       const x = viewBox.x + ((e.clientX - rect.left) / svg.clientWidth) * viewBox.w - nodeDrag.offset.x;
       const y = viewBox.y + ((e.clientY - rect.top) / svg.clientHeight) * viewBox.h - nodeDrag.offset.y;
 
-      positions[nodeDrag.id] = { x, y };
+      nodeDrag.pos.x = x;
+      nodeDrag.pos.y = y;
       nodeDrag.circle.setAttribute('cx', x);
       nodeDrag.circle.setAttribute('cy', y);
       nodeDrag.label.setAttribute('x', x);
       const baseR = Number(nodeDrag.circle.dataset.radius) || 20;
 
-      nodeDrag.label.setAttribute('y', y - (baseR + 8) * scale);
+      nodeDrag.label.setAttribute('y', y - (baseR + 8) * nodeScale);
       updateEdges(nodeDrag.id);
       nodeWasDragged = true;
       return;
@@ -76,7 +77,7 @@ export async function renderMap(root){
   window.addEventListener('mouseup', async () => {
     if (nodeDrag) {
       const it = itemMap[nodeDrag.id];
-      it.mapPos = positions[nodeDrag.id];
+      it.mapPos = { ...nodeDrag.pos };
       await upsertItem(it);
       nodeDrag = null;
     }
@@ -229,7 +230,7 @@ export async function renderMap(root){
       const rect = svg.getBoundingClientRect();
       const mouseX = viewBox.x + ((e.clientX - rect.left) / svg.clientWidth) * viewBox.w;
       const mouseY = viewBox.y + ((e.clientY - rect.top) / svg.clientHeight) * viewBox.h;
-      nodeDrag = { id: it.id, circle, label: text, offset: { x: mouseX - pos.x, y: mouseY - pos.y } };
+      nodeDrag = { id: it.id, circle, label: text, pos, offset: { x: mouseX - pos.x, y: mouseY - pos.y } };
       nodeWasDragged = false;
       svg.style.cursor = 'grabbing';
     });

--- a/js/validators.js
+++ b/js/validators.js
@@ -9,6 +9,7 @@ export function cleanItem(item) {
     blocks: item.blocks || [],
     weeks: item.weeks || [],
     lectures: item.lectures || [],
+    mapPos: item.mapPos || null,
     sr: item.sr || { box:0, last:0, due:0, ease:2.5 }
   };
 }


### PR DESCRIPTION
## Summary
- keep node position references during drag so edges stay connected
- persist map node coordinates by allowing mapPos in item schema
- rebuild bundle

## Testing
- `npx esbuild js/main.js --bundle --format=iife --global-name=Sevenn --outfile=bundle.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4ce5d48108322888b2b476b8f8fb3