### PR TITLE
Add collapsible browse sections for blocks and weeks

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -1175,6 +1175,8 @@ var Sevenn = (() => {
     ]
   };
   var expanded = /* @__PURE__ */ new Set();
+  var collapsedBlocks = /* @__PURE__ */ new Set();
+  var collapsedWeeks = /* @__PURE__ */ new Set();
   function createItemCard(item, onChange) {
     const card = document.createElement("div");
     card.className = `item-card card--${item.kind}`;
@@ -1380,12 +1382,26 @@ var Sevenn = (() => {
     sortedBlocks.forEach((b) => {
       const blockSec = document.createElement("section");
       blockSec.className = "block-section";
-      const h2 = document.createElement("div");
-      h2.className = "block-header";
-      h2.textContent = b === "_" ? "Unassigned" : blockTitle(b);
+      const blockHeader = document.createElement("button");
+      blockHeader.type = "button";
+      blockHeader.className = "block-header";
+      const blockLabel = b === "_" ? "Unassigned" : blockTitle(b);
+      const blockKey = String(b);
       const bdef = blocks.find((bl) => bl.blockId === b);
-      if (bdef?.color) h2.style.background = bdef.color;
-      blockSec.appendChild(h2);
+      if (bdef?.color) blockHeader.style.background = bdef.color;
+      function updateBlockState() {
+        const isCollapsed = collapsedBlocks.has(blockKey);
+        blockSec.classList.toggle("collapsed", isCollapsed);
+        blockHeader.textContent = `${isCollapsed ? "\u25B8" : "\u25BE"} ${blockLabel}`;
+        blockHeader.setAttribute("aria-expanded", String(!isCollapsed));
+      }
+      updateBlockState();
+      blockHeader.addEventListener("click", () => {
+        if (collapsedBlocks.has(blockKey)) collapsedBlocks.delete(blockKey);
+        else collapsedBlocks.add(blockKey);
+        updateBlockState();
+      });
+      blockSec.appendChild(blockHeader);
       const wkMap = groups.get(b);
       const sortedWeeks = Array.from(wkMap.keys()).sort((a, b2) => {
         if (a === "_" && b2 !== "_") return 1;
@@ -1395,9 +1411,24 @@ var Sevenn = (() => {
       sortedWeeks.forEach((w) => {
         const weekSec = document.createElement("div");
         weekSec.className = "week-section";
-        const h3 = document.createElement("h3");
-        h3.textContent = w === "_" ? "Unassigned" : `Week ${w}`;
-        weekSec.appendChild(h3);
+        const weekHeader = document.createElement("button");
+        weekHeader.type = "button";
+        weekHeader.className = "week-header";
+        const weekLabel = w === "_" ? "Unassigned" : `Week ${w}`;
+        const weekKey = `${blockKey}__${w}`;
+        function updateWeekState() {
+          const isCollapsed = collapsedWeeks.has(weekKey);
+          weekSec.classList.toggle("collapsed", isCollapsed);
+          weekHeader.textContent = `${isCollapsed ? "\u25B8" : "\u25BE"} ${weekLabel}`;
+          weekHeader.setAttribute("aria-expanded", String(!isCollapsed));
+        }
+        updateWeekState();
+        weekHeader.addEventListener("click", () => {
+          if (collapsedWeeks.has(weekKey)) collapsedWeeks.delete(weekKey);
+          else collapsedWeeks.add(weekKey);
+          updateWeekState();
+        });
+        weekSec.appendChild(weekHeader);
         const list = document.createElement("div");
         list.className = "card-list";
         const rows = wkMap.get(w);

--- a/style.css
+++ b/style.css
@@ -364,11 +364,56 @@ input[type="checkbox"]:checked::after {
   font-weight: 600;
   color: #000;
   margin-bottom: var(--pad-sm);
+  border: none;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+  transition: none;
+  display: block;
+}
+
+.block-header:hover {
+  transform: none;
+  box-shadow: none;
+}
+
+.block-section.collapsed .week-section {
+  display: none;
 }
 
 .week-section h3 {
   margin: var(--pad-sm) 0;
   font-size: 1rem;
+}
+
+.week-header {
+  margin: var(--pad-sm) 0;
+  font-size: 1rem;
+  background: none;
+  border: none;
+  color: inherit;
+  padding: 4px 6px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+  width: 100%;
+  border-radius: var(--radius);
+  transition: none;
+  font-weight: 600;
+}
+
+.week-header:hover {
+  background: rgba(255, 255, 255, 0.06);
+  transform: none;
+  box-shadow: none;
+}
+
+.week-section.collapsed .card-list {
+  display: none;
 }
 
 .card-list {


### PR DESCRIPTION
## Summary
- add persistent collapse toggles for blocks and weeks in the browse card list
- style the new interactive headers and hide collapsed sections cleanly
- rebuild the bundle so the offline entry point picks up the behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c986064db8832284e48755ea1f0882