### PR TITLE
Improve map cursors and toolbar styling

### DIFF
--- a/js/ui/components/map.js
+++ b/js/ui/components/map.js
@@ -19,29 +19,33 @@ function createCursor(svg, hotX = 8, hotY = 8) {
 const CURSOR_STYLE = {
   hide: createCursor(
     '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">'
-    + '<rect x="8" y="12" width="16" height="10" rx="2" fill="#f97316" transform="rotate(-30 16 17)" />'
-    + '<rect x="12" y="20" width="10" height="6" rx="1.5" fill="#fed7aa" transform="rotate(-30 17 23)" />'
+    + '<path d="M6 19.5l9-9a3 3 0 0 1 4.24 0l6.5 6.5a3 3 0 0 1 0 4.24l-9 9H9a3 3 0 0 1-3-3z" fill="#f97316" />'
+    + '<path d="M8.2 21.2l8.6 8.6" stroke="#fed7aa" stroke-width="3" stroke-linecap="round" />'
+    + '<path d="M11.3 24.5l4 4" stroke="#fff7ed" stroke-width="2" stroke-linecap="round" />'
     + '</svg>',
-    6,
+    7,
     26
   ),
   break: createCursor(
     '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">'
-    + '<circle cx="10" cy="12" r="4" fill="none" stroke="#f97316" stroke-width="2" />'
-    + '<circle cx="10" cy="20" r="4" fill="none" stroke="#f97316" stroke-width="2" />'
-    + '<path d="M6 7l20 18" stroke="#f97316" stroke-width="3" stroke-linecap="round" />'
-    + '<path d="M6 25l20-18" stroke="#f97316" stroke-width="3" stroke-linecap="round" />'
+    + '<circle cx="11" cy="11" r="4" fill="none" stroke="#f97316" stroke-width="2.2" />'
+    + '<circle cx="11" cy="21" r="4" fill="none" stroke="#f97316" stroke-width="2.2" />'
+    + '<path d="M14.5 13L24 3.5" stroke="#fbbf24" stroke-width="2.6" stroke-linecap="round" />'
+    + '<path d="M14.5 19L24 28.5" stroke="#fbbf24" stroke-width="2.6" stroke-linecap="round" />'
+    + '<path d="M6 6l7 7" stroke="#f97316" stroke-width="2.2" stroke-linecap="round" />'
+    + '<path d="M6 26l7-7" stroke="#f97316" stroke-width="2.2" stroke-linecap="round" />'
     + '</svg>',
-    8,
-    26
+    18,
+    18
   ),
   link: createCursor(
     '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">'
-    + '<path d="M12 11h6a5 5 0 0 1 0 10h-3" fill="none" stroke="#38bdf8" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />'
-    + '<path d="M14 15h-4a5 5 0 0 0 0 10h5" fill="none" stroke="#38bdf8" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />'
+    + '<path d="M12 11h5a4.5 4.5 0 0 1 0 9h-3" fill="none" stroke="#38bdf8" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />'
+    + '<path d="M14 15h-4a4.5 4.5 0 0 0 0 9h5" fill="none" stroke="#38bdf8" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />'
+    + '<path d="M13 19h6" stroke="#bae6fd" stroke-width="2" stroke-linecap="round" />'
     + '</svg>',
-    8,
-    24
+    9,
+    23
   )
 };
 
@@ -1022,10 +1026,20 @@ function ensureToolboxWithinBounds() {
 
 function determineBaseCursor() {
   if (mapState.draggingView || mapState.nodeDrag || mapState.areaDrag) return 'grabbing';
-  if (mapState.tool === TOOL.AREA) return 'crosshair';
-
-  if (mapState.tool === TOOL.NAVIGATE) return 'grab';
-  return 'pointer';
+  switch (mapState.tool) {
+    case TOOL.AREA:
+      return 'crosshair';
+    case TOOL.NAVIGATE:
+      return 'grab';
+    case TOOL.HIDE:
+      return CURSOR_STYLE.hide;
+    case TOOL.BREAK:
+      return CURSOR_STYLE.break;
+    case TOOL.ADD_LINK:
+      return CURSOR_STYLE.link;
+    default:
+      return 'pointer';
+  }
 }
 
 function refreshCursor(options = {}) {

--- a/style.css
+++ b/style.css
@@ -689,8 +689,10 @@ input[type="checkbox"]:checked::after {
   width: 100%;
   height: 100%;
   cursor: grab;
-  background: var(--muted);
-  border-top: 1px solid var(--border);
+  background:
+    radial-gradient(circle at 18% 22%, rgba(148, 163, 184, 0.12), transparent 58%),
+    linear-gradient(160deg, #0b1422 0%, #0a101b 45%, #05070d 100%);
+  border-top: 1px solid rgba(148, 163, 184, 0.24);
 }
 .map-node {
   cursor: inherit;
@@ -747,24 +749,23 @@ input[type="checkbox"]:checked::after {
   left: 16px;
   display: flex;
   flex-direction: column;
-
-  gap: 10px;
-  background: rgba(15, 23, 42, 0.55);
-  border: 1px solid rgba(148, 163, 184, 0.35);
+  gap: 8px;
+  background: rgba(15, 23, 42, 0.32);
+  border: 1px solid rgba(148, 163, 184, 0.28);
   border-radius: var(--radius-lg);
-  padding: 12px 14px;
+  padding: 10px 12px;
   z-index: 10;
-  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.45);
-  min-width: 136px;
-  max-width: 220px;
-  backdrop-filter: blur(14px);
-  -webkit-backdrop-filter: blur(14px);
-  transition: background 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+  box-shadow: 0 20px 45px rgba(8, 15, 28, 0.45);
+  min-width: 118px;
+  max-width: 180px;
+  backdrop-filter: blur(18px) saturate(140%);
+  -webkit-backdrop-filter: blur(18px) saturate(140%);
+  transition: background 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease, transform 0.3s ease;
 }
 
 .map-toolbox.collapsed {
-  padding: 10px 12px;
-  gap: 6px;
+  padding: 8px 10px;
+  gap: 4px;
   min-width: auto;
   max-width: none;
 }
@@ -777,18 +778,18 @@ input[type="checkbox"]:checked::after {
 .map-toolbox-header {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   cursor: grab;
   user-select: none;
   padding: 6px 8px;
   border-radius: var(--radius);
-  background: rgba(148, 163, 184, 0.08);
-  transition: background 0.2s ease, box-shadow 0.2s ease;
+  background: rgba(148, 163, 184, 0.12);
+  transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 .map-toolbox-header:hover {
-  background: rgba(148, 163, 184, 0.16);
-  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.26);
+  background: rgba(148, 163, 184, 0.2);
+  box-shadow: 0 10px 22px rgba(8, 15, 28, 0.38);
 }
 
 .map-toolbox-header:active {
@@ -806,55 +807,55 @@ input[type="checkbox"]:checked::after {
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 12px;
-  color: var(--text);
+  font-size: 11.5px;
+  color: rgba(226, 232, 240, 0.92);
   font-weight: 600;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.04em;
   flex: 1;
 }
 
 .map-toolbox-title-icon {
-  font-size: 18px;
+  font-size: 17px;
   line-height: 1;
 }
 
 .map-toolbox-toggle {
-  width: 28px;
-  height: 28px;
+  width: 26px;
+  height: 26px;
   border-radius: 8px;
-  background: rgba(148, 163, 184, 0.16);
-  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(148, 163, 184, 0.18);
+  border: 1px solid rgba(148, 163, 184, 0.28);
   display: grid;
   place-items: center;
-  font-size: 16px;
-  color: var(--text);
+  font-size: 15px;
+  color: rgba(226, 232, 240, 0.92);
   padding: 0;
   cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 .map-toolbox-toggle:hover {
-  background: rgba(148, 163, 184, 0.28);
-  border-color: rgba(148, 163, 184, 0.45);
-  transform: none;
-  box-shadow: 0 6px 12px rgba(15, 23, 42, 0.24);
+  background: rgba(148, 163, 184, 0.3);
+  border-color: rgba(148, 163, 184, 0.5);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 14px rgba(8, 15, 28, 0.32);
 }
 
 .map-tool-list {
   display: grid;
-  gap: 8px;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  justify-items: center;
+  gap: 6px;
+  grid-template-columns: repeat(2, 40px);
+  justify-content: center;
 }
 
 .map-tool {
-  width: 40px;
-  height: 40px;
+  width: 36px;
+  height: 36px;
   border-radius: 12px;
   background: rgba(148, 163, 184, 0.14);
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  color: var(--text);
-  font-size: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  color: rgba(226, 232, 240, 0.9);
+  font-size: 16px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -866,45 +867,46 @@ input[type="checkbox"]:checked::after {
 }
 
 .map-tool:hover {
-  background: rgba(148, 163, 184, 0.28);
+  background: rgba(148, 163, 184, 0.26);
   border-color: rgba(148, 163, 184, 0.45);
   transform: translateY(-1px);
-  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.26);
+  box-shadow: 0 8px 18px rgba(8, 15, 28, 0.32);
 }
 
 .map-tool.active {
-  background: rgba(166, 217, 255, 0.85);
-  color: #0b1120;
-  border-color: rgba(166, 217, 255, 0.9);
-  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.32);
+  background: rgba(166, 217, 255, 0.9);
+  color: #041026;
+  border-color: rgba(166, 217, 255, 0.95);
+  box-shadow: 0 10px 22px rgba(8, 15, 28, 0.36);
+  transform: translateY(-1px);
 }
 
 .map-tool-status {
-  font-size: 11px;
-  line-height: 1.4;
-  color: rgba(226, 232, 240, 0.85);
-  border-top: 1px solid rgba(148, 163, 184, 0.28);
-  padding-top: 8px;
+  font-size: 10.5px;
+  line-height: 1.35;
+  color: rgba(226, 232, 240, 0.82);
+  border-top: 1px solid rgba(148, 163, 184, 0.24);
+  padding-top: 6px;
   text-align: left;
   display: grid;
-  gap: 4px;
+  gap: 3px;
 }
 
 .map-tool-status-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: 6px;
 }
 
 .map-tool-status-row span {
-  color: rgba(148, 163, 184, 0.9);
+  color: rgba(148, 163, 184, 0.78);
   font-weight: 500;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.03em;
 }
 
 .map-tool-status-row strong {
-  color: var(--text);
+  color: rgba(226, 232, 240, 0.95);
   font-weight: 600;
 }
 


### PR DESCRIPTION
## Summary
- add tool-specific cursor assets and logic so hide, break, and add-link modes show appropriate pointers while combining node/link hiding into a single Hide tool
- restyle the map toolbar with a narrower, glassy layout and darken the canvas backdrop for better contrast

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9bc087d8c83229bd312cc4069edc6