### PR TITLE
Enhance concept map tooling

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -238,6 +238,7 @@ var Sevenn = (() => {
       weeks: item.weeks || [],
       lectures: item.lectures || [],
       mapPos: item.mapPos || null,
+      mapHidden: !!item.mapHidden,
       sr: item.sr || { box: 0, last: 0, due: 0, ease: 2.5 }
     };
   }
@@ -2184,150 +2185,87 @@ var Sevenn = (() => {
   }
 
   // js/ui/components/map.js
+  var TOOL = {
+    NAVIGATE: "navigate",
+    NODES: "nodes",
+    BREAK: "break-link",
+    ADD_LINK: "add-link",
+    HIDE_LINK: "hide-link",
+    AREA: "area"
+  };
+  var DEFAULT_LINK_COLOR = "#888888";
+  var mapState = {
+    tool: TOOL.NAVIGATE,
+    selectionIds: [],
+    previewSelection: null,
+    pendingLink: null,
+    hiddenMenuTab: "nodes",
+    panelVisible: true,
+    listenersAttached: false,
+    draggingView: false,
+    nodeDrag: null,
+    areaDrag: null,
+    menuDrag: null,
+    selectionRect: null,
+    nodeWasDragged: false,
+    viewBox: null,
+    svg: null,
+    g: null,
+    positions: {},
+    itemMap: {},
+    elements: /* @__PURE__ */ new Map(),
+    root: null,
+    updateViewBox: () => {
+    },
+    selectionBox: null,
+    sizeLimit: 2e3,
+    minView: 100,
+    lastPointer: { x: 0, y: 0 }
+  };
   async function renderMap(root) {
+    mapState.root = root;
     root.innerHTML = "";
+    mapState.nodeDrag = null;
+    mapState.areaDrag = null;
+    mapState.draggingView = false;
+    mapState.menuDrag = null;
+    mapState.selectionRect = null;
+    mapState.previewSelection = null;
+    mapState.nodeWasDragged = false;
+    ensureListeners();
     const items = [
       ...await listItemsByKind("disease"),
       ...await listItemsByKind("drug"),
       ...await listItemsByKind("concept")
     ];
+    const hiddenNodes = items.filter((it) => it.mapHidden);
+    const visibleItems = items.filter((it) => !it.mapHidden);
+    const itemMap = Object.fromEntries(items.map((it) => [it.id, it]));
+    mapState.itemMap = itemMap;
     const base = 1e3;
-    const size = Math.max(base, items.length * 150);
+    const size = Math.max(base, visibleItems.length * 150);
     const viewport = base;
+    mapState.sizeLimit = size * 2;
+    mapState.minView = 100;
+    const container = document.createElement("div");
+    container.className = "map-container";
+    root.appendChild(container);
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-    const viewBox = { x: (size - viewport) / 2, y: (size - viewport) / 2, w: viewport, h: viewport };
+    svg.classList.add("map-svg");
+    const viewBox = {
+      x: (size - viewport) / 2,
+      y: (size - viewport) / 2,
+      w: viewport,
+      h: viewport
+    };
+    mapState.svg = svg;
+    mapState.viewBox = viewBox;
     const updateViewBox = () => {
       svg.setAttribute("viewBox", `${viewBox.x} ${viewBox.y} ${viewBox.w} ${viewBox.h}`);
       adjustScale();
     };
-    svg.classList.add("map-svg");
+    mapState.updateViewBox = updateViewBox;
     const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
-    svg.appendChild(g);
-    const updateEdges = (id) => {
-      g.querySelectorAll(`path[data-a='${id}'], path[data-b='${id}']`).forEach((edge) => {
-        edge.setAttribute("d", calcPath(edge.dataset.a, edge.dataset.b));
-      });
-    };
-    let dragging = false;
-    let nodeDrag = null;
-    let nodeWasDragged = false;
-    let last = { x: 0, y: 0 };
-    svg.addEventListener("mousedown", (e) => {
-      if (e.target === svg) {
-        dragging = true;
-        last = { x: e.clientX, y: e.clientY };
-        svg.style.cursor = "grabbing";
-      }
-    });
-    window.addEventListener("mousemove", async (e) => {
-      if (nodeDrag) {
-        const rect = svg.getBoundingClientRect();
-        const unit = viewBox.w / svg.clientWidth;
-        const nodeScale = Math.pow(unit, 0.8);
-        const x = viewBox.x + (e.clientX - rect.left) / svg.clientWidth * viewBox.w - nodeDrag.offset.x;
-        const y = viewBox.y + (e.clientY - rect.top) / svg.clientHeight * viewBox.h - nodeDrag.offset.y;
-        nodeDrag.pos.x = x;
-        nodeDrag.pos.y = y;
-        nodeDrag.circle.setAttribute("cx", x);
-        nodeDrag.circle.setAttribute("cy", y);
-        nodeDrag.label.setAttribute("x", x);
-        const baseR = Number(nodeDrag.circle.dataset.radius) || 20;
-        nodeDrag.label.setAttribute("y", y - (baseR + 8) * nodeScale);
-        updateEdges(nodeDrag.id);
-        nodeWasDragged = true;
-        return;
-      }
-      if (!dragging) return;
-      const scale = viewBox.w / svg.clientWidth;
-      viewBox.x -= (e.clientX - last.x) * scale;
-      viewBox.y -= (e.clientY - last.y) * scale;
-      last = { x: e.clientX, y: e.clientY };
-      updateViewBox();
-    });
-    window.addEventListener("mouseup", async () => {
-      if (nodeDrag) {
-        const it = itemMap[nodeDrag.id];
-        it.mapPos = { ...nodeDrag.pos };
-        await upsertItem(it);
-        nodeDrag = null;
-      }
-      dragging = false;
-      svg.style.cursor = "grab";
-    });
-    svg.addEventListener("wheel", (e) => {
-      e.preventDefault();
-      const factor = e.deltaY < 0 ? 0.9 : 1.1;
-      const mx = viewBox.x + e.offsetX / svg.clientWidth * viewBox.w;
-      const my = viewBox.y + e.offsetY / svg.clientHeight * viewBox.h;
-      viewBox.w = Math.min(size * 2, Math.max(100, viewBox.w * factor));
-      viewBox.h = viewBox.w;
-      viewBox.x = mx - e.offsetX / svg.clientWidth * viewBox.w;
-      viewBox.y = my - e.offsetY / svg.clientHeight * viewBox.h;
-      updateViewBox();
-    });
-    if (!window._mapResizeAttached) {
-      window.addEventListener("resize", adjustScale);
-      window._mapResizeAttached = true;
-    }
-    const positions = {};
-    const itemMap = Object.fromEntries(items.map((it) => [it.id, it]));
-    const linkCounts = Object.fromEntries(items.map((it) => [it.id, (it.links || []).length]));
-    const maxLinks = Math.max(1, ...Object.values(linkCounts));
-    const minRadius = 20;
-    const maxRadius = 60;
-    const center = size / 2;
-    const newItems = [];
-    items.forEach((it) => {
-      if (it.mapPos) positions[it.id] = { ...it.mapPos };
-      else newItems.push(it);
-    });
-    newItems.sort((a, b) => linkCounts[b.id] - linkCounts[a.id]);
-    const step = 2 * Math.PI / Math.max(newItems.length, 1);
-    newItems.forEach((it, idx) => {
-      const angle = idx * step;
-      const degree = linkCounts[it.id];
-      const dist = 100 - degree / maxLinks * 50;
-      const x = center + dist * Math.cos(angle);
-      const y = center + dist * Math.sin(angle);
-      positions[it.id] = { x, y };
-      it.mapPos = positions[it.id];
-    });
-    for (const it of newItems) await upsertItem(it);
-    function pointToSeg(px, py, x1, y1, x2, y2) {
-      const dx = x2 - x1;
-      const dy = y2 - y1;
-      const l2 = dx * dx + dy * dy;
-      if (!l2) return Math.hypot(px - x1, py - y1);
-      let t = ((px - x1) * dx + (py - y1) * dy) / l2;
-      t = Math.max(0, Math.min(1, t));
-      const projX = x1 + t * dx;
-      const projY = y1 + t * dy;
-      return Math.hypot(px - projX, py - projY);
-    }
-    function calcPath(aId, bId) {
-      const a = positions[aId];
-      const b = positions[bId];
-      const x1 = a.x, y1 = a.y;
-      const x2 = b.x, y2 = b.y;
-      let cx = (x1 + x2) / 2;
-      let cy = (y1 + y2) / 2;
-      const dx = x2 - x1;
-      const dy = y2 - y1;
-      const len = Math.hypot(dx, dy) || 1;
-      for (const id in positions) {
-        if (id === aId || id === bId) continue;
-        const p = positions[id];
-        if (pointToSeg(p.x, p.y, x1, y1, x2, y2) < 40) {
-          const nx = -dy / len;
-          const ny = dx / len;
-          const side = (p.x - x1) * nx + (p.y - y1) * ny > 0 ? 1 : -1;
-          cx += nx * 80 * side;
-          cy += ny * 80 * side;
-          break;
-        }
-      }
-      return `M${x1} ${y1} Q${cx} ${cy} ${x2} ${y2}`;
-    }
     const defs = document.createElementNS("http://www.w3.org/2000/svg", "defs");
     const marker = document.createElementNS("http://www.w3.org/2000/svg", "marker");
     marker.setAttribute("id", "arrow");
@@ -2337,36 +2275,75 @@ var Sevenn = (() => {
     marker.setAttribute("markerWidth", "6");
     marker.setAttribute("markerHeight", "6");
     marker.setAttribute("orient", "auto");
-    const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
-    path.setAttribute("d", "M0,0 L10,5 L0,10 Z");
-    path.setAttribute("fill", "inherit");
-    marker.appendChild(path);
+    const arrowPath = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    arrowPath.setAttribute("d", "M0,0 L10,5 L0,10 Z");
+    arrowPath.setAttribute("fill", "inherit");
+    marker.appendChild(arrowPath);
     defs.appendChild(marker);
     svg.appendChild(defs);
+    svg.appendChild(g);
+    mapState.g = g;
+    container.appendChild(svg);
+    const selectionBox = document.createElement("div");
+    selectionBox.className = "map-selection hidden";
+    container.appendChild(selectionBox);
+    mapState.selectionBox = selectionBox;
+    attachSvgEvents(svg);
+    const positions = {};
+    mapState.positions = positions;
+    mapState.elements = /* @__PURE__ */ new Map();
+    const linkCounts = Object.fromEntries(items.map((it) => [it.id, (it.links || []).length]));
+    const maxLinks = Math.max(1, ...Object.values(linkCounts));
+    const minRadius = 20;
+    const maxRadius = 60;
+    const center = size / 2;
+    const newItems = [];
+    visibleItems.forEach((it) => {
+      if (it.mapPos) positions[it.id] = { ...it.mapPos };
+      else newItems.push(it);
+    });
+    newItems.sort((a, b) => (linkCounts[b.id] || 0) - (linkCounts[a.id] || 0));
+    const step = 2 * Math.PI / Math.max(newItems.length, 1);
+    newItems.forEach((it, idx) => {
+      const angle = idx * step;
+      const degree = linkCounts[it.id] || 0;
+      const dist = 100 - degree / maxLinks * 50;
+      const x = center + dist * Math.cos(angle);
+      const y = center + dist * Math.sin(angle);
+      positions[it.id] = { x, y };
+      it.mapPos = positions[it.id];
+    });
+    for (const it of newItems) await upsertItem(it);
+    mapState.selectionIds = mapState.selectionIds.filter((id) => positions[id]);
+    const hiddenLinks = gatherHiddenLinks(items, itemMap);
+    buildToolbox(container, hiddenNodes.length, hiddenLinks.length);
+    buildHiddenPanel(container, hiddenNodes, hiddenLinks);
     const drawn = /* @__PURE__ */ new Set();
-    items.forEach((it) => {
+    visibleItems.forEach((it) => {
       (it.links || []).forEach((l) => {
+        if (l.hidden) return;
         if (!positions[l.id]) return;
-        const key = it.id < l.id ? it.id + "|" + l.id : l.id + "|" + it.id;
+        const key = it.id < l.id ? `${it.id}|${l.id}` : `${l.id}|${it.id}`;
         if (drawn.has(key)) return;
         drawn.add(key);
-        const path2 = document.createElementNS("http://www.w3.org/2000/svg", "path");
-        path2.setAttribute("d", calcPath(it.id, l.id));
-        path2.setAttribute("fill", "none");
-        path2.setAttribute("class", "map-edge");
-        path2.setAttribute("vector-effect", "non-scaling-stroke");
-        applyLineStyle(path2, l);
-        path2.dataset.a = it.id;
-        path2.dataset.b = l.id;
-        path2.addEventListener("click", (e) => {
+        const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+        path.setAttribute("d", calcPath(it.id, l.id));
+        path.setAttribute("fill", "none");
+        path.setAttribute("class", "map-edge");
+        path.setAttribute("vector-effect", "non-scaling-stroke");
+        applyLineStyle(path, l);
+        path.dataset.a = it.id;
+        path.dataset.b = l.id;
+        path.addEventListener("click", (e) => {
           e.stopPropagation();
-          openLineMenu(e, path2, it.id, l.id);
+          handleEdgeClick(path, it.id, l.id, e);
         });
-        g.appendChild(path2);
+        g.appendChild(path);
       });
     });
-    items.forEach((it) => {
+    visibleItems.forEach((it) => {
       const pos = positions[it.id];
+      if (!pos) return;
       const circle = document.createElementNS("http://www.w3.org/2000/svg", "circle");
       circle.setAttribute("cx", pos.x);
       circle.setAttribute("cy", pos.y);
@@ -2378,53 +2355,579 @@ var Sevenn = (() => {
       const kindColors2 = { disease: "var(--purple)", drug: "var(--blue)" };
       const fill = kindColors2[it.kind] || it.color || "var(--gray)";
       circle.setAttribute("fill", fill);
-      let text;
-      circle.addEventListener("click", () => {
-        if (!nodeWasDragged) showPopup(it);
-        nodeWasDragged = false;
-      });
       circle.addEventListener("mousedown", (e) => {
         e.stopPropagation();
-        const rect = svg.getBoundingClientRect();
-        const mouseX = viewBox.x + (e.clientX - rect.left) / svg.clientWidth * viewBox.w;
-        const mouseY = viewBox.y + (e.clientY - rect.top) / svg.clientHeight * viewBox.h;
-        nodeDrag = { id: it.id, circle, label: text, pos, offset: { x: mouseX - pos.x, y: mouseY - pos.y } };
-        nodeWasDragged = false;
-        svg.style.cursor = "grabbing";
+        if (mapState.tool === TOOL.NAVIGATE) {
+          const { x, y } = clientToMap(e.clientX, e.clientY);
+          mapState.nodeDrag = {
+            id: it.id,
+            offset: { x: x - pos.x, y: y - pos.y }
+          };
+          mapState.nodeWasDragged = false;
+          mapState.svg.style.cursor = "grabbing";
+        } else if (mapState.tool === TOOL.AREA && mapState.selectionIds.includes(it.id)) {
+          const { x, y } = clientToMap(e.clientX, e.clientY);
+          mapState.areaDrag = {
+            ids: [...mapState.selectionIds],
+            start: { x, y },
+            origin: mapState.selectionIds.map((id) => ({ id, pos: { ...mapState.positions[id] } })),
+            moved: false
+          };
+          mapState.svg.style.cursor = "grabbing";
+        }
+      });
+      circle.addEventListener("click", async (e) => {
+        e.stopPropagation();
+        if (mapState.tool === TOOL.NAVIGATE) {
+          if (!mapState.nodeWasDragged) showPopup(it);
+          mapState.nodeWasDragged = false;
+        } else if (mapState.tool === TOOL.NODES) {
+          if (confirm(`Remove ${titleOf3(it)} from the map?`)) {
+            await setNodeHidden(it.id, true);
+            await renderMap(root);
+          }
+        } else if (mapState.tool === TOOL.ADD_LINK) {
+          await handleAddLinkClick(it.id);
+        }
       });
       g.appendChild(circle);
-      text = document.createElementNS("http://www.w3.org/2000/svg", "text");
+      const text = document.createElementNS("http://www.w3.org/2000/svg", "text");
       text.setAttribute("x", pos.x);
       text.setAttribute("y", pos.y - (baseR + 8));
       text.setAttribute("class", "map-label");
       text.dataset.id = it.id;
       text.textContent = it.name || it.concept || "?";
       g.appendChild(text);
+      mapState.elements.set(it.id, { circle, label: text });
     });
-    root.appendChild(svg);
+    updateSelectionHighlight();
+    updatePendingHighlight();
     updateViewBox();
+    svg.style.cursor = "grab";
   }
-  function adjustScale() {
-    const svg = document.querySelector(".map-svg");
-    if (!svg) return;
-    const vb = svg.getAttribute("viewBox").split(" ").map(Number);
-    const unit = vb[2] / svg.clientWidth;
-    const nodeScale = Math.pow(unit, 0.8);
-    const labelScale = Math.pow(unit, 1.1);
-    document.querySelectorAll(".map-node").forEach((c) => {
-      const baseR = Number(c.dataset.radius) || 20;
-      c.setAttribute("r", baseR * nodeScale);
-    });
-    document.querySelectorAll(".map-label").forEach((t) => {
-      t.setAttribute("font-size", 12 * labelScale);
-      const id = t.dataset.id;
-      const c = document.querySelector(`circle[data-id='${id}']`);
-      if (c) {
-        const baseR = Number(c.dataset.radius) || 20;
-        t.setAttribute("y", Number(c.getAttribute("cy")) - (baseR + 8) * nodeScale);
+  function ensureListeners() {
+    if (mapState.listenersAttached || typeof window === "undefined") return;
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseup", handleMouseUp);
+    mapState.listenersAttached = true;
+    if (!window._mapResizeAttached) {
+      window.addEventListener("resize", adjustScale);
+      window._mapResizeAttached = true;
+    }
+  }
+  function attachSvgEvents(svg) {
+    svg.addEventListener("mousedown", (e) => {
+      if (e.target !== svg) return;
+      if (mapState.tool === TOOL.NAVIGATE) {
+        mapState.draggingView = true;
+        mapState.lastPointer = { x: e.clientX, y: e.clientY };
+        svg.style.cursor = "grabbing";
+      } else if (mapState.tool === TOOL.AREA) {
+        mapState.selectionRect = {
+          start: { x: e.clientX, y: e.clientY },
+          current: { x: e.clientX, y: e.clientY }
+        };
+        mapState.selectionBox.classList.remove("hidden");
       }
     });
-    document.querySelectorAll(".map-edge").forEach((l) => l.setAttribute("stroke-width", 4 * Math.pow(unit, -0.2)));
+    svg.addEventListener("wheel", (e) => {
+      e.preventDefault();
+      const factor = e.deltaY < 0 ? 0.9 : 1.1;
+      const rect = svg.getBoundingClientRect();
+      const mx = mapState.viewBox.x + (e.clientX - rect.left) / rect.width * mapState.viewBox.w;
+      const my = mapState.viewBox.y + (e.clientY - rect.top) / rect.height * mapState.viewBox.h;
+      const maxSize = mapState.sizeLimit || 2e3;
+      const minSize = mapState.minView || 100;
+      const nextW = Math.max(minSize, Math.min(maxSize, mapState.viewBox.w * factor));
+      mapState.viewBox.w = nextW;
+      mapState.viewBox.h = nextW;
+      mapState.viewBox.x = mx - (e.clientX - rect.left) / rect.width * mapState.viewBox.w;
+      mapState.viewBox.y = my - (e.clientY - rect.top) / rect.height * mapState.viewBox.h;
+      mapState.updateViewBox();
+    }, { passive: false });
+  }
+  function handleMouseMove(e) {
+    if (!mapState.svg) return;
+    if (mapState.menuDrag) {
+      updateMenuDragPosition(e.clientX, e.clientY);
+      return;
+    }
+    if (mapState.nodeDrag) {
+      const { circle, label } = mapState.elements.get(mapState.nodeDrag.id) || {};
+      if (!circle) return;
+      const { x, y } = clientToMap(e.clientX, e.clientY);
+      const nx = x - mapState.nodeDrag.offset.x;
+      const ny = y - mapState.nodeDrag.offset.y;
+      mapState.positions[mapState.nodeDrag.id] = { x: nx, y: ny };
+      circle.setAttribute("cx", nx);
+      circle.setAttribute("cy", ny);
+      if (label) {
+        label.setAttribute("x", nx);
+        const baseR = Number(circle.dataset.radius) || 20;
+        label.setAttribute("y", ny - (baseR + 8));
+      }
+      updateEdgesFor(mapState.nodeDrag.id);
+      mapState.nodeWasDragged = true;
+      return;
+    }
+    if (mapState.areaDrag) {
+      const { x, y } = clientToMap(e.clientX, e.clientY);
+      const dx = x - mapState.areaDrag.start.x;
+      const dy = y - mapState.areaDrag.start.y;
+      mapState.areaDrag.moved = Math.abs(dx) > 0.5 || Math.abs(dy) > 0.5;
+      mapState.areaDrag.origin.forEach(({ id, pos }) => {
+        const nx = pos.x + dx;
+        const ny = pos.y + dy;
+        mapState.positions[id] = { x: nx, y: ny };
+        const entry = mapState.elements.get(id);
+        if (entry) {
+          entry.circle.setAttribute("cx", nx);
+          entry.circle.setAttribute("cy", ny);
+          entry.label.setAttribute("x", nx);
+          const baseR = Number(entry.circle.dataset.radius) || 20;
+          entry.label.setAttribute("y", ny - (baseR + 8));
+        }
+        updateEdgesFor(id);
+      });
+      mapState.nodeWasDragged = true;
+      return;
+    }
+    if (mapState.draggingView) {
+      const scale = mapState.viewBox.w / mapState.svg.clientWidth;
+      mapState.viewBox.x -= (e.clientX - mapState.lastPointer.x) * scale;
+      mapState.viewBox.y -= (e.clientY - mapState.lastPointer.y) * scale;
+      mapState.lastPointer = { x: e.clientX, y: e.clientY };
+      mapState.updateViewBox();
+      return;
+    }
+    if (mapState.selectionRect) {
+      mapState.selectionRect.current = { x: e.clientX, y: e.clientY };
+      updateSelectionBox();
+    }
+  }
+  async function handleMouseUp(e) {
+    if (!mapState.svg) return;
+    if (mapState.menuDrag) {
+      await finishMenuDrag(e.clientX, e.clientY);
+      return;
+    }
+    if (mapState.nodeDrag) {
+      const id = mapState.nodeDrag.id;
+      mapState.nodeDrag = null;
+      mapState.svg.style.cursor = "grab";
+      if (mapState.nodeWasDragged) {
+        await persistNodePosition(id);
+      }
+      mapState.nodeWasDragged = false;
+    }
+    if (mapState.areaDrag) {
+      const moved = mapState.areaDrag.moved;
+      const ids = mapState.areaDrag.ids;
+      mapState.areaDrag = null;
+      mapState.svg.style.cursor = "grab";
+      if (moved) {
+        await Promise.all(ids.map((id) => persistNodePosition(id)));
+      }
+      mapState.nodeWasDragged = false;
+    }
+    if (mapState.draggingView) {
+      mapState.draggingView = false;
+      mapState.svg.style.cursor = "grab";
+    }
+    if (mapState.selectionRect) {
+      const selected = computeSelectionFromRect();
+      mapState.selectionIds = selected;
+      mapState.previewSelection = null;
+      mapState.selectionRect = null;
+      mapState.selectionBox.classList.add("hidden");
+      updateSelectionHighlight();
+    }
+  }
+  function clientToMap(clientX, clientY) {
+    if (!mapState.svg) return { x: 0, y: 0 };
+    const rect = mapState.svg.getBoundingClientRect();
+    const x = mapState.viewBox.x + (clientX - rect.left) / rect.width * mapState.viewBox.w;
+    const y = mapState.viewBox.y + (clientY - rect.top) / rect.height * mapState.viewBox.h;
+    return { x, y };
+  }
+  function updateSelectionBox() {
+    if (!mapState.selectionRect || !mapState.selectionBox || !mapState.svg) return;
+    const { start, current } = mapState.selectionRect;
+    const rect = mapState.svg.getBoundingClientRect();
+    const left = Math.min(start.x, current.x) - rect.left;
+    const top = Math.min(start.y, current.y) - rect.top;
+    const width = Math.abs(start.x - current.x);
+    const height = Math.abs(start.y - current.y);
+    mapState.selectionBox.style.left = `${left}px`;
+    mapState.selectionBox.style.top = `${top}px`;
+    mapState.selectionBox.style.width = `${width}px`;
+    mapState.selectionBox.style.height = `${height}px`;
+    const from = clientToMap(start.x, start.y);
+    const to = clientToMap(current.x, current.y);
+    const minX = Math.min(from.x, to.x);
+    const maxX = Math.max(from.x, to.x);
+    const minY = Math.min(from.y, to.y);
+    const maxY = Math.max(from.y, to.y);
+    const preview = [];
+    Object.entries(mapState.positions).forEach(([id, pos]) => {
+      if (pos.x >= minX && pos.x <= maxX && pos.y >= minY && pos.y <= maxY) {
+        preview.push(id);
+      }
+    });
+    mapState.previewSelection = preview;
+    updateSelectionHighlight();
+  }
+  function computeSelectionFromRect() {
+    if (mapState.previewSelection) return mapState.previewSelection.slice();
+    return mapState.selectionIds.slice();
+  }
+  function updateSelectionHighlight() {
+    const ids = mapState.previewSelection || mapState.selectionIds;
+    const set = new Set(ids);
+    mapState.elements.forEach(({ circle, label }, id) => {
+      if (set.has(id)) {
+        circle.classList.add("selected");
+        label.classList.add("selected");
+      } else {
+        circle.classList.remove("selected");
+        label.classList.remove("selected");
+      }
+    });
+  }
+  function updatePendingHighlight() {
+    mapState.elements.forEach(({ circle, label }, id) => {
+      if (mapState.pendingLink === id) {
+        circle.classList.add("pending");
+        label.classList.add("pending");
+      } else {
+        circle.classList.remove("pending");
+        label.classList.remove("pending");
+      }
+    });
+  }
+  function updateEdgesFor(id) {
+    if (!mapState.g) return;
+    mapState.g.querySelectorAll(`path[data-a='${id}'], path[data-b='${id}']`).forEach((edge) => {
+      edge.setAttribute("d", calcPath(edge.dataset.a, edge.dataset.b));
+    });
+  }
+  function buildToolbox(container, hiddenNodeCount, hiddenLinkCount) {
+    const tools = [
+      { id: TOOL.NAVIGATE, icon: "\u{1F9ED}", label: "Navigate" },
+      { id: TOOL.NODES, icon: "\u{1F9E9}", label: "Nodes" },
+      { id: TOOL.BREAK, icon: "\u2702\uFE0F", label: "Break link" },
+      { id: TOOL.ADD_LINK, icon: "\u2795", label: "Add link" },
+      { id: TOOL.HIDE_LINK, icon: "\u{1F648}", label: "Hide link" },
+      { id: TOOL.AREA, icon: "\u{1F4E6}", label: "Select area" }
+    ];
+    const box = document.createElement("div");
+    box.className = "map-toolbox";
+    tools.forEach((tool) => {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "map-tool" + (mapState.tool === tool.id ? " active" : "");
+      btn.textContent = tool.icon;
+      btn.title = tool.label;
+      btn.addEventListener("click", () => {
+        if (mapState.tool !== tool.id) {
+          mapState.tool = tool.id;
+          if (tool.id === TOOL.NODES) mapState.hiddenMenuTab = "nodes";
+          if (tool.id === TOOL.HIDE_LINK) mapState.hiddenMenuTab = "links";
+          if (tool.id !== TOOL.AREA) {
+            mapState.selectionIds = [];
+            mapState.previewSelection = null;
+          }
+          if (tool.id !== TOOL.ADD_LINK) {
+            mapState.pendingLink = null;
+          }
+          if (tool.id === TOOL.NODES || tool.id === TOOL.HIDE_LINK) {
+            mapState.panelVisible = true;
+          }
+          renderMap(mapState.root);
+        }
+      });
+      box.appendChild(btn);
+    });
+    const status = document.createElement("div");
+    status.className = "map-tool-status";
+    status.innerHTML = `Hidden nodes: <strong>${hiddenNodeCount}</strong><br/>Hidden links: <strong>${hiddenLinkCount}</strong>`;
+    box.appendChild(status);
+    container.appendChild(box);
+  }
+  function buildHiddenPanel(container, hiddenNodes, hiddenLinks) {
+    const allowPanel = mapState.tool === TOOL.NODES || mapState.tool === TOOL.HIDE_LINK;
+    const panel = document.createElement("div");
+    panel.className = "map-hidden-panel";
+    if (!(allowPanel && mapState.panelVisible)) {
+      panel.classList.add("hidden");
+    }
+    const header = document.createElement("div");
+    header.className = "map-hidden-header";
+    const tabs2 = document.createElement("div");
+    tabs2.className = "map-hidden-tabs";
+    const nodeTab = document.createElement("button");
+    nodeTab.type = "button";
+    nodeTab.textContent = `Nodes (${hiddenNodes.length})`;
+    nodeTab.className = mapState.hiddenMenuTab === "nodes" ? "active" : "";
+    nodeTab.addEventListener("click", () => {
+      mapState.hiddenMenuTab = "nodes";
+      renderMap(mapState.root);
+    });
+    tabs2.appendChild(nodeTab);
+    const linkTab = document.createElement("button");
+    linkTab.type = "button";
+    linkTab.textContent = `Links (${hiddenLinks.length})`;
+    linkTab.className = mapState.hiddenMenuTab === "links" ? "active" : "";
+    linkTab.addEventListener("click", () => {
+      mapState.hiddenMenuTab = "links";
+      renderMap(mapState.root);
+    });
+    tabs2.appendChild(linkTab);
+    header.appendChild(tabs2);
+    const closeBtn = document.createElement("button");
+    closeBtn.type = "button";
+    closeBtn.className = "map-hidden-close";
+    closeBtn.textContent = mapState.panelVisible ? "Hide" : "Show";
+    closeBtn.addEventListener("click", () => {
+      mapState.panelVisible = !mapState.panelVisible;
+      renderMap(mapState.root);
+    });
+    header.appendChild(closeBtn);
+    panel.appendChild(header);
+    const body = document.createElement("div");
+    body.className = "map-hidden-body";
+    if (mapState.hiddenMenuTab === "nodes") {
+      const list = document.createElement("div");
+      list.className = "map-hidden-list";
+      if (hiddenNodes.length === 0) {
+        const empty = document.createElement("div");
+        empty.className = "map-hidden-empty";
+        empty.textContent = "No hidden nodes.";
+        list.appendChild(empty);
+      } else {
+        hiddenNodes.slice().sort((a, b) => titleOf3(a).localeCompare(titleOf3(b))).forEach((it) => {
+          const item = document.createElement("div");
+          item.className = "map-hidden-item";
+          item.classList.add("draggable");
+          item.textContent = titleOf3(it) || it.id;
+          item.addEventListener("mousedown", (e) => {
+            if (mapState.tool !== TOOL.NODES) return;
+            startMenuDrag(it, e);
+          });
+          list.appendChild(item);
+        });
+      }
+      body.appendChild(list);
+    } else {
+      const list = document.createElement("div");
+      list.className = "map-hidden-list";
+      if (hiddenLinks.length === 0) {
+        const empty = document.createElement("div");
+        empty.className = "map-hidden-empty";
+        empty.textContent = "No hidden links.";
+        list.appendChild(empty);
+      } else {
+        hiddenLinks.forEach((link) => {
+          const item = document.createElement("div");
+          item.className = "map-hidden-item";
+          const label = document.createElement("span");
+          label.textContent = `${titleOf3(link.a)} \u2194 ${titleOf3(link.b)}`;
+          item.appendChild(label);
+          const btn = document.createElement("button");
+          btn.type = "button";
+          btn.textContent = "Unhide";
+          btn.addEventListener("click", async () => {
+            await setLinkHidden(link.a.id, link.b.id, false);
+            await renderMap(mapState.root);
+          });
+          item.appendChild(btn);
+          list.appendChild(item);
+        });
+      }
+      body.appendChild(list);
+    }
+    panel.appendChild(body);
+    container.appendChild(panel);
+    if (allowPanel && !mapState.panelVisible) {
+      const toggle = document.createElement("button");
+      toggle.type = "button";
+      toggle.className = "map-hidden-toggle";
+      toggle.textContent = "Show menu";
+      toggle.addEventListener("click", () => {
+        mapState.panelVisible = true;
+        renderMap(mapState.root);
+      });
+      container.appendChild(toggle);
+    }
+  }
+  function startMenuDrag(item, event) {
+    event.preventDefault();
+    const ghost = document.createElement("div");
+    ghost.className = "map-drag-ghost";
+    ghost.textContent = titleOf3(item) || item.id;
+    document.body.appendChild(ghost);
+    mapState.menuDrag = { id: item.id, ghost };
+    updateMenuDragPosition(event.clientX, event.clientY);
+  }
+  async function finishMenuDrag(clientX, clientY) {
+    const drag = mapState.menuDrag;
+    mapState.menuDrag = null;
+    if (drag?.ghost) drag.ghost.remove();
+    if (!drag || !mapState.svg) return;
+    const rect = mapState.svg.getBoundingClientRect();
+    if (clientX < rect.left || clientX > rect.right || clientY < rect.top || clientY > rect.bottom) {
+      return;
+    }
+    const { x, y } = clientToMap(clientX, clientY);
+    const item = await getItem(drag.id);
+    if (!item) return;
+    item.mapHidden = false;
+    item.mapPos = { x, y };
+    await upsertItem(item);
+    await renderMap(mapState.root);
+  }
+  function updateMenuDragPosition(clientX, clientY) {
+    if (!mapState.menuDrag?.ghost) return;
+    mapState.menuDrag.ghost.style.left = `${clientX + 12}px`;
+    mapState.menuDrag.ghost.style.top = `${clientY + 12}px`;
+  }
+  async function persistNodePosition(id) {
+    const item = mapState.itemMap[id];
+    if (!item) return;
+    const next = { ...item, mapPos: { ...mapState.positions[id] } };
+    mapState.itemMap[id] = next;
+    await upsertItem(next);
+  }
+  function gatherHiddenLinks(items, itemMap) {
+    const hidden = [];
+    const seen = /* @__PURE__ */ new Set();
+    items.forEach((it) => {
+      (it.links || []).forEach((link) => {
+        if (!link.hidden) return;
+        const other = itemMap[link.id];
+        if (!other) return;
+        const key = it.id < link.id ? `${it.id}|${link.id}` : `${link.id}|${it.id}`;
+        if (seen.has(key)) return;
+        seen.add(key);
+        hidden.push({ a: it, b: other });
+      });
+    });
+    return hidden;
+  }
+  async function handleAddLinkClick(nodeId) {
+    if (!mapState.pendingLink) {
+      mapState.pendingLink = nodeId;
+      updatePendingHighlight();
+      return;
+    }
+    if (mapState.pendingLink === nodeId) {
+      mapState.pendingLink = null;
+      updatePendingHighlight();
+      return;
+    }
+    const from = mapState.itemMap[mapState.pendingLink];
+    const to = mapState.itemMap[nodeId];
+    if (!from || !to) {
+      mapState.pendingLink = null;
+      updatePendingHighlight();
+      return;
+    }
+    const existing = (from.links || []).find((l) => l.id === nodeId);
+    if (existing) {
+      if (existing.hidden) {
+        if (confirm("A hidden link already exists. Unhide it?")) {
+          await setLinkHidden(from.id, to.id, false);
+          await renderMap(mapState.root);
+        }
+      } else {
+        alert("These concepts are already linked.");
+      }
+      mapState.pendingLink = null;
+      updatePendingHighlight();
+      return;
+    }
+    if (!confirm(`Create a link between ${titleOf3(from)} and ${titleOf3(to)}?`)) {
+      mapState.pendingLink = null;
+      updatePendingHighlight();
+      return;
+    }
+    const label = prompt("Optional label for this link:", "") || "";
+    await createLink(from.id, to.id, { name: label, color: DEFAULT_LINK_COLOR, style: "solid", hidden: false });
+    mapState.pendingLink = null;
+    updatePendingHighlight();
+    await renderMap(mapState.root);
+  }
+  function handleEdgeClick(path, aId, bId, evt) {
+    if (mapState.tool === TOOL.NAVIGATE) {
+      openLineMenu(evt, path, aId, bId);
+    } else if (mapState.tool === TOOL.BREAK) {
+      if (confirm("Are you sure you want to delete this link?")) {
+        removeLink(aId, bId).then(() => renderMap(mapState.root));
+      }
+    } else if (mapState.tool === TOOL.HIDE_LINK) {
+      if (confirm("Hide this link on the map?")) {
+        setLinkHidden(aId, bId, true).then(() => renderMap(mapState.root));
+      }
+    }
+  }
+  function adjustScale() {
+    const svg = mapState.svg;
+    if (!svg) return;
+    const vb = svg.getAttribute("viewBox");
+    if (!vb) return;
+    const [, , w] = vb.split(" ").map(Number);
+    const unit = w / svg.clientWidth;
+    const nodeScale = Math.pow(unit, 0.8);
+    const labelScale = Math.pow(unit, 1.1);
+    mapState.elements.forEach(({ circle, label }) => {
+      const baseR = Number(circle.dataset.radius) || 20;
+      circle.setAttribute("r", baseR * nodeScale);
+      const pos = mapState.positions[circle.dataset.id];
+      if (pos) {
+        label.setAttribute("font-size", 12 * labelScale);
+        label.setAttribute("y", pos.y - (baseR + 8) * nodeScale);
+      }
+    });
+    svg.querySelectorAll(".map-edge").forEach((line) => {
+      line.setAttribute("stroke-width", 4 * Math.pow(unit, -0.2));
+    });
+  }
+  function pointToSegment(px, py, x1, y1, x2, y2) {
+    const dx = x2 - x1;
+    const dy = y2 - y1;
+    const l2 = dx * dx + dy * dy;
+    if (!l2) return Math.hypot(px - x1, py - y1);
+    let t = ((px - x1) * dx + (py - y1) * dy) / l2;
+    t = Math.max(0, Math.min(1, t));
+    const projX = x1 + t * dx;
+    const projY = y1 + t * dy;
+    return Math.hypot(px - projX, py - projY);
+  }
+  function calcPath(aId, bId) {
+    const positions = mapState.positions;
+    const a = positions[aId];
+    const b = positions[bId];
+    if (!a || !b) return "";
+    const x1 = a.x, y1 = a.y;
+    const x2 = b.x, y2 = b.y;
+    let cx = (x1 + x2) / 2;
+    let cy = (y1 + y2) / 2;
+    const dx = x2 - x1;
+    const dy = y2 - y1;
+    const len = Math.hypot(dx, dy) || 1;
+    for (const id in positions) {
+      if (id === aId || id === bId) continue;
+      const p = positions[id];
+      if (pointToSegment(p.x, p.y, x1, y1, x2, y2) < 40) {
+        const nx = -dy / len;
+        const ny = dx / len;
+        const side = (p.x - x1) * nx + (p.y - y1) * ny > 0 ? 1 : -1;
+        cx += nx * 80 * side;
+        cy += ny * 80 * side;
+        break;
+      }
+    }
+    return `M${x1} ${y1} Q${cx} ${cy} ${x2} ${y2}`;
   }
   function applyLineStyle(line, info) {
     const color = info.color || "var(--gray)";
@@ -2439,6 +2942,40 @@ var Sevenn = (() => {
       line.appendChild(title);
     }
     title.textContent = info.name || "";
+  }
+  async function setNodeHidden(id, hidden) {
+    const item = await getItem(id);
+    if (!item) return;
+    item.mapHidden = hidden;
+    await upsertItem(item);
+  }
+  async function createLink(aId, bId, info) {
+    const a = await getItem(aId);
+    const b = await getItem(bId);
+    if (!a || !b) return;
+    const linkInfo = { id: bId, style: "solid", color: DEFAULT_LINK_COLOR, name: "", hidden: false, ...info };
+    const reverseInfo = { ...linkInfo, id: aId };
+    a.links = a.links || [];
+    b.links = b.links || [];
+    a.links.push({ ...linkInfo });
+    b.links.push({ ...reverseInfo });
+    await upsertItem(a);
+    await upsertItem(b);
+  }
+  async function removeLink(aId, bId) {
+    const a = await getItem(aId);
+    const b = await getItem(bId);
+    if (!a || !b) return;
+    a.links = (a.links || []).filter((l) => l.id !== bId);
+    b.links = (b.links || []).filter((l) => l.id !== aId);
+    await upsertItem(a);
+    await upsertItem(b);
+  }
+  async function setLinkHidden(aId, bId, hidden) {
+    await updateLink(aId, bId, { hidden });
+  }
+  function titleOf3(item) {
+    return item?.name || item?.concept || "";
   }
   async function openLineMenu(evt, line, aId, bId) {
     const existing = await getItem(aId);

--- a/js/ui/components/map.js
+++ b/js/ui/components/map.js
@@ -1,296 +1,891 @@
 import { listItemsByKind, getItem, upsertItem } from '../../storage/storage.js';
 import { showPopup } from './popup.js';
 
-export async function renderMap(root){
+const TOOL = {
+  NAVIGATE: 'navigate',
+  NODES: 'nodes',
+  BREAK: 'break-link',
+  ADD_LINK: 'add-link',
+  HIDE_LINK: 'hide-link',
+  AREA: 'area'
+};
+
+const DEFAULT_LINK_COLOR = '#888888';
+
+const mapState = {
+  tool: TOOL.NAVIGATE,
+  selectionIds: [],
+  previewSelection: null,
+  pendingLink: null,
+  hiddenMenuTab: 'nodes',
+  panelVisible: true,
+  listenersAttached: false,
+  draggingView: false,
+  nodeDrag: null,
+  areaDrag: null,
+  menuDrag: null,
+  selectionRect: null,
+  nodeWasDragged: false,
+  viewBox: null,
+  svg: null,
+  g: null,
+  positions: {},
+  itemMap: {},
+  elements: new Map(),
+  root: null,
+  updateViewBox: () => {},
+  selectionBox: null,
+  sizeLimit: 2000,
+  minView: 100,
+  lastPointer: { x: 0, y: 0 }
+};
+
+export async function renderMap(root) {
+  mapState.root = root;
   root.innerHTML = '';
+  mapState.nodeDrag = null;
+  mapState.areaDrag = null;
+  mapState.draggingView = false;
+  mapState.menuDrag = null;
+  mapState.selectionRect = null;
+  mapState.previewSelection = null;
+  mapState.nodeWasDragged = false;
+
+  ensureListeners();
+
   const items = [
     ...(await listItemsByKind('disease')),
     ...(await listItemsByKind('drug')),
     ...(await listItemsByKind('concept'))
   ];
 
+  const hiddenNodes = items.filter(it => it.mapHidden);
+  const visibleItems = items.filter(it => !it.mapHidden);
+
+  const itemMap = Object.fromEntries(items.map(it => [it.id, it]));
+  mapState.itemMap = itemMap;
+
   const base = 1000;
-  const size = Math.max(base, items.length * 150);
+  const size = Math.max(base, visibleItems.length * 150);
   const viewport = base;
-  const svg = document.createElementNS('http://www.w3.org/2000/svg','svg');
-  const viewBox = { x:(size-viewport)/2, y:(size-viewport)/2, w:viewport, h:viewport };
+  mapState.sizeLimit = size * 2;
+  mapState.minView = 100;
+
+  const container = document.createElement('div');
+  container.className = 'map-container';
+  root.appendChild(container);
+
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.classList.add('map-svg');
+  const viewBox = {
+    x: (size - viewport) / 2,
+    y: (size - viewport) / 2,
+    w: viewport,
+    h: viewport
+  };
+
+  mapState.svg = svg;
+  mapState.viewBox = viewBox;
+
   const updateViewBox = () => {
     svg.setAttribute('viewBox', `${viewBox.x} ${viewBox.y} ${viewBox.w} ${viewBox.h}`);
     adjustScale();
   };
+  mapState.updateViewBox = updateViewBox;
 
-  svg.classList.add('map-svg');
-
-  const g = document.createElementNS('http://www.w3.org/2000/svg','g');
+  const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+  const defs = document.createElementNS('http://www.w3.org/2000/svg', 'defs');
+  const marker = document.createElementNS('http://www.w3.org/2000/svg', 'marker');
+  marker.setAttribute('id', 'arrow');
+  marker.setAttribute('viewBox', '0 0 10 10');
+  marker.setAttribute('refX', '10');
+  marker.setAttribute('refY', '5');
+  marker.setAttribute('markerWidth', '6');
+  marker.setAttribute('markerHeight', '6');
+  marker.setAttribute('orient', 'auto');
+  const arrowPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  arrowPath.setAttribute('d', 'M0,0 L10,5 L0,10 Z');
+  arrowPath.setAttribute('fill', 'inherit');
+  marker.appendChild(arrowPath);
+  defs.appendChild(marker);
+  svg.appendChild(defs);
   svg.appendChild(g);
+  mapState.g = g;
 
+  container.appendChild(svg);
 
-  const updateEdges = id => {
-    g.querySelectorAll(`path[data-a='${id}'], path[data-b='${id}']`).forEach(edge => {
-      edge.setAttribute('d', calcPath(edge.dataset.a, edge.dataset.b));
+  const selectionBox = document.createElement('div');
+  selectionBox.className = 'map-selection hidden';
+  container.appendChild(selectionBox);
+  mapState.selectionBox = selectionBox;
 
-    });
-  };
-
-  // pan/zoom state
-  let dragging = false;
-  let nodeDrag = null;
-  let nodeWasDragged = false;
-  let last = { x:0, y:0 };
-  svg.addEventListener('mousedown', e => {
-    if (e.target === svg) {
-      dragging = true;
-      last = { x: e.clientX, y: e.clientY };
-      svg.style.cursor = 'grabbing';
-    }
-  });
-
-  window.addEventListener('mousemove', async e => {
-    if (nodeDrag) {
-      const rect = svg.getBoundingClientRect();
-      const unit = viewBox.w / svg.clientWidth;
-      const nodeScale = Math.pow(unit, 0.8);
-      const x = viewBox.x + ((e.clientX - rect.left) / svg.clientWidth) * viewBox.w - nodeDrag.offset.x;
-      const y = viewBox.y + ((e.clientY - rect.top) / svg.clientHeight) * viewBox.h - nodeDrag.offset.y;
-
-      nodeDrag.pos.x = x;
-      nodeDrag.pos.y = y;
-      nodeDrag.circle.setAttribute('cx', x);
-      nodeDrag.circle.setAttribute('cy', y);
-      nodeDrag.label.setAttribute('x', x);
-      const baseR = Number(nodeDrag.circle.dataset.radius) || 20;
-
-      nodeDrag.label.setAttribute('y', y - (baseR + 8) * nodeScale);
-      updateEdges(nodeDrag.id);
-      nodeWasDragged = true;
-      return;
-    }
-
-    if (!dragging) return;
-    const scale = viewBox.w / svg.clientWidth;
-    viewBox.x -= (e.clientX - last.x) * scale;
-    viewBox.y -= (e.clientY - last.y) * scale;
-    last = { x: e.clientX, y: e.clientY };
-    updateViewBox();
-  });
-
-  window.addEventListener('mouseup', async () => {
-    if (nodeDrag) {
-      const it = itemMap[nodeDrag.id];
-      it.mapPos = { ...nodeDrag.pos };
-      await upsertItem(it);
-      nodeDrag = null;
-    }
-    dragging = false;
-    svg.style.cursor = 'grab';
-  });
-
-  svg.addEventListener('wheel', e => {
-    e.preventDefault();
-    const factor = e.deltaY < 0 ? 0.9 : 1.1;
-    const mx = viewBox.x + (e.offsetX / svg.clientWidth) * viewBox.w;
-    const my = viewBox.y + (e.offsetY / svg.clientHeight) * viewBox.h;
-
-    viewBox.w = Math.min(size * 2, Math.max(100, viewBox.w * factor));
-    viewBox.h = viewBox.w;
-    viewBox.x = mx - (e.offsetX / svg.clientWidth) * viewBox.w;
-    viewBox.y = my - (e.offsetY / svg.clientHeight) * viewBox.h;
-    updateViewBox();
-  });
-
-
-  if (!window._mapResizeAttached) {
-    window.addEventListener('resize', adjustScale);
-    window._mapResizeAttached = true;
-  }
+  attachSvgEvents(svg);
 
   const positions = {};
-  const itemMap = Object.fromEntries(items.map(it => [it.id, it]));
+  mapState.positions = positions;
+  mapState.elements = new Map();
+
   const linkCounts = Object.fromEntries(items.map(it => [it.id, (it.links || []).length]));
   const maxLinks = Math.max(1, ...Object.values(linkCounts));
   const minRadius = 20;
   const maxRadius = 60;
 
-  const center = size/2;
+  const center = size / 2;
   const newItems = [];
-  items.forEach(it => {
+  visibleItems.forEach(it => {
     if (it.mapPos) positions[it.id] = { ...it.mapPos };
     else newItems.push(it);
   });
-  newItems.sort((a,b) => linkCounts[b.id] - linkCounts[a.id]);
-  const step = (2*Math.PI) / Math.max(newItems.length,1);
+
+  newItems.sort((a, b) => (linkCounts[b.id] || 0) - (linkCounts[a.id] || 0));
+  const step = (2 * Math.PI) / Math.max(newItems.length, 1);
   newItems.forEach((it, idx) => {
     const angle = idx * step;
-    const degree = linkCounts[it.id];
+    const degree = linkCounts[it.id] || 0;
     const dist = 100 - (degree / maxLinks) * 50;
-    const x = center + dist*Math.cos(angle);
-    const y = center + dist*Math.sin(angle);
+    const x = center + dist * Math.cos(angle);
+    const y = center + dist * Math.sin(angle);
     positions[it.id] = { x, y };
     it.mapPos = positions[it.id];
   });
   for (const it of newItems) await upsertItem(it);
 
-  function pointToSeg(px, py, x1, y1, x2, y2){
-    const dx = x2 - x1;
-    const dy = y2 - y1;
-    const l2 = dx*dx + dy*dy;
-    if (!l2) return Math.hypot(px - x1, py - y1);
-    let t = ((px - x1) * dx + (py - y1) * dy) / l2;
-    t = Math.max(0, Math.min(1, t));
-    const projX = x1 + t * dx;
-    const projY = y1 + t * dy;
-    return Math.hypot(px - projX, py - projY);
-  }
+  mapState.selectionIds = mapState.selectionIds.filter(id => positions[id]);
 
-  function calcPath(aId, bId){
-    const a = positions[aId];
-    const b = positions[bId];
-    const x1 = a.x, y1 = a.y;
-    const x2 = b.x, y2 = b.y;
-    let cx = (x1 + x2) / 2;
-    let cy = (y1 + y2) / 2;
-    const dx = x2 - x1;
-    const dy = y2 - y1;
-    const len = Math.hypot(dx, dy) || 1;
-    for (const id in positions){
-      if (id === aId || id === bId) continue;
-      const p = positions[id];
-      if (pointToSeg(p.x, p.y, x1, y1, x2, y2) < 40){
-        const nx = -dy / len;
-        const ny = dx / len;
-        const side = ((p.x - x1) * nx + (p.y - y1) * ny) > 0 ? 1 : -1;
-        cx += nx * 80 * side;
-        cy += ny * 80 * side;
-        break;
-      }
-    }
-    return `M${x1} ${y1} Q${cx} ${cy} ${x2} ${y2}`;
-  }
+  const hiddenLinks = gatherHiddenLinks(items, itemMap);
 
-
-  const defs = document.createElementNS('http://www.w3.org/2000/svg','defs');
-  const marker = document.createElementNS('http://www.w3.org/2000/svg','marker');
-  marker.setAttribute('id','arrow');
-  marker.setAttribute('viewBox','0 0 10 10');
-  marker.setAttribute('refX','10');
-  marker.setAttribute('refY','5');
-  marker.setAttribute('markerWidth','6');
-  marker.setAttribute('markerHeight','6');
-  marker.setAttribute('orient','auto');
-  const path = document.createElementNS('http://www.w3.org/2000/svg','path');
-  path.setAttribute('d','M0,0 L10,5 L0,10 Z');
-  path.setAttribute('fill','inherit');
-  marker.appendChild(path);
-  defs.appendChild(marker);
-  svg.appendChild(defs);
+  buildToolbox(container, hiddenNodes.length, hiddenLinks.length);
+  buildHiddenPanel(container, hiddenNodes, hiddenLinks);
 
   const drawn = new Set();
-  items.forEach(it => {
-    (it.links||[]).forEach(l => {
+  visibleItems.forEach(it => {
+    (it.links || []).forEach(l => {
+      if (l.hidden) return;
       if (!positions[l.id]) return;
-      const key = it.id < l.id ? it.id + '|' + l.id : l.id + '|' + it.id;
+      const key = it.id < l.id ? `${it.id}|${l.id}` : `${l.id}|${it.id}`;
       if (drawn.has(key)) return;
       drawn.add(key);
 
-      const path = document.createElementNS('http://www.w3.org/2000/svg','path');
+      const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
       path.setAttribute('d', calcPath(it.id, l.id));
-      path.setAttribute('fill','none');
-      path.setAttribute('class','map-edge');
-      path.setAttribute('vector-effect','non-scaling-stroke');
+      path.setAttribute('fill', 'none');
+      path.setAttribute('class', 'map-edge');
+      path.setAttribute('vector-effect', 'non-scaling-stroke');
       applyLineStyle(path, l);
       path.dataset.a = it.id;
       path.dataset.b = l.id;
-      path.addEventListener('click', e => { e.stopPropagation(); openLineMenu(e, path, it.id, l.id); });
+      path.addEventListener('click', e => {
+        e.stopPropagation();
+        handleEdgeClick(path, it.id, l.id, e);
+      });
       g.appendChild(path);
-
     });
   });
 
-  items.forEach(it => {
+  visibleItems.forEach(it => {
     const pos = positions[it.id];
-    const circle = document.createElementNS('http://www.w3.org/2000/svg','circle');
+    if (!pos) return;
+
+    const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
     circle.setAttribute('cx', pos.x);
     circle.setAttribute('cy', pos.y);
-
-    // Scale radius between min and max based on link count
     const baseR = minRadius + ((maxRadius - minRadius) * (linkCounts[it.id] || 0) / maxLinks);
-
     circle.setAttribute('r', baseR);
     circle.dataset.radius = baseR;
-    circle.setAttribute('class','map-node');
-
+    circle.setAttribute('class', 'map-node');
     circle.dataset.id = it.id;
     const kindColors = { disease: 'var(--purple)', drug: 'var(--blue)' };
     const fill = kindColors[it.kind] || it.color || 'var(--gray)';
     circle.setAttribute('fill', fill);
-    let text;
-    circle.addEventListener('click', () => { if (!nodeWasDragged) showPopup(it); nodeWasDragged = false; });
+
     circle.addEventListener('mousedown', e => {
       e.stopPropagation();
-      const rect = svg.getBoundingClientRect();
-      const mouseX = viewBox.x + ((e.clientX - rect.left) / svg.clientWidth) * viewBox.w;
-      const mouseY = viewBox.y + ((e.clientY - rect.top) / svg.clientHeight) * viewBox.h;
-      nodeDrag = { id: it.id, circle, label: text, pos, offset: { x: mouseX - pos.x, y: mouseY - pos.y } };
-      nodeWasDragged = false;
-      svg.style.cursor = 'grabbing';
+      if (mapState.tool === TOOL.NAVIGATE) {
+        const { x, y } = clientToMap(e.clientX, e.clientY);
+        mapState.nodeDrag = {
+          id: it.id,
+          offset: { x: x - pos.x, y: y - pos.y }
+        };
+        mapState.nodeWasDragged = false;
+        mapState.svg.style.cursor = 'grabbing';
+      } else if (mapState.tool === TOOL.AREA && mapState.selectionIds.includes(it.id)) {
+        const { x, y } = clientToMap(e.clientX, e.clientY);
+        mapState.areaDrag = {
+          ids: [...mapState.selectionIds],
+          start: { x, y },
+          origin: mapState.selectionIds.map(id => ({ id, pos: { ...mapState.positions[id] } })),
+          moved: false
+        };
+        mapState.svg.style.cursor = 'grabbing';
+      }
+    });
+
+    circle.addEventListener('click', async e => {
+      e.stopPropagation();
+      if (mapState.tool === TOOL.NAVIGATE) {
+        if (!mapState.nodeWasDragged) showPopup(it);
+        mapState.nodeWasDragged = false;
+      } else if (mapState.tool === TOOL.NODES) {
+        if (confirm(`Remove ${titleOf(it)} from the map?`)) {
+          await setNodeHidden(it.id, true);
+          await renderMap(root);
+        }
+      } else if (mapState.tool === TOOL.ADD_LINK) {
+        await handleAddLinkClick(it.id);
+      }
     });
 
     g.appendChild(circle);
-    text = document.createElementNS('http://www.w3.org/2000/svg','text');
+
+    const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
     text.setAttribute('x', pos.x);
     text.setAttribute('y', pos.y - (baseR + 8));
-    text.setAttribute('class','map-label');
+    text.setAttribute('class', 'map-label');
     text.dataset.id = it.id;
     text.textContent = it.name || it.concept || '?';
     g.appendChild(text);
+
+    mapState.elements.set(it.id, { circle, label: text });
   });
 
-  root.appendChild(svg);
+  updateSelectionHighlight();
+  updatePendingHighlight();
+
   updateViewBox();
+  svg.style.cursor = 'grab';
 }
 
-function adjustScale(){
-  const svg = document.querySelector('.map-svg');
+function ensureListeners() {
+  if (mapState.listenersAttached || typeof window === 'undefined') return;
+  window.addEventListener('mousemove', handleMouseMove);
+  window.addEventListener('mouseup', handleMouseUp);
+  mapState.listenersAttached = true;
+  if (!window._mapResizeAttached) {
+    window.addEventListener('resize', adjustScale);
+    window._mapResizeAttached = true;
+  }
+}
+
+function attachSvgEvents(svg) {
+  svg.addEventListener('mousedown', e => {
+    if (e.target !== svg) return;
+    if (mapState.tool === TOOL.NAVIGATE) {
+      mapState.draggingView = true;
+      mapState.lastPointer = { x: e.clientX, y: e.clientY };
+      svg.style.cursor = 'grabbing';
+    } else if (mapState.tool === TOOL.AREA) {
+      mapState.selectionRect = {
+        start: { x: e.clientX, y: e.clientY },
+        current: { x: e.clientX, y: e.clientY }
+      };
+      mapState.selectionBox.classList.remove('hidden');
+    }
+  });
+
+  svg.addEventListener('wheel', e => {
+    e.preventDefault();
+    const factor = e.deltaY < 0 ? 0.9 : 1.1;
+    const rect = svg.getBoundingClientRect();
+    const mx = mapState.viewBox.x + ((e.clientX - rect.left) / rect.width) * mapState.viewBox.w;
+    const my = mapState.viewBox.y + ((e.clientY - rect.top) / rect.height) * mapState.viewBox.h;
+    const maxSize = mapState.sizeLimit || 2000;
+    const minSize = mapState.minView || 100;
+    const nextW = Math.max(minSize, Math.min(maxSize, mapState.viewBox.w * factor));
+    mapState.viewBox.w = nextW;
+    mapState.viewBox.h = nextW;
+    mapState.viewBox.x = mx - ((e.clientX - rect.left) / rect.width) * mapState.viewBox.w;
+    mapState.viewBox.y = my - ((e.clientY - rect.top) / rect.height) * mapState.viewBox.h;
+    mapState.updateViewBox();
+  }, { passive: false });
+}
+
+function handleMouseMove(e) {
+  if (!mapState.svg) return;
+
+  if (mapState.menuDrag) {
+    updateMenuDragPosition(e.clientX, e.clientY);
+    return;
+  }
+
+  if (mapState.nodeDrag) {
+    const { circle, label } = mapState.elements.get(mapState.nodeDrag.id) || {};
+    if (!circle) return;
+    const { x, y } = clientToMap(e.clientX, e.clientY);
+    const nx = x - mapState.nodeDrag.offset.x;
+    const ny = y - mapState.nodeDrag.offset.y;
+    mapState.positions[mapState.nodeDrag.id] = { x: nx, y: ny };
+    circle.setAttribute('cx', nx);
+    circle.setAttribute('cy', ny);
+    if (label) {
+      label.setAttribute('x', nx);
+      const baseR = Number(circle.dataset.radius) || 20;
+      label.setAttribute('y', ny - (baseR + 8));
+    }
+    updateEdgesFor(mapState.nodeDrag.id);
+    mapState.nodeWasDragged = true;
+    return;
+  }
+
+  if (mapState.areaDrag) {
+    const { x, y } = clientToMap(e.clientX, e.clientY);
+    const dx = x - mapState.areaDrag.start.x;
+    const dy = y - mapState.areaDrag.start.y;
+    mapState.areaDrag.moved = Math.abs(dx) > 0.5 || Math.abs(dy) > 0.5;
+    mapState.areaDrag.origin.forEach(({ id, pos }) => {
+      const nx = pos.x + dx;
+      const ny = pos.y + dy;
+      mapState.positions[id] = { x: nx, y: ny };
+      const entry = mapState.elements.get(id);
+      if (entry) {
+        entry.circle.setAttribute('cx', nx);
+        entry.circle.setAttribute('cy', ny);
+        entry.label.setAttribute('x', nx);
+        const baseR = Number(entry.circle.dataset.radius) || 20;
+        entry.label.setAttribute('y', ny - (baseR + 8));
+      }
+      updateEdgesFor(id);
+    });
+    mapState.nodeWasDragged = true;
+    return;
+  }
+
+  if (mapState.draggingView) {
+    const scale = mapState.viewBox.w / mapState.svg.clientWidth;
+    mapState.viewBox.x -= (e.clientX - mapState.lastPointer.x) * scale;
+    mapState.viewBox.y -= (e.clientY - mapState.lastPointer.y) * scale;
+    mapState.lastPointer = { x: e.clientX, y: e.clientY };
+    mapState.updateViewBox();
+    return;
+  }
+
+  if (mapState.selectionRect) {
+    mapState.selectionRect.current = { x: e.clientX, y: e.clientY };
+    updateSelectionBox();
+  }
+}
+
+async function handleMouseUp(e) {
+  if (!mapState.svg) return;
+
+  if (mapState.menuDrag) {
+    await finishMenuDrag(e.clientX, e.clientY);
+    return;
+  }
+
+  if (mapState.nodeDrag) {
+    const id = mapState.nodeDrag.id;
+    mapState.nodeDrag = null;
+    mapState.svg.style.cursor = 'grab';
+    if (mapState.nodeWasDragged) {
+      await persistNodePosition(id);
+    }
+    mapState.nodeWasDragged = false;
+  }
+
+  if (mapState.areaDrag) {
+    const moved = mapState.areaDrag.moved;
+    const ids = mapState.areaDrag.ids;
+    mapState.areaDrag = null;
+    mapState.svg.style.cursor = 'grab';
+    if (moved) {
+      await Promise.all(ids.map(id => persistNodePosition(id)));
+    }
+    mapState.nodeWasDragged = false;
+  }
+
+  if (mapState.draggingView) {
+    mapState.draggingView = false;
+    mapState.svg.style.cursor = 'grab';
+  }
+
+  if (mapState.selectionRect) {
+    const selected = computeSelectionFromRect();
+    mapState.selectionIds = selected;
+    mapState.previewSelection = null;
+    mapState.selectionRect = null;
+    mapState.selectionBox.classList.add('hidden');
+    updateSelectionHighlight();
+  }
+}
+
+function clientToMap(clientX, clientY) {
+  if (!mapState.svg) return { x: 0, y: 0 };
+  const rect = mapState.svg.getBoundingClientRect();
+  const x = mapState.viewBox.x + ((clientX - rect.left) / rect.width) * mapState.viewBox.w;
+  const y = mapState.viewBox.y + ((clientY - rect.top) / rect.height) * mapState.viewBox.h;
+  return { x, y };
+}
+
+function updateSelectionBox() {
+  if (!mapState.selectionRect || !mapState.selectionBox || !mapState.svg) return;
+  const { start, current } = mapState.selectionRect;
+  const rect = mapState.svg.getBoundingClientRect();
+  const left = Math.min(start.x, current.x) - rect.left;
+  const top = Math.min(start.y, current.y) - rect.top;
+  const width = Math.abs(start.x - current.x);
+  const height = Math.abs(start.y - current.y);
+  mapState.selectionBox.style.left = `${left}px`;
+  mapState.selectionBox.style.top = `${top}px`;
+  mapState.selectionBox.style.width = `${width}px`;
+  mapState.selectionBox.style.height = `${height}px`;
+
+  const from = clientToMap(start.x, start.y);
+  const to = clientToMap(current.x, current.y);
+  const minX = Math.min(from.x, to.x);
+  const maxX = Math.max(from.x, to.x);
+  const minY = Math.min(from.y, to.y);
+  const maxY = Math.max(from.y, to.y);
+  const preview = [];
+  Object.entries(mapState.positions).forEach(([id, pos]) => {
+    if (pos.x >= minX && pos.x <= maxX && pos.y >= minY && pos.y <= maxY) {
+      preview.push(id);
+    }
+  });
+  mapState.previewSelection = preview;
+  updateSelectionHighlight();
+}
+
+function computeSelectionFromRect() {
+  if (mapState.previewSelection) return mapState.previewSelection.slice();
+  return mapState.selectionIds.slice();
+}
+
+function updateSelectionHighlight() {
+  const ids = mapState.previewSelection || mapState.selectionIds;
+  const set = new Set(ids);
+  mapState.elements.forEach(({ circle, label }, id) => {
+    if (set.has(id)) {
+      circle.classList.add('selected');
+      label.classList.add('selected');
+    } else {
+      circle.classList.remove('selected');
+      label.classList.remove('selected');
+    }
+  });
+}
+
+function updatePendingHighlight() {
+  mapState.elements.forEach(({ circle, label }, id) => {
+    if (mapState.pendingLink === id) {
+      circle.classList.add('pending');
+      label.classList.add('pending');
+    } else {
+      circle.classList.remove('pending');
+      label.classList.remove('pending');
+    }
+  });
+}
+
+function updateEdgesFor(id) {
+  if (!mapState.g) return;
+  mapState.g.querySelectorAll(`path[data-a='${id}'], path[data-b='${id}']`).forEach(edge => {
+    edge.setAttribute('d', calcPath(edge.dataset.a, edge.dataset.b));
+  });
+}
+
+function buildToolbox(container, hiddenNodeCount, hiddenLinkCount) {
+  const tools = [
+    { id: TOOL.NAVIGATE, icon: '🧭', label: 'Navigate' },
+    { id: TOOL.NODES, icon: '🧩', label: 'Nodes' },
+    { id: TOOL.BREAK, icon: '✂️', label: 'Break link' },
+    { id: TOOL.ADD_LINK, icon: '➕', label: 'Add link' },
+    { id: TOOL.HIDE_LINK, icon: '🙈', label: 'Hide link' },
+    { id: TOOL.AREA, icon: '📦', label: 'Select area' }
+  ];
+  const box = document.createElement('div');
+  box.className = 'map-toolbox';
+  tools.forEach(tool => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'map-tool' + (mapState.tool === tool.id ? ' active' : '');
+    btn.textContent = tool.icon;
+    btn.title = tool.label;
+    btn.addEventListener('click', () => {
+      if (mapState.tool !== tool.id) {
+        mapState.tool = tool.id;
+        if (tool.id === TOOL.NODES) mapState.hiddenMenuTab = 'nodes';
+        if (tool.id === TOOL.HIDE_LINK) mapState.hiddenMenuTab = 'links';
+        if (tool.id !== TOOL.AREA) {
+          mapState.selectionIds = [];
+          mapState.previewSelection = null;
+        }
+        if (tool.id !== TOOL.ADD_LINK) {
+          mapState.pendingLink = null;
+        }
+        if (tool.id === TOOL.NODES || tool.id === TOOL.HIDE_LINK) {
+          mapState.panelVisible = true;
+        }
+        renderMap(mapState.root);
+      }
+    });
+    box.appendChild(btn);
+  });
+
+  const status = document.createElement('div');
+  status.className = 'map-tool-status';
+  status.innerHTML = `Hidden nodes: <strong>${hiddenNodeCount}</strong><br/>Hidden links: <strong>${hiddenLinkCount}</strong>`;
+  box.appendChild(status);
+
+  container.appendChild(box);
+}
+
+function buildHiddenPanel(container, hiddenNodes, hiddenLinks) {
+  const allowPanel = mapState.tool === TOOL.NODES || mapState.tool === TOOL.HIDE_LINK;
+  const panel = document.createElement('div');
+  panel.className = 'map-hidden-panel';
+  if (!(allowPanel && mapState.panelVisible)) {
+    panel.classList.add('hidden');
+  }
+
+  const header = document.createElement('div');
+  header.className = 'map-hidden-header';
+
+  const tabs = document.createElement('div');
+  tabs.className = 'map-hidden-tabs';
+
+  const nodeTab = document.createElement('button');
+  nodeTab.type = 'button';
+  nodeTab.textContent = `Nodes (${hiddenNodes.length})`;
+  nodeTab.className = mapState.hiddenMenuTab === 'nodes' ? 'active' : '';
+  nodeTab.addEventListener('click', () => {
+    mapState.hiddenMenuTab = 'nodes';
+    renderMap(mapState.root);
+  });
+  tabs.appendChild(nodeTab);
+
+  const linkTab = document.createElement('button');
+  linkTab.type = 'button';
+  linkTab.textContent = `Links (${hiddenLinks.length})`;
+  linkTab.className = mapState.hiddenMenuTab === 'links' ? 'active' : '';
+  linkTab.addEventListener('click', () => {
+    mapState.hiddenMenuTab = 'links';
+    renderMap(mapState.root);
+  });
+  tabs.appendChild(linkTab);
+
+  header.appendChild(tabs);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.type = 'button';
+  closeBtn.className = 'map-hidden-close';
+  closeBtn.textContent = mapState.panelVisible ? 'Hide' : 'Show';
+  closeBtn.addEventListener('click', () => {
+    mapState.panelVisible = !mapState.panelVisible;
+    renderMap(mapState.root);
+  });
+  header.appendChild(closeBtn);
+
+  panel.appendChild(header);
+
+  const body = document.createElement('div');
+  body.className = 'map-hidden-body';
+
+  if (mapState.hiddenMenuTab === 'nodes') {
+    const list = document.createElement('div');
+    list.className = 'map-hidden-list';
+    if (hiddenNodes.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'map-hidden-empty';
+      empty.textContent = 'No hidden nodes.';
+      list.appendChild(empty);
+    } else {
+      hiddenNodes
+        .slice()
+        .sort((a, b) => titleOf(a).localeCompare(titleOf(b)))
+        .forEach(it => {
+          const item = document.createElement('div');
+          item.className = 'map-hidden-item';
+          item.classList.add('draggable');
+          item.textContent = titleOf(it) || it.id;
+          item.addEventListener('mousedown', e => {
+            if (mapState.tool !== TOOL.NODES) return;
+            startMenuDrag(it, e);
+          });
+          list.appendChild(item);
+        });
+    }
+    body.appendChild(list);
+  } else {
+    const list = document.createElement('div');
+    list.className = 'map-hidden-list';
+    if (hiddenLinks.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'map-hidden-empty';
+      empty.textContent = 'No hidden links.';
+      list.appendChild(empty);
+    } else {
+      hiddenLinks.forEach(link => {
+        const item = document.createElement('div');
+        item.className = 'map-hidden-item';
+        const label = document.createElement('span');
+        label.textContent = `${titleOf(link.a)} ↔ ${titleOf(link.b)}`;
+        item.appendChild(label);
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.textContent = 'Unhide';
+        btn.addEventListener('click', async () => {
+          await setLinkHidden(link.a.id, link.b.id, false);
+          await renderMap(mapState.root);
+        });
+        item.appendChild(btn);
+        list.appendChild(item);
+      });
+    }
+    body.appendChild(list);
+  }
+
+  panel.appendChild(body);
+
+  container.appendChild(panel);
+
+  if (allowPanel && !mapState.panelVisible) {
+    const toggle = document.createElement('button');
+    toggle.type = 'button';
+    toggle.className = 'map-hidden-toggle';
+    toggle.textContent = 'Show menu';
+    toggle.addEventListener('click', () => {
+      mapState.panelVisible = true;
+      renderMap(mapState.root);
+    });
+    container.appendChild(toggle);
+  }
+}
+
+function startMenuDrag(item, event) {
+  event.preventDefault();
+  const ghost = document.createElement('div');
+  ghost.className = 'map-drag-ghost';
+  ghost.textContent = titleOf(item) || item.id;
+  document.body.appendChild(ghost);
+  mapState.menuDrag = { id: item.id, ghost };
+  updateMenuDragPosition(event.clientX, event.clientY);
+}
+
+async function finishMenuDrag(clientX, clientY) {
+  const drag = mapState.menuDrag;
+  mapState.menuDrag = null;
+  if (drag?.ghost) drag.ghost.remove();
+  if (!drag || !mapState.svg) return;
+  const rect = mapState.svg.getBoundingClientRect();
+  if (clientX < rect.left || clientX > rect.right || clientY < rect.top || clientY > rect.bottom) {
+    return;
+  }
+  const { x, y } = clientToMap(clientX, clientY);
+  const item = await getItem(drag.id);
+  if (!item) return;
+  item.mapHidden = false;
+  item.mapPos = { x, y };
+  await upsertItem(item);
+  await renderMap(mapState.root);
+}
+
+function updateMenuDragPosition(clientX, clientY) {
+  if (!mapState.menuDrag?.ghost) return;
+  mapState.menuDrag.ghost.style.left = `${clientX + 12}px`;
+  mapState.menuDrag.ghost.style.top = `${clientY + 12}px`;
+}
+
+async function persistNodePosition(id) {
+  const item = mapState.itemMap[id];
+  if (!item) return;
+  const next = { ...item, mapPos: { ...mapState.positions[id] } };
+  mapState.itemMap[id] = next;
+  await upsertItem(next);
+}
+
+function gatherHiddenLinks(items, itemMap) {
+  const hidden = [];
+  const seen = new Set();
+  items.forEach(it => {
+    (it.links || []).forEach(link => {
+      if (!link.hidden) return;
+      const other = itemMap[link.id];
+      if (!other) return;
+      const key = it.id < link.id ? `${it.id}|${link.id}` : `${link.id}|${it.id}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      hidden.push({ a: it, b: other });
+    });
+  });
+  return hidden;
+}
+
+async function handleAddLinkClick(nodeId) {
+  if (!mapState.pendingLink) {
+    mapState.pendingLink = nodeId;
+    updatePendingHighlight();
+    return;
+  }
+  if (mapState.pendingLink === nodeId) {
+    mapState.pendingLink = null;
+    updatePendingHighlight();
+    return;
+  }
+  const from = mapState.itemMap[mapState.pendingLink];
+  const to = mapState.itemMap[nodeId];
+  if (!from || !to) {
+    mapState.pendingLink = null;
+    updatePendingHighlight();
+    return;
+  }
+  const existing = (from.links || []).find(l => l.id === nodeId);
+  if (existing) {
+    if (existing.hidden) {
+      if (confirm('A hidden link already exists. Unhide it?')) {
+        await setLinkHidden(from.id, to.id, false);
+        await renderMap(mapState.root);
+      }
+    } else {
+      alert('These concepts are already linked.');
+    }
+    mapState.pendingLink = null;
+    updatePendingHighlight();
+    return;
+  }
+  if (!confirm(`Create a link between ${titleOf(from)} and ${titleOf(to)}?`)) {
+    mapState.pendingLink = null;
+    updatePendingHighlight();
+    return;
+  }
+  const label = prompt('Optional label for this link:', '') || '';
+  await createLink(from.id, to.id, { name: label, color: DEFAULT_LINK_COLOR, style: 'solid', hidden: false });
+  mapState.pendingLink = null;
+  updatePendingHighlight();
+  await renderMap(mapState.root);
+}
+
+function handleEdgeClick(path, aId, bId, evt) {
+  if (mapState.tool === TOOL.NAVIGATE) {
+    openLineMenu(evt, path, aId, bId);
+  } else if (mapState.tool === TOOL.BREAK) {
+    if (confirm('Are you sure you want to delete this link?')) {
+      removeLink(aId, bId).then(() => renderMap(mapState.root));
+    }
+  } else if (mapState.tool === TOOL.HIDE_LINK) {
+    if (confirm('Hide this link on the map?')) {
+      setLinkHidden(aId, bId, true).then(() => renderMap(mapState.root));
+    }
+  }
+}
+
+function adjustScale() {
+  const svg = mapState.svg;
   if (!svg) return;
-  const vb = svg.getAttribute('viewBox').split(' ').map(Number);
-  const unit = vb[2] / svg.clientWidth; // units per pixel
+  const vb = svg.getAttribute('viewBox');
+  if (!vb) return;
+  const [,, w] = vb.split(' ').map(Number);
+  const unit = w / svg.clientWidth;
   const nodeScale = Math.pow(unit, 0.8);
   const labelScale = Math.pow(unit, 1.1);
 
-  document.querySelectorAll('.map-node').forEach(c => {
-    const baseR = Number(c.dataset.radius) || 20;
-    c.setAttribute('r', baseR * nodeScale);
-  });
-  document.querySelectorAll('.map-label').forEach(t => {
-    t.setAttribute('font-size', 12 * labelScale);
-    const id = t.dataset.id;
-    const c = document.querySelector(`circle[data-id='${id}']`);
-    if (c) {
-      const baseR = Number(c.dataset.radius) || 20;
-      t.setAttribute('y', Number(c.getAttribute('cy')) - (baseR + 8) * nodeScale);
+  mapState.elements.forEach(({ circle, label }) => {
+    const baseR = Number(circle.dataset.radius) || 20;
+    circle.setAttribute('r', baseR * nodeScale);
+    const pos = mapState.positions[circle.dataset.id];
+    if (pos) {
+      label.setAttribute('font-size', 12 * labelScale);
+      label.setAttribute('y', pos.y - (baseR + 8) * nodeScale);
     }
   });
-  document.querySelectorAll('.map-edge').forEach(l => l.setAttribute('stroke-width', 4 * Math.pow(unit, -0.2)));
-
+  svg.querySelectorAll('.map-edge').forEach(line => {
+    line.setAttribute('stroke-width', 4 * Math.pow(unit, -0.2));
+  });
 }
 
-function applyLineStyle(line, info){
+function pointToSegment(px, py, x1, y1, x2, y2) {
+  const dx = x2 - x1;
+  const dy = y2 - y1;
+  const l2 = dx * dx + dy * dy;
+  if (!l2) return Math.hypot(px - x1, py - y1);
+  let t = ((px - x1) * dx + (py - y1) * dy) / l2;
+  t = Math.max(0, Math.min(1, t));
+  const projX = x1 + t * dx;
+  const projY = y1 + t * dy;
+  return Math.hypot(px - projX, py - projY);
+}
+
+function calcPath(aId, bId) {
+  const positions = mapState.positions;
+  const a = positions[aId];
+  const b = positions[bId];
+  if (!a || !b) return '';
+  const x1 = a.x, y1 = a.y;
+  const x2 = b.x, y2 = b.y;
+  let cx = (x1 + x2) / 2;
+  let cy = (y1 + y2) / 2;
+  const dx = x2 - x1;
+  const dy = y2 - y1;
+  const len = Math.hypot(dx, dy) || 1;
+  for (const id in positions) {
+    if (id === aId || id === bId) continue;
+    const p = positions[id];
+    if (pointToSegment(p.x, p.y, x1, y1, x2, y2) < 40) {
+      const nx = -dy / len;
+      const ny = dx / len;
+      const side = ((p.x - x1) * nx + (p.y - y1) * ny) > 0 ? 1 : -1;
+      cx += nx * 80 * side;
+      cy += ny * 80 * side;
+      break;
+    }
+  }
+  return `M${x1} ${y1} Q${cx} ${cy} ${x2} ${y2}`;
+}
+
+function applyLineStyle(line, info) {
   const color = info.color || 'var(--gray)';
   line.style.stroke = color;
-
-  if (info.style === 'dashed') line.setAttribute('stroke-dasharray','4,4');
+  if (info.style === 'dashed') line.setAttribute('stroke-dasharray', '4,4');
   else line.removeAttribute('stroke-dasharray');
-  if (info.style === 'arrow') line.setAttribute('marker-end','url(#arrow)');
+  if (info.style === 'arrow') line.setAttribute('marker-end', 'url(#arrow)');
   else line.removeAttribute('marker-end');
   let title = line.querySelector('title');
   if (!title) {
-    title = document.createElementNS('http://www.w3.org/2000/svg','title');
+    title = document.createElementNS('http://www.w3.org/2000/svg', 'title');
     line.appendChild(title);
   }
   title.textContent = info.name || '';
 }
 
-async function openLineMenu(evt, line, aId, bId){
+async function setNodeHidden(id, hidden) {
+  const item = await getItem(id);
+  if (!item) return;
+  item.mapHidden = hidden;
+  await upsertItem(item);
+}
+
+async function createLink(aId, bId, info) {
+  const a = await getItem(aId);
+  const b = await getItem(bId);
+  if (!a || !b) return;
+  const linkInfo = { id: bId, style: 'solid', color: DEFAULT_LINK_COLOR, name: '', hidden: false, ...info };
+  const reverseInfo = { ...linkInfo, id: aId };
+  a.links = a.links || [];
+  b.links = b.links || [];
+  a.links.push({ ...linkInfo });
+  b.links.push({ ...reverseInfo });
+  await upsertItem(a);
+  await upsertItem(b);
+}
+
+async function removeLink(aId, bId) {
+  const a = await getItem(aId);
+  const b = await getItem(bId);
+  if (!a || !b) return;
+  a.links = (a.links || []).filter(l => l.id !== bId);
+  b.links = (b.links || []).filter(l => l.id !== aId);
+  await upsertItem(a);
+  await upsertItem(b);
+}
+
+async function setLinkHidden(aId, bId, hidden) {
+  await updateLink(aId, bId, { hidden });
+}
+
+function titleOf(item) {
+  return item?.name || item?.concept || '';
+}
+
+async function openLineMenu(evt, line, aId, bId) {
   const existing = await getItem(aId);
   const link = existing.links.find(l => l.id === bId) || {};
   const menu = document.createElement('div');
@@ -309,9 +904,10 @@ async function openLineMenu(evt, line, aId, bId){
   const typeLabel = document.createElement('label');
   typeLabel.textContent = 'Style';
   const typeSel = document.createElement('select');
-  ['solid','dashed','arrow'].forEach(t => {
+  ['solid', 'dashed', 'arrow'].forEach(t => {
     const opt = document.createElement('option');
-    opt.value = t; opt.textContent = t;
+    opt.value = t;
+    opt.textContent = t;
     typeSel.appendChild(opt);
   });
   typeSel.value = link.style || 'solid';
@@ -347,7 +943,7 @@ async function openLineMenu(evt, line, aId, bId){
   setTimeout(() => document.addEventListener('mousedown', closer), 0);
 }
 
-async function updateLink(aId, bId, patch){
+async function updateLink(aId, bId, patch) {
   const a = await getItem(aId);
   const b = await getItem(bId);
   if (!a || !b) return;

--- a/js/validators.js
+++ b/js/validators.js
@@ -10,6 +10,7 @@ export function cleanItem(item) {
     weeks: item.weeks || [],
     lectures: item.lectures || [],
     mapPos: item.mapPos || null,
+    mapHidden: !!item.mapHidden,
     sr: item.sr || { box:0, last:0, due:0, ease:2.5 }
   };
 }

--- a/style.css
+++ b/style.css
@@ -734,3 +734,224 @@ input[type="checkbox"]:checked::after {
   font-size: 12px;
   gap: 2px;
 }
+
+.map-container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.map-toolbox {
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 8px;
+  z-index: 10;
+  box-shadow: 0 10px 24px rgba(0,0,0,0.45);
+}
+
+.map-tool {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background: var(--muted);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-size: 20px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.map-tool:hover {
+  background: rgba(148,163,184,0.2);
+  transform: translateY(-1px);
+}
+
+.map-tool.active {
+  background: var(--blue);
+  color: #000;
+  border-color: var(--border);
+}
+
+.map-tool-status {
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--gray);
+  border-top: 1px solid var(--border);
+  padding-top: 6px;
+  text-align: left;
+}
+
+.map-hidden-panel {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 260px;
+  max-height: calc(100% - 32px);
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+  box-shadow: 0 10px 24px rgba(0,0,0,0.45);
+  z-index: 10;
+}
+
+.map-hidden-panel.hidden {
+  display: none;
+}
+
+.map-hidden-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.map-hidden-tabs {
+  display: flex;
+  gap: 6px;
+  flex: 1;
+}
+
+.map-hidden-tabs button {
+  flex: 1;
+  background: var(--muted);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 4px 6px;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.map-hidden-tabs button.active {
+  background: var(--blue);
+  color: #000;
+}
+
+.map-hidden-close {
+  background: transparent;
+  color: var(--gray);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 4px 8px;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.map-hidden-body {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.map-hidden-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.map-hidden-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  background: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 6px 8px;
+  font-size: 14px;
+}
+
+.map-hidden-item.draggable {
+  cursor: grab;
+}
+
+.map-hidden-item.draggable:active {
+  cursor: grabbing;
+}
+
+.map-hidden-item button {
+  background: var(--blue);
+  color: #000;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 4px 8px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.map-hidden-empty {
+  text-align: center;
+  color: var(--gray);
+  padding: 16px 0;
+  font-size: 14px;
+}
+
+.map-hidden-toggle {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  background: var(--panel);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 8px 12px;
+  cursor: pointer;
+  z-index: 9;
+}
+
+.map-drag-ghost {
+  position: fixed;
+  pointer-events: none;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 6px 10px;
+  box-shadow: 0 10px 24px rgba(0,0,0,0.45);
+  color: var(--text);
+  font-size: 14px;
+  z-index: 1000;
+}
+
+.map-selection {
+  position: absolute;
+  border: 1px dashed var(--blue);
+  background: rgba(166, 217, 255, 0.12);
+  pointer-events: none;
+  z-index: 5;
+}
+
+.map-selection.hidden {
+  display: none;
+}
+
+.map-node.selected {
+  stroke: var(--yellow);
+  stroke-width: 3;
+}
+
+.map-label.selected {
+  fill: var(--yellow);
+  font-weight: 600;
+}
+
+.map-node.pending {
+  stroke: var(--pink);
+  stroke-width: 4;
+}
+
+.map-label.pending {
+  fill: var(--pink);
+  font-weight: 600;
+}


### PR DESCRIPTION
## Summary
- Expand the concept map renderer with a centralized tool system that drives navigation, node removal/restore, link creation/removal/hiding, and area selection moves.
- Add a floating toolbox plus hidden node/link panel with drag-and-drop restore and unhide flows, and refresh styling to support the new controls.
- Persist a `mapHidden` flag on items and regenerate the bundle so the updated map behavior is available in production.

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c99bfa09d083228b0a85aba0932139