### PR TITLE
Restyle toolbar layout and dragging

### DIFF
--- a/js/ui/components/map.js
+++ b/js/ui/components/map.js
@@ -19,29 +19,33 @@ function createCursor(svg, hotX = 8, hotY = 8) {
 const CURSOR_STYLE = {
   hide: createCursor(
     '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">'
-    + '<rect x="8" y="12" width="16" height="10" rx="2" fill="#f97316" transform="rotate(-30 16 17)" />'
-    + '<rect x="12" y="20" width="10" height="6" rx="1.5" fill="#fed7aa" transform="rotate(-30 17 23)" />'
+    + '<path d="M6 19.5l9-9a3 3 0 0 1 4.24 0l6.5 6.5a3 3 0 0 1 0 4.24l-9 9H9a3 3 0 0 1-3-3z" fill="#f97316" />'
+    + '<path d="M8.2 21.2l8.6 8.6" stroke="#fed7aa" stroke-width="3" stroke-linecap="round" />'
+    + '<path d="M11.3 24.5l4 4" stroke="#fff7ed" stroke-width="2" stroke-linecap="round" />'
     + '</svg>',
-    6,
+    7,
     26
   ),
   break: createCursor(
     '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">'
-    + '<circle cx="10" cy="12" r="4" fill="none" stroke="#f97316" stroke-width="2" />'
-    + '<circle cx="10" cy="20" r="4" fill="none" stroke="#f97316" stroke-width="2" />'
-    + '<path d="M6 7l20 18" stroke="#f97316" stroke-width="3" stroke-linecap="round" />'
-    + '<path d="M6 25l20-18" stroke="#f97316" stroke-width="3" stroke-linecap="round" />'
+    + '<circle cx="11" cy="11" r="4" fill="none" stroke="#f97316" stroke-width="2.2" />'
+    + '<circle cx="11" cy="21" r="4" fill="none" stroke="#f97316" stroke-width="2.2" />'
+    + '<path d="M14.5 13L24 3.5" stroke="#fbbf24" stroke-width="2.6" stroke-linecap="round" />'
+    + '<path d="M14.5 19L24 28.5" stroke="#fbbf24" stroke-width="2.6" stroke-linecap="round" />'
+    + '<path d="M6 6l7 7" stroke="#f97316" stroke-width="2.2" stroke-linecap="round" />'
+    + '<path d="M6 26l7-7" stroke="#f97316" stroke-width="2.2" stroke-linecap="round" />'
     + '</svg>',
-    8,
-    26
+    18,
+    18
   ),
   link: createCursor(
     '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">'
-    + '<path d="M12 11h6a5 5 0 0 1 0 10h-3" fill="none" stroke="#38bdf8" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />'
-    + '<path d="M14 15h-4a5 5 0 0 0 0 10h5" fill="none" stroke="#38bdf8" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />'
+    + '<path d="M12 11h5a4.5 4.5 0 0 1 0 9h-3" fill="none" stroke="#38bdf8" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />'
+    + '<path d="M14 15h-4a4.5 4.5 0 0 0 0 9h5" fill="none" stroke="#38bdf8" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />'
+    + '<path d="M13 19h6" stroke="#bae6fd" stroke-width="2" stroke-linecap="round" />'
     + '</svg>',
-    8,
-    24
+    9,
+    23
   )
 };
 
@@ -76,7 +80,6 @@ const mapState = {
   autoPan: null,
   autoPanFrame: null,
   toolboxPos: { x: 16, y: 16 },
-  toolboxCollapsed: false,
   toolboxDrag: null,
   toolboxEl: null,
   toolboxContainer: null,
@@ -691,69 +694,32 @@ function updateEdgesFor(id) {
 function buildToolbox(container, hiddenNodeCount, hiddenLinkCount) {
   const tools = [
     { id: TOOL.NAVIGATE, icon: '🧭', label: 'Navigate' },
-    { id: TOOL.HIDE, icon: '🧽', label: 'Hide' },
+    { id: TOOL.HIDE, icon: '🪄', label: 'Hide' },
     { id: TOOL.BREAK, icon: '✂️', label: 'Break link' },
     { id: TOOL.ADD_LINK, icon: '🔗', label: 'Add link' },
     { id: TOOL.AREA, icon: '📦', label: 'Select area' }
   ];
 
   const box = document.createElement('div');
-  box.className = 'map-toolbox' + (mapState.toolboxCollapsed ? ' collapsed' : '');
+  box.className = 'map-toolbox';
   box.style.left = `${mapState.toolboxPos.x}px`;
   box.style.top = `${mapState.toolboxPos.y}px`;
   mapState.toolboxEl = box;
   mapState.toolboxContainer = container;
 
-  const header = document.createElement('div');
-  header.className = 'map-toolbox-header';
-  header.addEventListener('mousedown', startToolboxDrag);
-
-  header.setAttribute('title', 'Drag to move. Double-click to minimize or maximize.');
-  header.addEventListener('dblclick', evt => {
-    if (evt.target.closest('.map-toolbox-toggle')) return;
-    mapState.toolboxCollapsed = !mapState.toolboxCollapsed;
-    renderMap(mapState.root);
+  box.addEventListener('mousedown', event => {
+    if (event.button !== 0) return;
+    if (event.target.closest('.map-tool') || event.target.closest('.map-toolbox-drag')) return;
+    startToolboxDrag(event);
   });
 
-
-  const handle = document.createElement('span');
-  handle.className = 'map-toolbox-handle';
-  handle.textContent = '⠿';
-  header.appendChild(handle);
-
-  const title = document.createElement('div');
-  title.className = 'map-toolbox-title';
-  const activeTool = tools.find(tool => tool.id === mapState.tool);
-  if (activeTool) {
-    const icon = document.createElement('span');
-    icon.className = 'map-toolbox-title-icon';
-    icon.textContent = activeTool.icon;
-    title.appendChild(icon);
-    const label = document.createElement('span');
-    label.textContent = activeTool.label;
-    title.appendChild(label);
-  } else {
-    title.textContent = 'Tools';
-  }
-  header.appendChild(title);
-
-  const toggle = document.createElement('button');
-  toggle.type = 'button';
-  toggle.className = 'map-toolbox-toggle';
-
-  const toggleLabel = mapState.toolboxCollapsed ? 'Maximize toolbar' : 'Minimize toolbar';
-  toggle.setAttribute('aria-label', toggleLabel);
-  toggle.title = toggleLabel;
-  toggle.textContent = mapState.toolboxCollapsed ? '⤢' : '—';
-
-  toggle.addEventListener('click', evt => {
-    evt.stopPropagation();
-    mapState.toolboxCollapsed = !mapState.toolboxCollapsed;
-    renderMap(mapState.root);
-  });
-  header.appendChild(toggle);
-
-  box.appendChild(header);
+  const handle = document.createElement('button');
+  handle.type = 'button';
+  handle.className = 'map-toolbox-drag';
+  handle.setAttribute('aria-label', 'Drag toolbar');
+  handle.innerHTML = '<span>⋮</span>';
+  handle.addEventListener('mousedown', startToolboxDrag);
+  box.appendChild(handle);
 
   const list = document.createElement('div');
   list.className = 'map-tool-list';
@@ -785,13 +751,21 @@ function buildToolbox(container, hiddenNodeCount, hiddenLinkCount) {
   });
   box.appendChild(list);
 
-  const status = document.createElement('div');
-  status.className = 'map-tool-status';
-  status.innerHTML = `
-    <div class="map-tool-status-row"><span>Nodes hidden</span><strong>${hiddenNodeCount}</strong></div>
-    <div class="map-tool-status-row"><span>Links hidden</span><strong>${hiddenLinkCount}</strong></div>
-  `.trim();
-  box.appendChild(status);
+  const badges = document.createElement('div');
+  badges.className = 'map-tool-badges';
+  const nodeBadge = document.createElement('span');
+  nodeBadge.className = 'map-tool-badge';
+  nodeBadge.setAttribute('title', `${hiddenNodeCount} hidden node${hiddenNodeCount === 1 ? '' : 's'}`);
+  nodeBadge.innerHTML = `<span>🙈</span><strong>${hiddenNodeCount}</strong>`;
+  badges.appendChild(nodeBadge);
+
+  const linkBadge = document.createElement('span');
+  linkBadge.className = 'map-tool-badge';
+  linkBadge.setAttribute('title', `${hiddenLinkCount} hidden link${hiddenLinkCount === 1 ? '' : 's'}`);
+  linkBadge.innerHTML = `<span>🕸️</span><strong>${hiddenLinkCount}</strong>`;
+  badges.appendChild(linkBadge);
+
+  box.appendChild(badges);
 
   container.appendChild(box);
   ensureToolboxWithinBounds();
@@ -1022,10 +996,18 @@ function ensureToolboxWithinBounds() {
 
 function determineBaseCursor() {
   if (mapState.draggingView || mapState.nodeDrag || mapState.areaDrag) return 'grabbing';
-  if (mapState.tool === TOOL.AREA) return 'crosshair';
-
-  if (mapState.tool === TOOL.NAVIGATE) return 'grab';
-  return 'pointer';
+  switch (mapState.tool) {
+    case TOOL.AREA:
+      return 'crosshair';
+    case TOOL.NAVIGATE:
+      return 'grab';
+    case TOOL.HIDE:
+    case TOOL.BREAK:
+    case TOOL.ADD_LINK:
+      return 'grab';
+    default:
+      return 'pointer';
+  }
 }
 
 function refreshCursor(options = {}) {

--- a/style.css
+++ b/style.css
@@ -689,8 +689,10 @@ input[type="checkbox"]:checked::after {
   width: 100%;
   height: 100%;
   cursor: grab;
-  background: var(--muted);
-  border-top: 1px solid var(--border);
+  background:
+    radial-gradient(circle at 18% 22%, rgba(148, 163, 184, 0.12), transparent 58%),
+    linear-gradient(160deg, #0b1422 0%, #0a101b 45%, #05070d 100%);
+  border-top: 1px solid rgba(148, 163, 184, 0.24);
 }
 .map-node {
   cursor: inherit;
@@ -745,167 +747,112 @@ input[type="checkbox"]:checked::after {
   position: absolute;
   top: 16px;
   left: 16px;
-  display: flex;
-  flex-direction: column;
-
+  display: inline-flex;
+  align-items: center;
   gap: 10px;
-  background: rgba(15, 23, 42, 0.55);
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  border-radius: var(--radius-lg);
-  padding: 12px 14px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.28);
+  border: 1px solid rgba(148, 163, 184, 0.38);
+  box-shadow: 0 18px 38px rgba(8, 15, 28, 0.42);
+  backdrop-filter: blur(16px) saturate(150%);
+  -webkit-backdrop-filter: blur(16px) saturate(150%);
   z-index: 10;
-  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.45);
-  min-width: 136px;
-  max-width: 220px;
-  backdrop-filter: blur(14px);
-  -webkit-backdrop-filter: blur(14px);
-  transition: background 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.map-toolbox.collapsed {
-  padding: 10px 12px;
-  gap: 6px;
-  min-width: auto;
-  max-width: none;
+.map-toolbox:hover {
+  background: rgba(15, 23, 42, 0.36);
+  border-color: rgba(203, 213, 225, 0.45);
+  box-shadow: 0 20px 42px rgba(8, 15, 28, 0.48);
 }
 
-.map-toolbox.collapsed .map-tool-list,
-.map-toolbox.collapsed .map-tool-status {
-  display: none;
-}
-
-.map-toolbox-header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  cursor: grab;
-  user-select: none;
-  padding: 6px 8px;
-  border-radius: var(--radius);
-  background: rgba(148, 163, 184, 0.08);
-  transition: background 0.2s ease, box-shadow 0.2s ease;
-}
-
-.map-toolbox-header:hover {
-  background: rgba(148, 163, 184, 0.16);
-  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.26);
-}
-
-.map-toolbox-header:active {
-  cursor: grabbing;
-}
-
-.map-toolbox-handle {
-  font-size: 14px;
-  color: rgba(148, 163, 184, 0.75);
-  line-height: 1;
-  letter-spacing: 1px;
-}
-
-.map-toolbox-title {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 12px;
-  color: var(--text);
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  flex: 1;
-}
-
-.map-toolbox-title-icon {
-  font-size: 18px;
-  line-height: 1;
-}
-
-.map-toolbox-toggle {
+.map-toolbox-drag {
   width: 28px;
   height: 28px;
-  border-radius: 8px;
+  border-radius: 999px;
   background: rgba(148, 163, 184, 0.16);
   border: 1px solid rgba(148, 163, 184, 0.35);
   display: grid;
   place-items: center;
-  font-size: 16px;
-  color: var(--text);
+  font-size: 14px;
+  color: rgba(226, 232, 240, 0.85);
+  cursor: grab;
   padding: 0;
-  cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.map-toolbox-toggle:hover {
-  background: rgba(148, 163, 184, 0.28);
-  border-color: rgba(148, 163, 184, 0.45);
-  transform: none;
-  box-shadow: 0 6px 12px rgba(15, 23, 42, 0.24);
+.map-toolbox-drag:hover {
+  background: rgba(148, 163, 184, 0.26);
+  border-color: rgba(203, 213, 225, 0.45);
+  box-shadow: 0 10px 24px rgba(8, 15, 28, 0.35);
+}
+
+.map-toolbox-drag:active {
+  cursor: grabbing;
+  transform: scale(0.96);
 }
 
 .map-tool-list {
-  display: grid;
-  gap: 8px;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  justify-items: center;
+  display: inline-flex;
+  gap: 6px;
 }
 
 .map-tool {
-  width: 40px;
-  height: 40px;
+  width: 32px;
+  height: 32px;
   border-radius: 12px;
   background: rgba(148, 163, 184, 0.14);
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  color: var(--text);
-  font-size: 18px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  color: rgba(226, 232, 240, 0.92);
+  font-size: 17px;
+  display: grid;
+  place-items: center;
   cursor: pointer;
-  transition: background 0.2s ease, transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
   padding: 0;
-  line-height: 1;
-  box-shadow: none;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .map-tool:hover {
   background: rgba(148, 163, 184, 0.28);
-  border-color: rgba(148, 163, 184, 0.45);
+  border-color: rgba(203, 213, 225, 0.5);
+  box-shadow: 0 10px 20px rgba(8, 15, 28, 0.34);
   transform: translateY(-1px);
-  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.26);
 }
 
 .map-tool.active {
-  background: rgba(166, 217, 255, 0.85);
-  color: #0b1120;
-  border-color: rgba(166, 217, 255, 0.9);
-  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.32);
+  background: rgba(166, 217, 255, 0.95);
+  color: #041026;
+  border-color: rgba(166, 217, 255, 1);
+  box-shadow: 0 12px 26px rgba(8, 15, 28, 0.4);
 }
 
-.map-tool-status {
-  font-size: 11px;
-  line-height: 1.4;
-  color: rgba(226, 232, 240, 0.85);
-  border-top: 1px solid rgba(148, 163, 184, 0.28);
-  padding-top: 8px;
-  text-align: left;
-  display: grid;
-  gap: 4px;
+.map-tool-badges {
+  display: inline-flex;
+  gap: 6px;
 }
 
-.map-tool-status-row {
-  display: flex;
+.map-tool-badge {
+  display: inline-flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 8px;
+  gap: 4px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.18);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  color: rgba(226, 232, 240, 0.88);
+  font-size: 11px;
+  line-height: 1;
 }
 
-.map-tool-status-row span {
-  color: rgba(148, 163, 184, 0.9);
-  font-weight: 500;
-  letter-spacing: 0.02em;
+.map-tool-badge span {
+  font-size: 12px;
 }
 
-.map-tool-status-row strong {
-  color: var(--text);
+.map-tool-badge strong {
   font-weight: 600;
+  color: rgba(226, 232, 240, 0.96);
+  font-size: 11px;
 }
 
 .map-hidden-panel {


### PR DESCRIPTION
## Summary
- reshape the concept map toolbar into a single-row glass panel with a drag handle, cute hide icon, and hidden counts badges
- update the runtime logic so the floating toolbar remembers its position and can be dragged anywhere on the canvas

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9bc087d8c83229bd312cc4069edc6