### PR TITLE
Improve concept map area selection UX

### DIFF
--- a/style.css
+++ b/style.css
@@ -743,6 +743,11 @@ input[type="checkbox"]:checked::after {
   height: 100%;
 }
 
+.map-area-interacting {
+  user-select: none;
+  -webkit-user-select: none;
+}
+
 .map-toolbox {
   position: absolute;
   top: 16px;


### PR DESCRIPTION
## Summary
- track concept map area interactions so dragging selections prevents unwanted text highlighting
- reuse a pointer-down handler for nodes to keep navigation and area drags consistent with current positions
- add a temporary `.map-area-interacting` style to suppress text selection while the area tool is active

## Testing
- `npx esbuild js/main.js --bundle --format=iife --global-name=Sevenn --outfile=bundle.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c9d14d8a888322a81ffada257426bd