### PR TITLE
Revamp exams experience

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -495,6 +495,10 @@ var Sevenn = (() => {
     };
     await prom2(e.put(next));
   }
+  async function deleteExam(id) {
+    const e = await store("exams", "readwrite");
+    await prom2(e.delete(id));
+  }
 
   // js/ui/components/confirm.js
   function confirmModal(message) {
@@ -2041,74 +2045,1044 @@ var Sevenn = (() => {
   }
 
   // js/ui/components/exams.js
+  var DEFAULT_SECONDS = 60;
+  function clone(value) {
+    return value ? JSON.parse(JSON.stringify(value)) : value;
+  }
+  function ensureExamShape(exam) {
+    const next = clone(exam) || {};
+    let changed = false;
+    if (!next.id) {
+      next.id = uid();
+      changed = true;
+    }
+    if (!next.examTitle) {
+      next.examTitle = "Untitled Exam";
+      changed = true;
+    }
+    if (next.timerMode !== "timed") {
+      if (next.timerMode !== "untimed") changed = true;
+      next.timerMode = "untimed";
+    }
+    if (typeof next.secondsPerQuestion !== "number" || next.secondsPerQuestion <= 0) {
+      next.secondsPerQuestion = DEFAULT_SECONDS;
+      changed = true;
+    }
+    if (!Array.isArray(next.questions)) {
+      next.questions = [];
+      changed = true;
+    }
+    next.questions = next.questions.map((q) => {
+      const question = { ...q };
+      if (!question.id) {
+        question.id = uid();
+        changed = true;
+      }
+      question.stem = question.stem ? String(question.stem) : "";
+      if (!Array.isArray(question.options)) {
+        question.options = [];
+        changed = true;
+      }
+      question.options = question.options.map((opt) => {
+        const option = { ...opt };
+        if (!option.id) {
+          option.id = uid();
+          changed = true;
+        }
+        option.text = option.text ? String(option.text) : "";
+        return option;
+      });
+      if (!question.answer || !question.options.some((opt) => opt.id === question.answer)) {
+        question.answer = question.options[0]?.id || "";
+        changed = true;
+      }
+      if (question.explanation == null) {
+        question.explanation = "";
+        changed = true;
+      }
+      if (!Array.isArray(question.tags)) {
+        if (question.tags == null) question.tags = [];
+        else question.tags = Array.isArray(question.tags) ? question.tags : [String(question.tags)];
+        changed = true;
+      }
+      question.tags = question.tags.map((t) => String(t)).filter(Boolean);
+      if (question.media == null) {
+        question.media = "";
+        changed = true;
+      }
+      return question;
+    });
+    if (!Array.isArray(next.results)) {
+      next.results = [];
+      changed = true;
+    }
+    next.results = next.results.map((res) => {
+      const result = { ...res };
+      if (!result.id) {
+        result.id = uid();
+        changed = true;
+      }
+      if (typeof result.when !== "number") {
+        result.when = Date.now();
+        changed = true;
+      }
+      if (typeof result.correct !== "number") {
+        result.correct = Number(result.correct) || 0;
+        changed = true;
+      }
+      if (typeof result.total !== "number") {
+        result.total = Number(result.total) || (next.questions?.length ?? 0);
+        changed = true;
+      }
+      if (!result.answers || typeof result.answers !== "object") {
+        result.answers = {};
+        changed = true;
+      }
+      if (!Array.isArray(result.flagged)) {
+        result.flagged = [];
+        changed = true;
+      }
+      if (typeof result.durationMs !== "number") {
+        result.durationMs = 0;
+        changed = true;
+      }
+      if (typeof result.answered !== "number") {
+        result.answered = Object.keys(result.answers || {}).length;
+        changed = true;
+      }
+      return result;
+    });
+    return { exam: next, changed };
+  }
+  function createBlankQuestion() {
+    return {
+      id: uid(),
+      stem: "",
+      options: [1, 2, 3, 4].map(() => ({ id: uid(), text: "" })),
+      answer: "",
+      explanation: "",
+      tags: [],
+      media: ""
+    };
+  }
+  function createTakingSession(exam) {
+    return {
+      mode: "taking",
+      exam: clone(exam),
+      idx: 0,
+      answers: {},
+      flagged: {},
+      startedAt: Date.now()
+    };
+  }
   async function renderExams(root, render2) {
     root.innerHTML = "";
+    root.className = "exam-view";
+    const controls = document.createElement("div");
+    controls.className = "exam-controls";
+    const heading = document.createElement("div");
+    heading.className = "exam-heading";
+    heading.innerHTML = "<h1>Exams</h1><p>Import exams, take them, and review your attempts.</p>";
+    controls.appendChild(heading);
+    const actions = document.createElement("div");
+    actions.className = "exam-control-actions";
+    const status = document.createElement("div");
+    status.className = "exam-status";
     const fileInput = document.createElement("input");
     fileInput.type = "file";
     fileInput.accept = "application/json";
+    fileInput.style.display = "none";
     fileInput.addEventListener("change", async (e) => {
-      const file = e.target.files[0];
+      const file = e.target.files?.[0];
       if (!file) return;
       try {
         const text = await file.text();
-        const exam = JSON.parse(text);
-        exam.id = exam.id || crypto.randomUUID();
-        exam.createdAt = exam.createdAt || Date.now();
-        exam.updatedAt = Date.now();
-        exam.results = exam.results || [];
-        await upsertExam(exam);
+        const parsed = JSON.parse(text);
+        const { exam } = ensureExamShape(parsed);
+        await upsertExam({ ...exam, updatedAt: Date.now() });
         render2();
       } catch (err) {
-        alert("Invalid exam JSON");
+        console.warn("Failed to import exam", err);
+        status.textContent = "Unable to import exam \u2014 invalid JSON structure.";
+      } finally {
+        fileInput.value = "";
       }
     });
+    const importBtn = document.createElement("button");
+    importBtn.type = "button";
+    importBtn.className = "btn secondary";
+    importBtn.textContent = "Import Exam";
+    importBtn.addEventListener("click", () => fileInput.click());
+    actions.appendChild(importBtn);
+    const newBtn = document.createElement("button");
+    newBtn.type = "button";
+    newBtn.className = "btn";
+    newBtn.textContent = "New Exam";
+    newBtn.addEventListener("click", () => openExamEditor(null, render2));
+    actions.appendChild(newBtn);
+    controls.appendChild(actions);
+    controls.appendChild(status);
+    root.appendChild(controls);
     root.appendChild(fileInput);
-    const exams = await listExams();
-    const list = document.createElement("div");
-    exams.forEach((ex) => {
-      const row = document.createElement("div");
-      row.className = "row";
-      const title = document.createElement("span");
-      title.textContent = ex.examTitle;
-      const start = document.createElement("button");
-      start.className = "btn";
-      start.textContent = "Start";
-      start.addEventListener("click", () => {
-        setExamSession({ exam: ex, idx: 0, answers: [] });
+    const stored = await listExams();
+    const exams = [];
+    for (const raw of stored) {
+      const { exam, changed } = ensureExamShape(raw);
+      exams.push(exam);
+      if (changed) await upsertExam(exam);
+    }
+    exams.sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
+    if (!exams.length) {
+      const empty = document.createElement("div");
+      empty.className = "exam-empty";
+      empty.innerHTML = "<p>No exams yet. Import a JSON exam or create one from scratch.</p>";
+      root.appendChild(empty);
+      return;
+    }
+    const grid = document.createElement("div");
+    grid.className = "exam-grid";
+    exams.forEach((exam) => {
+      grid.appendChild(buildExamCard(exam, render2));
+    });
+    root.appendChild(grid);
+  }
+  function buildExamCard(exam, render2) {
+    const card = document.createElement("article");
+    card.className = "card exam-card";
+    const title = document.createElement("h2");
+    title.className = "exam-card-title";
+    title.textContent = exam.examTitle;
+    card.appendChild(title);
+    const meta = document.createElement("div");
+    meta.className = "exam-card-meta";
+    const questionCount = document.createElement("span");
+    questionCount.textContent = `${exam.questions.length} question${exam.questions.length === 1 ? "" : "s"}`;
+    meta.appendChild(questionCount);
+    if (exam.timerMode === "timed") {
+      const timed = document.createElement("span");
+      timed.textContent = `Timed \u2022 ${exam.secondsPerQuestion}s/question`;
+      meta.appendChild(timed);
+    } else {
+      const timed = document.createElement("span");
+      timed.textContent = "Untimed";
+      meta.appendChild(timed);
+    }
+    card.appendChild(meta);
+    const stats = document.createElement("div");
+    stats.className = "exam-card-stats";
+    stats.appendChild(createStat("Attempts", String(exam.results.length)));
+    const last = latestResult(exam);
+    if (last) {
+      stats.appendChild(createStat("Last Score", formatScore(last)));
+      const best = bestResult(exam);
+      if (best) stats.appendChild(createStat("Best Score", formatScore(best)));
+    } else {
+      stats.appendChild(createStat("Last Score", "\u2014"));
+      stats.appendChild(createStat("Best Score", "\u2014"));
+    }
+    card.appendChild(stats);
+    const actions = document.createElement("div");
+    actions.className = "exam-card-actions";
+    const startBtn = document.createElement("button");
+    startBtn.className = "btn";
+    startBtn.textContent = "Start Exam";
+    startBtn.disabled = exam.questions.length === 0;
+    startBtn.addEventListener("click", () => {
+      setExamSession(createTakingSession(exam));
+      render2();
+    });
+    actions.appendChild(startBtn);
+    if (last) {
+      const reviewBtn = document.createElement("button");
+      reviewBtn.className = "btn secondary";
+      reviewBtn.textContent = "Review Last Attempt";
+      reviewBtn.addEventListener("click", () => {
+        setExamSession({ mode: "review", exam: clone(exam), result: clone(last), idx: 0 });
         render2();
       });
-      row.appendChild(title);
-      row.appendChild(start);
-      list.appendChild(row);
+      actions.appendChild(reviewBtn);
+    }
+    const editBtn = document.createElement("button");
+    editBtn.className = "btn secondary";
+    editBtn.textContent = "Edit";
+    editBtn.addEventListener("click", () => openExamEditor(exam, render2));
+    actions.appendChild(editBtn);
+    const delBtn = document.createElement("button");
+    delBtn.className = "btn danger";
+    delBtn.textContent = "Delete";
+    delBtn.addEventListener("click", async () => {
+      const ok = await confirmModal(`Delete "${exam.examTitle}"? This will remove all attempts.`);
+      if (!ok) return;
+      await deleteExam(exam.id);
+      render2();
     });
-    root.appendChild(list);
+    actions.appendChild(delBtn);
+    card.appendChild(actions);
+    const attemptsWrap = document.createElement("div");
+    attemptsWrap.className = "exam-attempts";
+    const attemptsTitle = document.createElement("h3");
+    attemptsTitle.textContent = "Attempts";
+    attemptsWrap.appendChild(attemptsTitle);
+    if (!exam.results.length) {
+      const none = document.createElement("p");
+      none.className = "exam-attempt-empty";
+      none.textContent = "No attempts yet.";
+      attemptsWrap.appendChild(none);
+    } else {
+      const list = document.createElement("div");
+      list.className = "exam-attempt-list";
+      [...exam.results].sort((a, b) => b.when - a.when).forEach((result) => {
+        list.appendChild(buildAttemptRow(exam, result, render2));
+      });
+      attemptsWrap.appendChild(list);
+    }
+    card.appendChild(attemptsWrap);
+    return card;
+  }
+  function buildAttemptRow(exam, result, render2) {
+    const row = document.createElement("div");
+    row.className = "exam-attempt-row";
+    const info = document.createElement("div");
+    info.className = "exam-attempt-info";
+    const title = document.createElement("div");
+    title.className = "exam-attempt-score";
+    title.textContent = formatScore(result);
+    info.appendChild(title);
+    const meta = document.createElement("div");
+    meta.className = "exam-attempt-meta";
+    const date = new Date(result.when).toLocaleString();
+    const answeredText = `${result.answered}/${result.total} answered`;
+    const flaggedText = `${result.flagged.length} flagged`;
+    const durationText = result.durationMs ? formatDuration(result.durationMs) : "\u2014";
+    meta.textContent = `${date} \u2022 ${answeredText} \u2022 ${flaggedText} \u2022 ${durationText}`;
+    info.appendChild(meta);
+    row.appendChild(info);
+    const review = document.createElement("button");
+    review.className = "btn secondary";
+    review.textContent = "Review";
+    review.addEventListener("click", () => {
+      setExamSession({ mode: "review", exam: clone(exam), result: clone(result), idx: 0 });
+      render2();
+    });
+    row.appendChild(review);
+    return row;
+  }
+  function createStat(label, value) {
+    const wrap = document.createElement("div");
+    wrap.className = "exam-stat";
+    const lbl = document.createElement("div");
+    lbl.className = "exam-stat-label";
+    lbl.textContent = label;
+    const val = document.createElement("div");
+    val.className = "exam-stat-value";
+    val.textContent = value;
+    wrap.appendChild(lbl);
+    wrap.appendChild(val);
+    return wrap;
+  }
+  function latestResult(exam) {
+    if (!exam.results?.length) return null;
+    return exam.results.reduce((acc, res) => acc == null || res.when > acc.when ? res : acc, null);
+  }
+  function bestResult(exam) {
+    if (!exam.results?.length) return null;
+    return exam.results.reduce((acc, res) => {
+      const pct = res.total ? res.correct / res.total : 0;
+      const bestPct = acc?.total ? acc.correct / acc.total : -1;
+      if (!acc || pct > bestPct) return res;
+      return acc;
+    }, null);
+  }
+  function formatScore(result) {
+    const pct = result.total ? Math.round(result.correct / result.total * 100) : 0;
+    return `${result.correct}/${result.total} \u2022 ${pct}%`;
+  }
+  function formatDuration(ms) {
+    if (!ms) return "\u2014";
+    const totalSeconds = Math.max(0, Math.round(ms / 1e3));
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor(totalSeconds % 3600 / 60);
+    const seconds = totalSeconds % 60;
+    const parts = [];
+    if (hours) parts.push(`${hours}h`);
+    if (minutes) parts.push(`${minutes}m`);
+    parts.push(`${seconds}s`);
+    return parts.join(" ");
+  }
+  function optionText(question, id) {
+    return question.options.find((opt) => opt.id === id)?.text || "";
+  }
+  function mediaElement(source) {
+    if (!source) return null;
+    const wrap = document.createElement("div");
+    wrap.className = "exam-media";
+    const lower = source.toLowerCase();
+    if (lower.startsWith("data:video") || /\.(mp4|webm|ogg)$/i.test(lower)) {
+      const video = document.createElement("video");
+      video.controls = true;
+      video.src = source;
+      wrap.appendChild(video);
+    } else if (lower.startsWith("data:audio") || /\.(mp3|wav|ogg)$/i.test(lower)) {
+      const audio = document.createElement("audio");
+      audio.controls = true;
+      audio.src = source;
+      wrap.appendChild(audio);
+    } else {
+      const img = document.createElement("img");
+      img.src = source;
+      img.alt = "Question media";
+      wrap.appendChild(img);
+    }
+    return wrap;
+  }
+  function answerClass(question, selectedId, optionId) {
+    const isCorrect = optionId === question.answer;
+    if (selectedId == null) return isCorrect ? "correct-answer" : "";
+    if (selectedId === optionId) {
+      return selectedId === question.answer ? "correct-answer" : "incorrect-answer";
+    }
+    return isCorrect ? "correct-answer" : "";
+  }
+  function renderPalette(sidebar, sess, render2) {
+    const palette = document.createElement("div");
+    palette.className = "exam-palette";
+    const title = document.createElement("h3");
+    title.textContent = "Question Map";
+    palette.appendChild(title);
+    const grid = document.createElement("div");
+    grid.className = "exam-palette-grid";
+    const answers = sess.mode === "review" ? sess.result.answers || {} : sess.answers || {};
+    const flaggedSet = new Set(sess.mode === "review" ? sess.result.flagged || [] : Object.entries(sess.flagged || {}).filter(([_, v]) => v).map(([idx]) => Number(idx)));
+    sess.exam.questions.forEach((_, idx) => {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.textContent = String(idx + 1);
+      btn.className = "palette-button";
+      if (sess.idx === idx) btn.classList.add("active");
+      if (answers[idx] != null) btn.classList.add("answered");
+      if (flaggedSet.has(idx)) btn.classList.add("flagged");
+      btn.addEventListener("click", () => {
+        sess.idx = idx;
+        render2();
+      });
+      grid.appendChild(btn);
+    });
+    palette.appendChild(grid);
+    sidebar.appendChild(palette);
   }
   function renderExamRunner(root, render2) {
     const sess = state.examSession;
-    const q = sess.exam.questions[sess.idx];
+    if (!sess) return;
     root.innerHTML = "";
-    const h = document.createElement("h2");
-    h.textContent = `Question ${sess.idx + 1} / ${sess.exam.questions.length}`;
-    root.appendChild(h);
-    const stem = document.createElement("p");
-    stem.textContent = q.stem;
-    root.appendChild(stem);
-    q.options.forEach((opt) => {
-      const btn = document.createElement("button");
-      btn.className = "btn";
-      btn.textContent = opt.text;
-      btn.addEventListener("click", () => {
-        sess.answers.push(opt.id);
-        sess.idx++;
-        if (sess.idx >= sess.exam.questions.length) {
-          const correct = sess.exam.questions.filter((qu, i) => sess.answers[i] === qu.answer).length;
-          alert(`Score: ${correct}/${sess.exam.questions.length}`);
-          setExamSession(null);
-        }
+    root.className = "exam-session";
+    if (sess.mode === "summary") {
+      renderSummary(root, render2, sess);
+      return;
+    }
+    const questionCount = sess.exam.questions.length;
+    if (!questionCount) {
+      const empty = document.createElement("div");
+      empty.className = "exam-empty";
+      empty.innerHTML = "<p>This exam does not contain any questions.</p>";
+      const back = document.createElement("button");
+      back.className = "btn";
+      back.textContent = "Back to Exams";
+      back.addEventListener("click", () => {
+        setExamSession(null);
         render2();
       });
-      root.appendChild(btn);
+      empty.appendChild(back);
+      root.appendChild(empty);
+      return;
+    }
+    if (sess.idx < 0) sess.idx = 0;
+    if (sess.idx >= questionCount) sess.idx = questionCount - 1;
+    const container = document.createElement("div");
+    container.className = "exam-runner";
+    root.appendChild(container);
+    const main = document.createElement("section");
+    main.className = "exam-main";
+    container.appendChild(main);
+    const sidebar = document.createElement("aside");
+    sidebar.className = "exam-sidebar";
+    container.appendChild(sidebar);
+    const question = sess.exam.questions[sess.idx];
+    const answers = sess.mode === "review" ? sess.result.answers || {} : sess.answers || {};
+    const selected = answers[sess.idx];
+    const top = document.createElement("div");
+    top.className = "exam-topbar";
+    const progress = document.createElement("div");
+    progress.className = "exam-progress";
+    progress.textContent = `${sess.exam.examTitle} \u2022 Question ${sess.idx + 1} of ${questionCount}`;
+    top.appendChild(progress);
+    const flagBtn = document.createElement("button");
+    flagBtn.type = "button";
+    flagBtn.className = "flag-btn";
+    const isFlagged = sess.mode === "review" ? (sess.result.flagged || []).includes(sess.idx) : Boolean(sess.flagged?.[sess.idx]);
+    flagBtn.classList.toggle("active", isFlagged);
+    flagBtn.textContent = isFlagged ? "\u{1F6A9} Flagged" : "Flag question";
+    if (sess.mode === "taking") {
+      flagBtn.addEventListener("click", () => {
+        if (!sess.flagged) sess.flagged = {};
+        sess.flagged[sess.idx] = !isFlagged;
+        render2();
+      });
+    } else {
+      flagBtn.disabled = true;
+    }
+    top.appendChild(flagBtn);
+    main.appendChild(top);
+    const stem = document.createElement("div");
+    stem.className = "exam-stem";
+    stem.textContent = question.stem || "(No prompt)";
+    main.appendChild(stem);
+    const media = mediaElement(question.media);
+    if (media) main.appendChild(media);
+    if (question.tags?.length) {
+      const tagWrap = document.createElement("div");
+      tagWrap.className = "exam-tags";
+      question.tags.forEach((tag) => {
+        const chip = document.createElement("span");
+        chip.className = "exam-tag";
+        chip.textContent = tag;
+        tagWrap.appendChild(chip);
+      });
+      main.appendChild(tagWrap);
+    }
+    const optionsWrap = document.createElement("div");
+    optionsWrap.className = "exam-options";
+    if (!question.options.length) {
+      const warn = document.createElement("p");
+      warn.className = "exam-warning";
+      warn.textContent = "This question has no answer options.";
+      optionsWrap.appendChild(warn);
+    }
+    question.options.forEach((opt) => {
+      const choice = document.createElement(sess.mode === "taking" ? "button" : "div");
+      if (sess.mode === "taking") choice.type = "button";
+      choice.className = "exam-option";
+      if (sess.mode === "review") choice.classList.add("review");
+      choice.textContent = opt.text || "(Empty option)";
+      if (sess.mode === "taking") {
+        if (selected === opt.id) choice.classList.add("selected");
+        choice.addEventListener("click", () => {
+          sess.answers[sess.idx] = opt.id;
+          render2();
+        });
+      } else {
+        const cls = answerClass(question, selected, opt.id);
+        if (cls) choice.classList.add(cls);
+        if (selected === opt.id) choice.classList.add("chosen");
+      }
+      optionsWrap.appendChild(choice);
     });
+    main.appendChild(optionsWrap);
+    if (sess.mode === "review") {
+      const verdict = document.createElement("div");
+      verdict.className = "exam-verdict";
+      let verdictText = "Not answered";
+      let verdictClass = "neutral";
+      if (selected != null) {
+        if (selected === question.answer) {
+          verdictText = "Correct";
+          verdictClass = "correct";
+        } else {
+          verdictText = "Incorrect";
+          verdictClass = "incorrect";
+        }
+      }
+      verdict.classList.add(verdictClass);
+      verdict.textContent = verdictText;
+      main.appendChild(verdict);
+      const answerSummary = document.createElement("div");
+      answerSummary.className = "exam-answer-summary";
+      const your = optionText(question, selected);
+      const correct = optionText(question, question.answer);
+      answerSummary.innerHTML = `<div><strong>Your answer:</strong> ${your || "\u2014"}</div><div><strong>Correct answer:</strong> ${correct || "\u2014"}</div>`;
+      main.appendChild(answerSummary);
+      if (question.explanation) {
+        const explain = document.createElement("div");
+        explain.className = "exam-explanation";
+        const title = document.createElement("h3");
+        title.textContent = "Explanation";
+        const body = document.createElement("p");
+        body.textContent = question.explanation;
+        explain.appendChild(title);
+        explain.appendChild(body);
+        main.appendChild(explain);
+      }
+    }
+    renderPalette(sidebar, sess, render2);
+    renderSidebarMeta(sidebar, sess);
+    const nav = document.createElement("div");
+    nav.className = "exam-nav";
+    const prev = document.createElement("button");
+    prev.className = "btn secondary";
+    prev.textContent = "Previous";
+    prev.disabled = sess.idx === 0;
+    prev.addEventListener("click", () => {
+      if (sess.idx > 0) {
+        sess.idx -= 1;
+        render2();
+      }
+    });
+    nav.appendChild(prev);
+    if (sess.mode === "taking") {
+      const nextBtn = document.createElement("button");
+      nextBtn.className = "btn secondary";
+      nextBtn.textContent = "Next Question";
+      nextBtn.disabled = sess.idx >= questionCount - 1;
+      nextBtn.addEventListener("click", () => {
+        if (sess.idx < questionCount - 1) {
+          sess.idx += 1;
+          render2();
+        }
+      });
+      nav.appendChild(nextBtn);
+      const submit = document.createElement("button");
+      submit.className = "btn";
+      submit.textContent = "Submit Exam";
+      submit.addEventListener("click", async () => {
+        await finalizeExam(sess, render2);
+      });
+      nav.appendChild(submit);
+    } else {
+      const nextBtn = document.createElement("button");
+      nextBtn.className = "btn secondary";
+      nextBtn.textContent = "Next";
+      nextBtn.disabled = sess.idx >= questionCount - 1;
+      nextBtn.addEventListener("click", () => {
+        if (sess.idx < questionCount - 1) {
+          sess.idx += 1;
+          render2();
+        }
+      });
+      nav.appendChild(nextBtn);
+      const exit = document.createElement("button");
+      exit.className = "btn";
+      if (sess.fromSummary) {
+        exit.textContent = "Back to Summary";
+        exit.addEventListener("click", () => {
+          setExamSession({ mode: "summary", exam: sess.exam, latestResult: sess.fromSummary });
+          render2();
+        });
+      } else {
+        exit.textContent = "Back to Exams";
+        exit.addEventListener("click", () => {
+          setExamSession(null);
+          render2();
+        });
+      }
+      nav.appendChild(exit);
+    }
+    root.appendChild(nav);
+  }
+  function renderSidebarMeta(sidebar, sess) {
+    const info = document.createElement("div");
+    info.className = "exam-sidebar-info";
+    const attempts = document.createElement("div");
+    attempts.innerHTML = `<strong>Attempts:</strong> ${sess.exam.results?.length || 0}`;
+    info.appendChild(attempts);
+    if (sess.mode === "review" && sess.result.durationMs) {
+      const duration = document.createElement("div");
+      duration.innerHTML = `<strong>Duration:</strong> ${formatDuration(sess.result.durationMs)}`;
+      info.appendChild(duration);
+    } else if (sess.mode === "taking") {
+      const timerMode = document.createElement("div");
+      if (sess.exam.timerMode === "timed") {
+        timerMode.innerHTML = `<strong>Timer:</strong> Timed (${sess.exam.secondsPerQuestion}s/question)`;
+      } else {
+        timerMode.innerHTML = "<strong>Timer:</strong> Untimed";
+      }
+      info.appendChild(timerMode);
+    }
+    sidebar.appendChild(info);
+  }
+  async function finalizeExam(sess, render2) {
+    const unanswered = sess.exam.questions.filter((_, idx) => sess.answers[idx] == null);
+    if (unanswered.length) {
+      const confirm2 = await confirmModal(`You have ${unanswered.length} unanswered question${unanswered.length === 1 ? "" : "s"}. Submit anyway?`);
+      if (!confirm2) return;
+    }
+    const answers = {};
+    let correct = 0;
+    let answeredCount = 0;
+    sess.exam.questions.forEach((question, idx) => {
+      const ans = sess.answers[idx];
+      if (ans != null) {
+        answers[idx] = ans;
+        answeredCount += 1;
+        if (ans === question.answer) correct += 1;
+      }
+    });
+    const flagged = Object.entries(sess.flagged || {}).filter(([_, val]) => Boolean(val)).map(([idx]) => Number(idx));
+    const result = {
+      id: uid(),
+      when: Date.now(),
+      correct,
+      total: sess.exam.questions.length,
+      answers,
+      flagged,
+      durationMs: sess.startedAt ? Date.now() - sess.startedAt : 0,
+      answered: answeredCount
+    };
+    const updatedExam = clone(sess.exam);
+    updatedExam.results = [...updatedExam.results || [], result];
+    updatedExam.updatedAt = Date.now();
+    await upsertExam(updatedExam);
+    setExamSession({ mode: "summary", exam: updatedExam, latestResult: result });
+    render2();
+  }
+  function renderSummary(root, render2, sess) {
+    const wrap = document.createElement("div");
+    wrap.className = "exam-summary";
+    const title = document.createElement("h2");
+    title.textContent = `${sess.exam.examTitle} \u2014 Results`;
+    wrap.appendChild(title);
+    const score = document.createElement("div");
+    score.className = "exam-summary-score";
+    const pct = sess.latestResult.total ? Math.round(sess.latestResult.correct / sess.latestResult.total * 100) : 0;
+    score.innerHTML = `<span class="score-number">${sess.latestResult.correct}/${sess.latestResult.total}</span><span class="score-percent">${pct}%</span>`;
+    wrap.appendChild(score);
+    const metrics = document.createElement("div");
+    metrics.className = "exam-summary-metrics";
+    metrics.appendChild(createStat("Answered", `${sess.latestResult.answered}/${sess.latestResult.total}`));
+    metrics.appendChild(createStat("Flagged", String(sess.latestResult.flagged.length)));
+    metrics.appendChild(createStat("Duration", formatDuration(sess.latestResult.durationMs)));
+    wrap.appendChild(metrics);
+    const actions = document.createElement("div");
+    actions.className = "exam-summary-actions";
+    const reviewBtn = document.createElement("button");
+    reviewBtn.className = "btn";
+    reviewBtn.textContent = "Review Attempt";
+    reviewBtn.addEventListener("click", () => {
+      setExamSession({
+        mode: "review",
+        exam: clone(sess.exam),
+        result: clone(sess.latestResult),
+        idx: 0,
+        fromSummary: clone(sess.latestResult)
+      });
+      render2();
+    });
+    actions.appendChild(reviewBtn);
+    const retake = document.createElement("button");
+    retake.className = "btn secondary";
+    retake.textContent = "Retake Exam";
+    retake.addEventListener("click", () => {
+      setExamSession(createTakingSession(sess.exam));
+      render2();
+    });
+    actions.appendChild(retake);
+    const exit = document.createElement("button");
+    exit.className = "btn";
+    exit.textContent = "Back to Exams";
+    exit.addEventListener("click", () => {
+      setExamSession(null);
+      render2();
+    });
+    actions.appendChild(exit);
+    wrap.appendChild(actions);
+    root.appendChild(wrap);
+  }
+  function openExamEditor(existing, render2) {
+    const overlay = document.createElement("div");
+    overlay.className = "modal";
+    const form = document.createElement("form");
+    form.className = "card modal-form exam-editor";
+    const { exam } = ensureExamShape(existing || {
+      id: uid(),
+      examTitle: "New Exam",
+      timerMode: "untimed",
+      secondsPerQuestion: DEFAULT_SECONDS,
+      questions: [],
+      results: []
+    });
+    const heading = document.createElement("h2");
+    heading.textContent = existing ? "Edit Exam" : "Create Exam";
+    form.appendChild(heading);
+    const error = document.createElement("div");
+    error.className = "exam-error";
+    form.appendChild(error);
+    const titleLabel = document.createElement("label");
+    titleLabel.textContent = "Title";
+    const titleInput = document.createElement("input");
+    titleInput.className = "input";
+    titleInput.value = exam.examTitle;
+    titleInput.addEventListener("input", () => {
+      exam.examTitle = titleInput.value;
+    });
+    titleLabel.appendChild(titleInput);
+    form.appendChild(titleLabel);
+    const timerRow = document.createElement("div");
+    timerRow.className = "exam-timer-row";
+    const modeLabel = document.createElement("label");
+    modeLabel.textContent = "Timer Mode";
+    const modeSelect = document.createElement("select");
+    modeSelect.className = "input";
+    ["untimed", "timed"].forEach((mode) => {
+      const opt = document.createElement("option");
+      opt.value = mode;
+      opt.textContent = mode === "timed" ? "Timed" : "Untimed";
+      modeSelect.appendChild(opt);
+    });
+    modeSelect.value = exam.timerMode;
+    modeSelect.addEventListener("change", () => {
+      exam.timerMode = modeSelect.value;
+      secondsLabel.style.display = exam.timerMode === "timed" ? "flex" : "none";
+    });
+    modeLabel.appendChild(modeSelect);
+    timerRow.appendChild(modeLabel);
+    const secondsLabel = document.createElement("label");
+    secondsLabel.textContent = "Seconds per question";
+    const secondsInput = document.createElement("input");
+    secondsInput.type = "number";
+    secondsInput.min = "10";
+    secondsInput.className = "input";
+    secondsInput.value = String(exam.secondsPerQuestion);
+    secondsInput.addEventListener("input", () => {
+      const val = Number(secondsInput.value);
+      if (!Number.isNaN(val) && val > 0) exam.secondsPerQuestion = val;
+    });
+    secondsLabel.appendChild(secondsInput);
+    secondsLabel.style.display = exam.timerMode === "timed" ? "flex" : "none";
+    timerRow.appendChild(secondsLabel);
+    form.appendChild(timerRow);
+    const questionSection = document.createElement("div");
+    questionSection.className = "exam-question-section";
+    form.appendChild(questionSection);
+    const questionsHeader = document.createElement("div");
+    questionsHeader.className = "exam-question-header";
+    const qTitle = document.createElement("h3");
+    qTitle.textContent = "Questions";
+    const addQuestion = document.createElement("button");
+    addQuestion.type = "button";
+    addQuestion.className = "btn secondary";
+    addQuestion.textContent = "Add Question";
+    addQuestion.addEventListener("click", () => {
+      exam.questions.push(createBlankQuestion());
+      renderQuestions();
+    });
+    questionsHeader.appendChild(qTitle);
+    questionsHeader.appendChild(addQuestion);
+    form.appendChild(questionsHeader);
+    function renderQuestions() {
+      questionSection.innerHTML = "";
+      if (!exam.questions.length) {
+        const empty = document.createElement("p");
+        empty.className = "exam-question-empty";
+        empty.textContent = "No questions yet. Add your first question to get started.";
+        questionSection.appendChild(empty);
+        return;
+      }
+      exam.questions.forEach((question, idx) => {
+        const card = document.createElement("div");
+        card.className = "exam-question-editor";
+        const header = document.createElement("div");
+        header.className = "exam-question-editor-header";
+        const title = document.createElement("h4");
+        title.textContent = `Question ${idx + 1}`;
+        const remove = document.createElement("button");
+        remove.type = "button";
+        remove.className = "ghost-btn";
+        remove.textContent = "Remove";
+        remove.addEventListener("click", () => {
+          exam.questions.splice(idx, 1);
+          renderQuestions();
+        });
+        header.appendChild(title);
+        header.appendChild(remove);
+        card.appendChild(header);
+        const stemLabel = document.createElement("label");
+        stemLabel.textContent = "Prompt";
+        const stemInput = document.createElement("textarea");
+        stemInput.className = "input";
+        stemInput.value = question.stem;
+        stemInput.addEventListener("input", () => {
+          question.stem = stemInput.value;
+        });
+        stemLabel.appendChild(stemInput);
+        card.appendChild(stemLabel);
+        const mediaLabel = document.createElement("label");
+        mediaLabel.textContent = "Media (URL or upload)";
+        const mediaInput = document.createElement("input");
+        mediaInput.className = "input";
+        mediaInput.placeholder = "https://example.com/image.png";
+        mediaInput.value = question.media || "";
+        mediaInput.addEventListener("input", () => {
+          question.media = mediaInput.value.trim();
+          updatePreview();
+        });
+        mediaLabel.appendChild(mediaInput);
+        const mediaUpload = document.createElement("input");
+        mediaUpload.type = "file";
+        mediaUpload.accept = "image/*,video/*,audio/*";
+        mediaUpload.addEventListener("change", () => {
+          const file = mediaUpload.files?.[0];
+          if (!file) return;
+          const reader = new FileReader();
+          reader.onload = () => {
+            question.media = typeof reader.result === "string" ? reader.result : "";
+            mediaInput.value = question.media;
+            updatePreview();
+          };
+          reader.readAsDataURL(file);
+        });
+        mediaLabel.appendChild(mediaUpload);
+        const clearMedia = document.createElement("button");
+        clearMedia.type = "button";
+        clearMedia.className = "ghost-btn";
+        clearMedia.textContent = "Remove media";
+        clearMedia.addEventListener("click", () => {
+          question.media = "";
+          mediaInput.value = "";
+          mediaUpload.value = "";
+          updatePreview();
+        });
+        mediaLabel.appendChild(clearMedia);
+        card.appendChild(mediaLabel);
+        const preview = document.createElement("div");
+        preview.className = "exam-media-preview";
+        function updatePreview() {
+          preview.innerHTML = "";
+          const el = mediaElement(question.media);
+          if (el) preview.appendChild(el);
+        }
+        updatePreview();
+        card.appendChild(preview);
+        const tagsLabel = document.createElement("label");
+        tagsLabel.textContent = "Tags (comma separated)";
+        const tagsInput = document.createElement("input");
+        tagsInput.className = "input";
+        tagsInput.value = question.tags.join(", ");
+        tagsInput.addEventListener("input", () => {
+          question.tags = tagsInput.value.split(",").map((t) => t.trim()).filter(Boolean);
+        });
+        tagsLabel.appendChild(tagsInput);
+        card.appendChild(tagsLabel);
+        const explanationLabel = document.createElement("label");
+        explanationLabel.textContent = "Explanation";
+        const explanationInput = document.createElement("textarea");
+        explanationInput.className = "input";
+        explanationInput.value = question.explanation || "";
+        explanationInput.addEventListener("input", () => {
+          question.explanation = explanationInput.value;
+        });
+        explanationLabel.appendChild(explanationInput);
+        card.appendChild(explanationLabel);
+        const optionsWrap = document.createElement("div");
+        optionsWrap.className = "exam-option-editor-list";
+        function renderOptions() {
+          optionsWrap.innerHTML = "";
+          question.options.forEach((opt, optIdx) => {
+            const row = document.createElement("div");
+            row.className = "exam-option-editor";
+            const radio = document.createElement("input");
+            radio.type = "radio";
+            radio.name = `correct-${question.id}`;
+            radio.checked = question.answer === opt.id;
+            radio.addEventListener("change", () => {
+              question.answer = opt.id;
+            });
+            const text = document.createElement("input");
+            text.className = "input";
+            text.type = "text";
+            text.placeholder = `Option ${optIdx + 1}`;
+            text.value = opt.text;
+            text.addEventListener("input", () => {
+              opt.text = text.value;
+            });
+            const removeBtn = document.createElement("button");
+            removeBtn.type = "button";
+            removeBtn.className = "ghost-btn";
+            removeBtn.textContent = "Remove";
+            removeBtn.disabled = question.options.length <= 2;
+            removeBtn.addEventListener("click", () => {
+              question.options.splice(optIdx, 1);
+              if (question.answer === opt.id) {
+                question.answer = question.options[0]?.id || "";
+              }
+              renderOptions();
+            });
+            row.appendChild(radio);
+            row.appendChild(text);
+            row.appendChild(removeBtn);
+            optionsWrap.appendChild(row);
+          });
+        }
+        renderOptions();
+        const addOption = document.createElement("button");
+        addOption.type = "button";
+        addOption.className = "btn secondary";
+        addOption.textContent = "Add Option";
+        addOption.addEventListener("click", () => {
+          const opt = { id: uid(), text: "" };
+          question.options.push(opt);
+          renderOptions();
+        });
+        card.appendChild(optionsWrap);
+        card.appendChild(addOption);
+        questionSection.appendChild(card);
+      });
+    }
+    renderQuestions();
+    const actions = document.createElement("div");
+    actions.className = "modal-actions";
+    const cancel = document.createElement("button");
+    cancel.type = "button";
+    cancel.className = "btn secondary";
+    cancel.textContent = "Cancel";
+    cancel.addEventListener("click", () => document.body.removeChild(overlay));
+    actions.appendChild(cancel);
+    const save = document.createElement("button");
+    save.type = "submit";
+    save.className = "btn";
+    save.textContent = "Save Exam";
+    actions.appendChild(save);
+    form.appendChild(actions);
+    form.addEventListener("submit", async (e) => {
+      e.preventDefault();
+      error.textContent = "";
+      const title = titleInput.value.trim();
+      if (!title) {
+        error.textContent = "Exam title is required.";
+        return;
+      }
+      if (!exam.questions.length) {
+        error.textContent = "Add at least one question.";
+        return;
+      }
+      for (let i = 0; i < exam.questions.length; i++) {
+        const question = exam.questions[i];
+        question.stem = question.stem.trim();
+        question.explanation = question.explanation?.trim() || "";
+        question.media = question.media?.trim() || "";
+        question.options = question.options.map((opt) => ({ id: opt.id, text: opt.text.trim() })).filter((opt) => opt.text);
+        if (question.options.length < 2) {
+          error.textContent = `Question ${i + 1} needs at least two answer options.`;
+          return;
+        }
+        if (!question.answer || !question.options.some((opt) => opt.id === question.answer)) {
+          error.textContent = `Select a correct answer for question ${i + 1}.`;
+          return;
+        }
+        question.tags = question.tags.map((t) => t.trim()).filter(Boolean);
+      }
+      const payload = {
+        ...exam,
+        examTitle: title,
+        updatedAt: Date.now()
+      };
+      await upsertExam(payload);
+      document.body.removeChild(overlay);
+      render2();
+    });
+    overlay.appendChild(form);
+    overlay.addEventListener("click", (e) => {
+      if (e.target === overlay) document.body.removeChild(overlay);
+    });
+    document.body.appendChild(overlay);
+    titleInput.focus();
   }
 
   // js/ui/components/popup.js

--- a/js/types.js
+++ b/js/types.js
@@ -45,13 +45,13 @@
  *              lectures:{id:number, name:string, week:number}[],
  *              createdAt:number, updatedAt:number }} BlockDef */
 
-/** @typedef {{ id:string, stem:string, options:{id:string,text:string}[], answer:string, explanation?:string, tags?:string[] }} Question */
+/** @typedef {{ id:string, stem:string, options:{id:string,text:string}[], answer:string, explanation?:string, tags?:string[], media?:string }} Question */
 
 /** @typedef {{ id:string, examTitle:string, block?:string, week?:string,
  *   timerMode:"timed"|"untimed", secondsPerQuestion:number,
  *   questions:Question[], results:ExamResult[] }} Exam */
 
-/** @typedef {{ when:number, correct:number, total:number, answers:Record<number,string> }} ExamResult */
+/** @typedef {{ id:string, when:number, correct:number, total:number, answers:Record<number,string>, flagged:number[], durationMs:number, answered:number }} ExamResult */
 
 /** @typedef {{ dailyCount:number, theme:"dark" }} Settings */
 

--- a/js/ui/components/exams.js
+++ b/js/ui/components/exams.js
@@ -1,78 +1,1131 @@
-import { listExams, upsertExam } from '../../storage/storage.js';
+import { listExams, upsertExam, deleteExam } from '../../storage/storage.js';
 import { state, setExamSession } from '../../state.js';
+import { uid } from '../../utils.js';
+import { confirmModal } from './confirm.js';
 
-// render list and import of exams
+const DEFAULT_SECONDS = 60;
+
+function clone(value) {
+  return value ? JSON.parse(JSON.stringify(value)) : value;
+}
+
+function ensureExamShape(exam) {
+  const next = clone(exam) || {};
+  let changed = false;
+
+  if (!next.id) { next.id = uid(); changed = true; }
+  if (!next.examTitle) { next.examTitle = 'Untitled Exam'; changed = true; }
+  if (next.timerMode !== 'timed') {
+    if (next.timerMode !== 'untimed') changed = true;
+    next.timerMode = 'untimed';
+  }
+  if (typeof next.secondsPerQuestion !== 'number' || next.secondsPerQuestion <= 0) {
+    next.secondsPerQuestion = DEFAULT_SECONDS;
+    changed = true;
+  }
+  if (!Array.isArray(next.questions)) {
+    next.questions = [];
+    changed = true;
+  }
+  next.questions = next.questions.map(q => {
+    const question = { ...q };
+    if (!question.id) { question.id = uid(); changed = true; }
+    question.stem = question.stem ? String(question.stem) : '';
+    if (!Array.isArray(question.options)) {
+      question.options = [];
+      changed = true;
+    }
+    question.options = question.options.map(opt => {
+      const option = { ...opt };
+      if (!option.id) { option.id = uid(); changed = true; }
+      option.text = option.text ? String(option.text) : '';
+      return option;
+    });
+    if (!question.answer || !question.options.some(opt => opt.id === question.answer)) {
+      question.answer = question.options[0]?.id || '';
+      changed = true;
+    }
+    if (question.explanation == null) { question.explanation = ''; changed = true; }
+    if (!Array.isArray(question.tags)) {
+      if (question.tags == null) question.tags = [];
+      else question.tags = Array.isArray(question.tags) ? question.tags : [String(question.tags)];
+      changed = true;
+    }
+    question.tags = question.tags.map(t => String(t)).filter(Boolean);
+    if (question.media == null) { question.media = ''; changed = true; }
+    return question;
+  });
+
+  if (!Array.isArray(next.results)) {
+    next.results = [];
+    changed = true;
+  }
+  next.results = next.results.map(res => {
+    const result = { ...res };
+    if (!result.id) { result.id = uid(); changed = true; }
+    if (typeof result.when !== 'number') { result.when = Date.now(); changed = true; }
+    if (typeof result.correct !== 'number') { result.correct = Number(result.correct) || 0; changed = true; }
+    if (typeof result.total !== 'number') { result.total = Number(result.total) || (next.questions?.length ?? 0); changed = true; }
+    if (!result.answers || typeof result.answers !== 'object') { result.answers = {}; changed = true; }
+    if (!Array.isArray(result.flagged)) { result.flagged = []; changed = true; }
+    if (typeof result.durationMs !== 'number') { result.durationMs = 0; changed = true; }
+    if (typeof result.answered !== 'number') { result.answered = Object.keys(result.answers || {}).length; changed = true; }
+    return result;
+  });
+
+  return { exam: next, changed };
+}
+
+function createBlankQuestion() {
+  return {
+    id: uid(),
+    stem: '',
+    options: [1, 2, 3, 4].map(() => ({ id: uid(), text: '' })),
+    answer: '',
+    explanation: '',
+    tags: [],
+    media: ''
+  };
+}
+
+function createTakingSession(exam) {
+  return {
+    mode: 'taking',
+    exam: clone(exam),
+    idx: 0,
+    answers: {},
+    flagged: {},
+    startedAt: Date.now()
+  };
+}
+
 export async function renderExams(root, render) {
   root.innerHTML = '';
+  root.className = 'exam-view';
 
-  // Import button
+  const controls = document.createElement('div');
+  controls.className = 'exam-controls';
+
+  const heading = document.createElement('div');
+  heading.className = 'exam-heading';
+  heading.innerHTML = '<h1>Exams</h1><p>Import exams, take them, and review your attempts.</p>';
+  controls.appendChild(heading);
+
+  const actions = document.createElement('div');
+  actions.className = 'exam-control-actions';
+
+  const status = document.createElement('div');
+  status.className = 'exam-status';
+
   const fileInput = document.createElement('input');
   fileInput.type = 'file';
   fileInput.accept = 'application/json';
+  fileInput.style.display = 'none';
   fileInput.addEventListener('change', async e => {
-    const file = e.target.files[0];
+    const file = e.target.files?.[0];
     if (!file) return;
     try {
       const text = await file.text();
-      const exam = JSON.parse(text);
-      exam.id = exam.id || crypto.randomUUID();
-      exam.createdAt = exam.createdAt || Date.now();
-      exam.updatedAt = Date.now();
-      exam.results = exam.results || [];
-      await upsertExam(exam);
+      const parsed = JSON.parse(text);
+      const { exam } = ensureExamShape(parsed);
+      await upsertExam({ ...exam, updatedAt: Date.now() });
       render();
     } catch (err) {
-      alert('Invalid exam JSON');
+      console.warn('Failed to import exam', err);
+      status.textContent = 'Unable to import exam — invalid JSON structure.';
+    } finally {
+      fileInput.value = '';
     }
   });
+
+  const importBtn = document.createElement('button');
+  importBtn.type = 'button';
+  importBtn.className = 'btn secondary';
+  importBtn.textContent = 'Import Exam';
+  importBtn.addEventListener('click', () => fileInput.click());
+  actions.appendChild(importBtn);
+
+  const newBtn = document.createElement('button');
+  newBtn.type = 'button';
+  newBtn.className = 'btn';
+  newBtn.textContent = 'New Exam';
+  newBtn.addEventListener('click', () => openExamEditor(null, render));
+  actions.appendChild(newBtn);
+
+  controls.appendChild(actions);
+  controls.appendChild(status);
+
+  root.appendChild(controls);
   root.appendChild(fileInput);
 
-  // existing exams list
-  const exams = await listExams();
-  const list = document.createElement('div');
-  exams.forEach(ex => {
-    const row = document.createElement('div');
-    row.className = 'row';
-    const title = document.createElement('span');
-    title.textContent = ex.examTitle;
-    const start = document.createElement('button');
-    start.className = 'btn';
-    start.textContent = 'Start';
-    start.addEventListener('click', () => {
-      setExamSession({ exam: ex, idx: 0, answers: [] });
+  const stored = await listExams();
+  const exams = [];
+  for (const raw of stored) {
+    const { exam, changed } = ensureExamShape(raw);
+    exams.push(exam);
+    if (changed) await upsertExam(exam);
+  }
+  exams.sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
+
+  if (!exams.length) {
+    const empty = document.createElement('div');
+    empty.className = 'exam-empty';
+    empty.innerHTML = '<p>No exams yet. Import a JSON exam or create one from scratch.</p>';
+    root.appendChild(empty);
+    return;
+  }
+
+  const grid = document.createElement('div');
+  grid.className = 'exam-grid';
+  exams.forEach(exam => {
+    grid.appendChild(buildExamCard(exam, render));
+  });
+  root.appendChild(grid);
+}
+
+function buildExamCard(exam, render) {
+  const card = document.createElement('article');
+  card.className = 'card exam-card';
+
+  const title = document.createElement('h2');
+  title.className = 'exam-card-title';
+  title.textContent = exam.examTitle;
+  card.appendChild(title);
+
+  const meta = document.createElement('div');
+  meta.className = 'exam-card-meta';
+  const questionCount = document.createElement('span');
+  questionCount.textContent = `${exam.questions.length} question${exam.questions.length === 1 ? '' : 's'}`;
+  meta.appendChild(questionCount);
+  if (exam.timerMode === 'timed') {
+    const timed = document.createElement('span');
+    timed.textContent = `Timed • ${exam.secondsPerQuestion}s/question`;
+    meta.appendChild(timed);
+  } else {
+    const timed = document.createElement('span');
+    timed.textContent = 'Untimed';
+    meta.appendChild(timed);
+  }
+  card.appendChild(meta);
+
+  const stats = document.createElement('div');
+  stats.className = 'exam-card-stats';
+  stats.appendChild(createStat('Attempts', String(exam.results.length)));
+  const last = latestResult(exam);
+  if (last) {
+    stats.appendChild(createStat('Last Score', formatScore(last)));
+    const best = bestResult(exam);
+    if (best) stats.appendChild(createStat('Best Score', formatScore(best)));
+  } else {
+    stats.appendChild(createStat('Last Score', '—'));
+    stats.appendChild(createStat('Best Score', '—'));
+  }
+  card.appendChild(stats);
+
+  const actions = document.createElement('div');
+  actions.className = 'exam-card-actions';
+
+  const startBtn = document.createElement('button');
+  startBtn.className = 'btn';
+  startBtn.textContent = 'Start Exam';
+  startBtn.disabled = exam.questions.length === 0;
+  startBtn.addEventListener('click', () => {
+    setExamSession(createTakingSession(exam));
+    render();
+  });
+  actions.appendChild(startBtn);
+
+  if (last) {
+    const reviewBtn = document.createElement('button');
+    reviewBtn.className = 'btn secondary';
+    reviewBtn.textContent = 'Review Last Attempt';
+    reviewBtn.addEventListener('click', () => {
+      setExamSession({ mode: 'review', exam: clone(exam), result: clone(last), idx: 0 });
       render();
     });
-    row.appendChild(title);
-    row.appendChild(start);
-    list.appendChild(row);
+    actions.appendChild(reviewBtn);
+  }
+
+  const editBtn = document.createElement('button');
+  editBtn.className = 'btn secondary';
+  editBtn.textContent = 'Edit';
+  editBtn.addEventListener('click', () => openExamEditor(exam, render));
+  actions.appendChild(editBtn);
+
+  const delBtn = document.createElement('button');
+  delBtn.className = 'btn danger';
+  delBtn.textContent = 'Delete';
+  delBtn.addEventListener('click', async () => {
+    const ok = await confirmModal(`Delete "${exam.examTitle}"? This will remove all attempts.`);
+    if (!ok) return;
+    await deleteExam(exam.id);
+    render();
   });
-  root.appendChild(list);
+  actions.appendChild(delBtn);
+
+  card.appendChild(actions);
+
+  const attemptsWrap = document.createElement('div');
+  attemptsWrap.className = 'exam-attempts';
+  const attemptsTitle = document.createElement('h3');
+  attemptsTitle.textContent = 'Attempts';
+  attemptsWrap.appendChild(attemptsTitle);
+
+  if (!exam.results.length) {
+    const none = document.createElement('p');
+    none.className = 'exam-attempt-empty';
+    none.textContent = 'No attempts yet.';
+    attemptsWrap.appendChild(none);
+  } else {
+    const list = document.createElement('div');
+    list.className = 'exam-attempt-list';
+    [...exam.results]
+      .sort((a, b) => b.when - a.when)
+      .forEach(result => {
+        list.appendChild(buildAttemptRow(exam, result, render));
+      });
+    attemptsWrap.appendChild(list);
+  }
+
+  card.appendChild(attemptsWrap);
+  return card;
+}
+
+function buildAttemptRow(exam, result, render) {
+  const row = document.createElement('div');
+  row.className = 'exam-attempt-row';
+
+  const info = document.createElement('div');
+  info.className = 'exam-attempt-info';
+
+  const title = document.createElement('div');
+  title.className = 'exam-attempt-score';
+  title.textContent = formatScore(result);
+  info.appendChild(title);
+
+  const meta = document.createElement('div');
+  meta.className = 'exam-attempt-meta';
+  const date = new Date(result.when).toLocaleString();
+  const answeredText = `${result.answered}/${result.total} answered`;
+  const flaggedText = `${result.flagged.length} flagged`;
+  const durationText = result.durationMs ? formatDuration(result.durationMs) : '—';
+  meta.textContent = `${date} • ${answeredText} • ${flaggedText} • ${durationText}`;
+  info.appendChild(meta);
+
+  row.appendChild(info);
+
+  const review = document.createElement('button');
+  review.className = 'btn secondary';
+  review.textContent = 'Review';
+  review.addEventListener('click', () => {
+    setExamSession({ mode: 'review', exam: clone(exam), result: clone(result), idx: 0 });
+    render();
+  });
+  row.appendChild(review);
+
+  return row;
+}
+
+function createStat(label, value) {
+  const wrap = document.createElement('div');
+  wrap.className = 'exam-stat';
+  const lbl = document.createElement('div');
+  lbl.className = 'exam-stat-label';
+  lbl.textContent = label;
+  const val = document.createElement('div');
+  val.className = 'exam-stat-value';
+  val.textContent = value;
+  wrap.appendChild(lbl);
+  wrap.appendChild(val);
+  return wrap;
+}
+
+function latestResult(exam) {
+  if (!exam.results?.length) return null;
+  return exam.results.reduce((acc, res) => (acc == null || res.when > acc.when ? res : acc), null);
+}
+
+function bestResult(exam) {
+  if (!exam.results?.length) return null;
+  return exam.results.reduce((acc, res) => {
+    const pct = res.total ? res.correct / res.total : 0;
+    const bestPct = acc?.total ? acc.correct / acc.total : -1;
+    if (!acc || pct > bestPct) return res;
+    return acc;
+  }, null);
+}
+
+function formatScore(result) {
+  const pct = result.total ? Math.round((result.correct / result.total) * 100) : 0;
+  return `${result.correct}/${result.total} • ${pct}%`;
+}
+
+function formatDuration(ms) {
+  if (!ms) return '—';
+  const totalSeconds = Math.max(0, Math.round(ms / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const parts = [];
+  if (hours) parts.push(`${hours}h`);
+  if (minutes) parts.push(`${minutes}m`);
+  parts.push(`${seconds}s`);
+  return parts.join(' ');
+}
+
+function optionText(question, id) {
+  return question.options.find(opt => opt.id === id)?.text || '';
+}
+
+function mediaElement(source) {
+  if (!source) return null;
+  const wrap = document.createElement('div');
+  wrap.className = 'exam-media';
+  const lower = source.toLowerCase();
+  if (lower.startsWith('data:video') || /\.(mp4|webm|ogg)$/i.test(lower)) {
+    const video = document.createElement('video');
+    video.controls = true;
+    video.src = source;
+    wrap.appendChild(video);
+  } else if (lower.startsWith('data:audio') || /\.(mp3|wav|ogg)$/i.test(lower)) {
+    const audio = document.createElement('audio');
+    audio.controls = true;
+    audio.src = source;
+    wrap.appendChild(audio);
+  } else {
+    const img = document.createElement('img');
+    img.src = source;
+    img.alt = 'Question media';
+    wrap.appendChild(img);
+  }
+  return wrap;
+}
+
+function answerClass(question, selectedId, optionId) {
+  const isCorrect = optionId === question.answer;
+  if (selectedId == null) return isCorrect ? 'correct-answer' : '';
+  if (selectedId === optionId) {
+    return selectedId === question.answer ? 'correct-answer' : 'incorrect-answer';
+  }
+  return isCorrect ? 'correct-answer' : '';
+}
+
+function renderPalette(sidebar, sess, render) {
+  const palette = document.createElement('div');
+  palette.className = 'exam-palette';
+  const title = document.createElement('h3');
+  title.textContent = 'Question Map';
+  palette.appendChild(title);
+
+  const grid = document.createElement('div');
+  grid.className = 'exam-palette-grid';
+
+  const answers = sess.mode === 'review' ? sess.result.answers || {} : sess.answers || {};
+  const flaggedSet = new Set(sess.mode === 'review'
+    ? (sess.result.flagged || [])
+    : Object.entries(sess.flagged || {}).filter(([_, v]) => v).map(([idx]) => Number(idx)));
+
+  sess.exam.questions.forEach((_, idx) => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.textContent = String(idx + 1);
+    btn.className = 'palette-button';
+    if (sess.idx === idx) btn.classList.add('active');
+    if (answers[idx] != null) btn.classList.add('answered');
+    if (flaggedSet.has(idx)) btn.classList.add('flagged');
+    btn.addEventListener('click', () => {
+      sess.idx = idx;
+      render();
+    });
+    grid.appendChild(btn);
+  });
+
+  palette.appendChild(grid);
+  sidebar.appendChild(palette);
 }
 
 export function renderExamRunner(root, render) {
   const sess = state.examSession;
-  const q = sess.exam.questions[sess.idx];
+  if (!sess) return;
   root.innerHTML = '';
-  const h = document.createElement('h2');
-  h.textContent = `Question ${sess.idx + 1} / ${sess.exam.questions.length}`;
-  root.appendChild(h);
-  const stem = document.createElement('p');
-  stem.textContent = q.stem;
-  root.appendChild(stem);
-  q.options.forEach(opt => {
-    const btn = document.createElement('button');
-    btn.className = 'btn';
-    btn.textContent = opt.text;
-    btn.addEventListener('click', () => {
-      sess.answers.push(opt.id);
-      sess.idx++;
-      if (sess.idx >= sess.exam.questions.length) {
-        const correct = sess.exam.questions.filter((qu, i) => sess.answers[i] === qu.answer).length;
-        alert(`Score: ${correct}/${sess.exam.questions.length}`);
-        setExamSession(null);
-      }
+  root.className = 'exam-session';
+
+  if (sess.mode === 'summary') {
+    renderSummary(root, render, sess);
+    return;
+  }
+
+  const questionCount = sess.exam.questions.length;
+  if (!questionCount) {
+    const empty = document.createElement('div');
+    empty.className = 'exam-empty';
+    empty.innerHTML = '<p>This exam does not contain any questions.</p>';
+    const back = document.createElement('button');
+    back.className = 'btn';
+    back.textContent = 'Back to Exams';
+    back.addEventListener('click', () => { setExamSession(null); render(); });
+    empty.appendChild(back);
+    root.appendChild(empty);
+    return;
+  }
+
+  if (sess.idx < 0) sess.idx = 0;
+  if (sess.idx >= questionCount) sess.idx = questionCount - 1;
+
+  const container = document.createElement('div');
+  container.className = 'exam-runner';
+  root.appendChild(container);
+
+  const main = document.createElement('section');
+  main.className = 'exam-main';
+  container.appendChild(main);
+
+  const sidebar = document.createElement('aside');
+  sidebar.className = 'exam-sidebar';
+  container.appendChild(sidebar);
+
+  const question = sess.exam.questions[sess.idx];
+  const answers = sess.mode === 'review' ? sess.result.answers || {} : sess.answers || {};
+  const selected = answers[sess.idx];
+
+  const top = document.createElement('div');
+  top.className = 'exam-topbar';
+  const progress = document.createElement('div');
+  progress.className = 'exam-progress';
+  progress.textContent = `${sess.exam.examTitle} • Question ${sess.idx + 1} of ${questionCount}`;
+  top.appendChild(progress);
+
+  const flagBtn = document.createElement('button');
+  flagBtn.type = 'button';
+  flagBtn.className = 'flag-btn';
+  const isFlagged = sess.mode === 'review'
+    ? (sess.result.flagged || []).includes(sess.idx)
+    : Boolean(sess.flagged?.[sess.idx]);
+  flagBtn.classList.toggle('active', isFlagged);
+  flagBtn.textContent = isFlagged ? '🚩 Flagged' : 'Flag question';
+  if (sess.mode === 'taking') {
+    flagBtn.addEventListener('click', () => {
+      if (!sess.flagged) sess.flagged = {};
+      sess.flagged[sess.idx] = !isFlagged;
       render();
     });
-    root.appendChild(btn);
+  } else {
+    flagBtn.disabled = true;
+  }
+  top.appendChild(flagBtn);
+  main.appendChild(top);
+
+  const stem = document.createElement('div');
+  stem.className = 'exam-stem';
+  stem.textContent = question.stem || '(No prompt)';
+  main.appendChild(stem);
+
+  const media = mediaElement(question.media);
+  if (media) main.appendChild(media);
+
+  if (question.tags?.length) {
+    const tagWrap = document.createElement('div');
+    tagWrap.className = 'exam-tags';
+    question.tags.forEach(tag => {
+      const chip = document.createElement('span');
+      chip.className = 'exam-tag';
+      chip.textContent = tag;
+      tagWrap.appendChild(chip);
+    });
+    main.appendChild(tagWrap);
+  }
+
+  const optionsWrap = document.createElement('div');
+  optionsWrap.className = 'exam-options';
+  if (!question.options.length) {
+    const warn = document.createElement('p');
+    warn.className = 'exam-warning';
+    warn.textContent = 'This question has no answer options.';
+    optionsWrap.appendChild(warn);
+  }
+
+  question.options.forEach(opt => {
+    const choice = document.createElement(sess.mode === 'taking' ? 'button' : 'div');
+    if (sess.mode === 'taking') choice.type = 'button';
+    choice.className = 'exam-option';
+    if (sess.mode === 'review') choice.classList.add('review');
+    choice.textContent = opt.text || '(Empty option)';
+    if (sess.mode === 'taking') {
+      if (selected === opt.id) choice.classList.add('selected');
+      choice.addEventListener('click', () => {
+        sess.answers[sess.idx] = opt.id;
+        render();
+      });
+    } else {
+      const cls = answerClass(question, selected, opt.id);
+      if (cls) choice.classList.add(cls);
+      if (selected === opt.id) choice.classList.add('chosen');
+    }
+    optionsWrap.appendChild(choice);
   });
+
+  main.appendChild(optionsWrap);
+
+  if (sess.mode === 'review') {
+    const verdict = document.createElement('div');
+    verdict.className = 'exam-verdict';
+    let verdictText = 'Not answered';
+    let verdictClass = 'neutral';
+    if (selected != null) {
+      if (selected === question.answer) {
+        verdictText = 'Correct';
+        verdictClass = 'correct';
+      } else {
+        verdictText = 'Incorrect';
+        verdictClass = 'incorrect';
+      }
+    }
+    verdict.classList.add(verdictClass);
+    verdict.textContent = verdictText;
+    main.appendChild(verdict);
+
+    const answerSummary = document.createElement('div');
+    answerSummary.className = 'exam-answer-summary';
+    const your = optionText(question, selected);
+    const correct = optionText(question, question.answer);
+    answerSummary.innerHTML = `<div><strong>Your answer:</strong> ${your || '—'}</div><div><strong>Correct answer:</strong> ${correct || '—'}</div>`;
+    main.appendChild(answerSummary);
+
+    if (question.explanation) {
+      const explain = document.createElement('div');
+      explain.className = 'exam-explanation';
+      const title = document.createElement('h3');
+      title.textContent = 'Explanation';
+      const body = document.createElement('p');
+      body.textContent = question.explanation;
+      explain.appendChild(title);
+      explain.appendChild(body);
+      main.appendChild(explain);
+    }
+  }
+
+  renderPalette(sidebar, sess, render);
+  renderSidebarMeta(sidebar, sess);
+
+  const nav = document.createElement('div');
+  nav.className = 'exam-nav';
+
+  const prev = document.createElement('button');
+  prev.className = 'btn secondary';
+  prev.textContent = 'Previous';
+  prev.disabled = sess.idx === 0;
+  prev.addEventListener('click', () => {
+    if (sess.idx > 0) {
+      sess.idx -= 1;
+      render();
+    }
+  });
+  nav.appendChild(prev);
+
+  if (sess.mode === 'taking') {
+    const nextBtn = document.createElement('button');
+    nextBtn.className = 'btn secondary';
+    nextBtn.textContent = 'Next Question';
+    nextBtn.disabled = sess.idx >= questionCount - 1;
+    nextBtn.addEventListener('click', () => {
+      if (sess.idx < questionCount - 1) {
+        sess.idx += 1;
+        render();
+      }
+    });
+    nav.appendChild(nextBtn);
+
+    const submit = document.createElement('button');
+    submit.className = 'btn';
+    submit.textContent = 'Submit Exam';
+    submit.addEventListener('click', async () => {
+      await finalizeExam(sess, render);
+    });
+    nav.appendChild(submit);
+  } else {
+    const nextBtn = document.createElement('button');
+    nextBtn.className = 'btn secondary';
+    nextBtn.textContent = 'Next';
+    nextBtn.disabled = sess.idx >= questionCount - 1;
+    nextBtn.addEventListener('click', () => {
+      if (sess.idx < questionCount - 1) {
+        sess.idx += 1;
+        render();
+      }
+    });
+    nav.appendChild(nextBtn);
+
+    const exit = document.createElement('button');
+    exit.className = 'btn';
+    if (sess.fromSummary) {
+      exit.textContent = 'Back to Summary';
+      exit.addEventListener('click', () => {
+        setExamSession({ mode: 'summary', exam: sess.exam, latestResult: sess.fromSummary });
+        render();
+      });
+    } else {
+      exit.textContent = 'Back to Exams';
+      exit.addEventListener('click', () => { setExamSession(null); render(); });
+    }
+    nav.appendChild(exit);
+  }
+
+  root.appendChild(nav);
 }
+function renderSidebarMeta(sidebar, sess) {
+  const info = document.createElement('div');
+  info.className = 'exam-sidebar-info';
+
+  const attempts = document.createElement('div');
+  attempts.innerHTML = `<strong>Attempts:</strong> ${sess.exam.results?.length || 0}`;
+  info.appendChild(attempts);
+
+  if (sess.mode === 'review' && sess.result.durationMs) {
+    const duration = document.createElement('div');
+    duration.innerHTML = `<strong>Duration:</strong> ${formatDuration(sess.result.durationMs)}`;
+    info.appendChild(duration);
+  } else if (sess.mode === 'taking') {
+    const timerMode = document.createElement('div');
+    if (sess.exam.timerMode === 'timed') {
+      timerMode.innerHTML = `<strong>Timer:</strong> Timed (${sess.exam.secondsPerQuestion}s/question)`;
+    } else {
+      timerMode.innerHTML = '<strong>Timer:</strong> Untimed';
+    }
+    info.appendChild(timerMode);
+  }
+
+  sidebar.appendChild(info);
+}
+
+async function finalizeExam(sess, render) {
+  const unanswered = sess.exam.questions.filter((_, idx) => sess.answers[idx] == null);
+  if (unanswered.length) {
+    const confirm = await confirmModal(`You have ${unanswered.length} unanswered question${unanswered.length === 1 ? '' : 's'}. Submit anyway?`);
+    if (!confirm) return;
+  }
+
+  const answers = {};
+  let correct = 0;
+  let answeredCount = 0;
+  sess.exam.questions.forEach((question, idx) => {
+    const ans = sess.answers[idx];
+    if (ans != null) {
+      answers[idx] = ans;
+      answeredCount += 1;
+      if (ans === question.answer) correct += 1;
+    }
+  });
+
+  const flagged = Object.entries(sess.flagged || {})
+    .filter(([_, val]) => Boolean(val))
+    .map(([idx]) => Number(idx));
+
+  const result = {
+    id: uid(),
+    when: Date.now(),
+    correct,
+    total: sess.exam.questions.length,
+    answers,
+    flagged,
+    durationMs: sess.startedAt ? Date.now() - sess.startedAt : 0,
+    answered: answeredCount
+  };
+
+  const updatedExam = clone(sess.exam);
+  updatedExam.results = [...(updatedExam.results || []), result];
+  updatedExam.updatedAt = Date.now();
+  await upsertExam(updatedExam);
+
+  setExamSession({ mode: 'summary', exam: updatedExam, latestResult: result });
+  render();
+}
+
+function renderSummary(root, render, sess) {
+  const wrap = document.createElement('div');
+  wrap.className = 'exam-summary';
+
+  const title = document.createElement('h2');
+  title.textContent = `${sess.exam.examTitle} — Results`;
+  wrap.appendChild(title);
+
+  const score = document.createElement('div');
+  score.className = 'exam-summary-score';
+  const pct = sess.latestResult.total ? Math.round((sess.latestResult.correct / sess.latestResult.total) * 100) : 0;
+  score.innerHTML = `<span class="score-number">${sess.latestResult.correct}/${sess.latestResult.total}</span><span class="score-percent">${pct}%</span>`;
+  wrap.appendChild(score);
+
+  const metrics = document.createElement('div');
+  metrics.className = 'exam-summary-metrics';
+  metrics.appendChild(createStat('Answered', `${sess.latestResult.answered}/${sess.latestResult.total}`));
+  metrics.appendChild(createStat('Flagged', String(sess.latestResult.flagged.length)));
+  metrics.appendChild(createStat('Duration', formatDuration(sess.latestResult.durationMs)));
+  wrap.appendChild(metrics);
+
+  const actions = document.createElement('div');
+  actions.className = 'exam-summary-actions';
+
+  const reviewBtn = document.createElement('button');
+  reviewBtn.className = 'btn';
+  reviewBtn.textContent = 'Review Attempt';
+  reviewBtn.addEventListener('click', () => {
+    setExamSession({
+      mode: 'review',
+      exam: clone(sess.exam),
+      result: clone(sess.latestResult),
+      idx: 0,
+      fromSummary: clone(sess.latestResult)
+    });
+    render();
+  });
+  actions.appendChild(reviewBtn);
+
+  const retake = document.createElement('button');
+  retake.className = 'btn secondary';
+  retake.textContent = 'Retake Exam';
+  retake.addEventListener('click', () => {
+    setExamSession(createTakingSession(sess.exam));
+    render();
+  });
+  actions.appendChild(retake);
+
+  const exit = document.createElement('button');
+  exit.className = 'btn';
+  exit.textContent = 'Back to Exams';
+  exit.addEventListener('click', () => { setExamSession(null); render(); });
+  actions.appendChild(exit);
+
+  wrap.appendChild(actions);
+  root.appendChild(wrap);
+}
+
+function openExamEditor(existing, render) {
+  const overlay = document.createElement('div');
+  overlay.className = 'modal';
+
+  const form = document.createElement('form');
+  form.className = 'card modal-form exam-editor';
+
+  const { exam } = ensureExamShape(existing || {
+    id: uid(),
+    examTitle: 'New Exam',
+    timerMode: 'untimed',
+    secondsPerQuestion: DEFAULT_SECONDS,
+    questions: [],
+    results: []
+  });
+
+  const heading = document.createElement('h2');
+  heading.textContent = existing ? 'Edit Exam' : 'Create Exam';
+  form.appendChild(heading);
+
+  const error = document.createElement('div');
+  error.className = 'exam-error';
+  form.appendChild(error);
+
+  const titleLabel = document.createElement('label');
+  titleLabel.textContent = 'Title';
+  const titleInput = document.createElement('input');
+  titleInput.className = 'input';
+  titleInput.value = exam.examTitle;
+  titleInput.addEventListener('input', () => { exam.examTitle = titleInput.value; });
+  titleLabel.appendChild(titleInput);
+  form.appendChild(titleLabel);
+
+  const timerRow = document.createElement('div');
+  timerRow.className = 'exam-timer-row';
+
+  const modeLabel = document.createElement('label');
+  modeLabel.textContent = 'Timer Mode';
+  const modeSelect = document.createElement('select');
+  modeSelect.className = 'input';
+  ['untimed', 'timed'].forEach(mode => {
+    const opt = document.createElement('option');
+    opt.value = mode;
+    opt.textContent = mode === 'timed' ? 'Timed' : 'Untimed';
+    modeSelect.appendChild(opt);
+  });
+  modeSelect.value = exam.timerMode;
+  modeSelect.addEventListener('change', () => {
+    exam.timerMode = modeSelect.value;
+    secondsLabel.style.display = exam.timerMode === 'timed' ? 'flex' : 'none';
+  });
+  modeLabel.appendChild(modeSelect);
+  timerRow.appendChild(modeLabel);
+
+  const secondsLabel = document.createElement('label');
+  secondsLabel.textContent = 'Seconds per question';
+  const secondsInput = document.createElement('input');
+  secondsInput.type = 'number';
+  secondsInput.min = '10';
+  secondsInput.className = 'input';
+  secondsInput.value = String(exam.secondsPerQuestion);
+  secondsInput.addEventListener('input', () => {
+    const val = Number(secondsInput.value);
+    if (!Number.isNaN(val) && val > 0) exam.secondsPerQuestion = val;
+  });
+  secondsLabel.appendChild(secondsInput);
+  secondsLabel.style.display = exam.timerMode === 'timed' ? 'flex' : 'none';
+  timerRow.appendChild(secondsLabel);
+
+  form.appendChild(timerRow);
+
+  const questionSection = document.createElement('div');
+  questionSection.className = 'exam-question-section';
+  form.appendChild(questionSection);
+
+  const questionsHeader = document.createElement('div');
+  questionsHeader.className = 'exam-question-header';
+  const qTitle = document.createElement('h3');
+  qTitle.textContent = 'Questions';
+  const addQuestion = document.createElement('button');
+  addQuestion.type = 'button';
+  addQuestion.className = 'btn secondary';
+  addQuestion.textContent = 'Add Question';
+  addQuestion.addEventListener('click', () => {
+    exam.questions.push(createBlankQuestion());
+    renderQuestions();
+  });
+  questionsHeader.appendChild(qTitle);
+  questionsHeader.appendChild(addQuestion);
+  form.appendChild(questionsHeader);
+
+  function renderQuestions() {
+    questionSection.innerHTML = '';
+    if (!exam.questions.length) {
+      const empty = document.createElement('p');
+      empty.className = 'exam-question-empty';
+      empty.textContent = 'No questions yet. Add your first question to get started.';
+      questionSection.appendChild(empty);
+      return;
+    }
+
+    exam.questions.forEach((question, idx) => {
+      const card = document.createElement('div');
+      card.className = 'exam-question-editor';
+
+      const header = document.createElement('div');
+      header.className = 'exam-question-editor-header';
+      const title = document.createElement('h4');
+      title.textContent = `Question ${idx + 1}`;
+      const remove = document.createElement('button');
+      remove.type = 'button';
+      remove.className = 'ghost-btn';
+      remove.textContent = 'Remove';
+      remove.addEventListener('click', () => {
+        exam.questions.splice(idx, 1);
+        renderQuestions();
+      });
+      header.appendChild(title);
+      header.appendChild(remove);
+      card.appendChild(header);
+
+      const stemLabel = document.createElement('label');
+      stemLabel.textContent = 'Prompt';
+      const stemInput = document.createElement('textarea');
+      stemInput.className = 'input';
+      stemInput.value = question.stem;
+      stemInput.addEventListener('input', () => { question.stem = stemInput.value; });
+      stemLabel.appendChild(stemInput);
+      card.appendChild(stemLabel);
+
+      const mediaLabel = document.createElement('label');
+      mediaLabel.textContent = 'Media (URL or upload)';
+      const mediaInput = document.createElement('input');
+      mediaInput.className = 'input';
+      mediaInput.placeholder = 'https://example.com/image.png';
+      mediaInput.value = question.media || '';
+      mediaInput.addEventListener('input', () => { question.media = mediaInput.value.trim(); updatePreview(); });
+      mediaLabel.appendChild(mediaInput);
+
+      const mediaUpload = document.createElement('input');
+      mediaUpload.type = 'file';
+      mediaUpload.accept = 'image/*,video/*,audio/*';
+      mediaUpload.addEventListener('change', () => {
+        const file = mediaUpload.files?.[0];
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = () => {
+          question.media = typeof reader.result === 'string' ? reader.result : '';
+          mediaInput.value = question.media;
+          updatePreview();
+        };
+        reader.readAsDataURL(file);
+      });
+      mediaLabel.appendChild(mediaUpload);
+
+      const clearMedia = document.createElement('button');
+      clearMedia.type = 'button';
+      clearMedia.className = 'ghost-btn';
+      clearMedia.textContent = 'Remove media';
+      clearMedia.addEventListener('click', () => {
+        question.media = '';
+        mediaInput.value = '';
+        mediaUpload.value = '';
+        updatePreview();
+      });
+      mediaLabel.appendChild(clearMedia);
+      card.appendChild(mediaLabel);
+
+      const preview = document.createElement('div');
+      preview.className = 'exam-media-preview';
+      function updatePreview() {
+        preview.innerHTML = '';
+        const el = mediaElement(question.media);
+        if (el) preview.appendChild(el);
+      }
+      updatePreview();
+      card.appendChild(preview);
+
+      const tagsLabel = document.createElement('label');
+      tagsLabel.textContent = 'Tags (comma separated)';
+      const tagsInput = document.createElement('input');
+      tagsInput.className = 'input';
+      tagsInput.value = question.tags.join(', ');
+      tagsInput.addEventListener('input', () => {
+        question.tags = tagsInput.value.split(',').map(t => t.trim()).filter(Boolean);
+      });
+      tagsLabel.appendChild(tagsInput);
+      card.appendChild(tagsLabel);
+
+      const explanationLabel = document.createElement('label');
+      explanationLabel.textContent = 'Explanation';
+      const explanationInput = document.createElement('textarea');
+      explanationInput.className = 'input';
+      explanationInput.value = question.explanation || '';
+      explanationInput.addEventListener('input', () => { question.explanation = explanationInput.value; });
+      explanationLabel.appendChild(explanationInput);
+      card.appendChild(explanationLabel);
+
+      const optionsWrap = document.createElement('div');
+      optionsWrap.className = 'exam-option-editor-list';
+
+      function renderOptions() {
+        optionsWrap.innerHTML = '';
+        question.options.forEach((opt, optIdx) => {
+          const row = document.createElement('div');
+          row.className = 'exam-option-editor';
+
+          const radio = document.createElement('input');
+          radio.type = 'radio';
+          radio.name = `correct-${question.id}`;
+          radio.checked = question.answer === opt.id;
+          radio.addEventListener('change', () => { question.answer = opt.id; });
+
+          const text = document.createElement('input');
+          text.className = 'input';
+          text.type = 'text';
+          text.placeholder = `Option ${optIdx + 1}`;
+          text.value = opt.text;
+          text.addEventListener('input', () => { opt.text = text.value; });
+
+          const removeBtn = document.createElement('button');
+          removeBtn.type = 'button';
+          removeBtn.className = 'ghost-btn';
+          removeBtn.textContent = 'Remove';
+          removeBtn.disabled = question.options.length <= 2;
+          removeBtn.addEventListener('click', () => {
+            question.options.splice(optIdx, 1);
+            if (question.answer === opt.id) {
+              question.answer = question.options[0]?.id || '';
+            }
+            renderOptions();
+          });
+
+          row.appendChild(radio);
+          row.appendChild(text);
+          row.appendChild(removeBtn);
+          optionsWrap.appendChild(row);
+        });
+      }
+
+      renderOptions();
+
+      const addOption = document.createElement('button');
+      addOption.type = 'button';
+      addOption.className = 'btn secondary';
+      addOption.textContent = 'Add Option';
+      addOption.addEventListener('click', () => {
+        const opt = { id: uid(), text: '' };
+        question.options.push(opt);
+        renderOptions();
+      });
+
+      card.appendChild(optionsWrap);
+      card.appendChild(addOption);
+
+      questionSection.appendChild(card);
+    });
+  }
+
+  renderQuestions();
+
+  const actions = document.createElement('div');
+  actions.className = 'modal-actions';
+
+  const cancel = document.createElement('button');
+  cancel.type = 'button';
+  cancel.className = 'btn secondary';
+  cancel.textContent = 'Cancel';
+  cancel.addEventListener('click', () => document.body.removeChild(overlay));
+  actions.appendChild(cancel);
+
+  const save = document.createElement('button');
+  save.type = 'submit';
+  save.className = 'btn';
+  save.textContent = 'Save Exam';
+  actions.appendChild(save);
+
+  form.appendChild(actions);
+
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    error.textContent = '';
+
+    const title = titleInput.value.trim();
+    if (!title) {
+      error.textContent = 'Exam title is required.';
+      return;
+    }
+
+    if (!exam.questions.length) {
+      error.textContent = 'Add at least one question.';
+      return;
+    }
+
+    for (let i = 0; i < exam.questions.length; i++) {
+      const question = exam.questions[i];
+      question.stem = question.stem.trim();
+      question.explanation = question.explanation?.trim() || '';
+      question.media = question.media?.trim() || '';
+      question.options = question.options.map(opt => ({ id: opt.id, text: opt.text.trim() })).filter(opt => opt.text);
+      if (question.options.length < 2) {
+        error.textContent = `Question ${i + 1} needs at least two answer options.`;
+        return;
+      }
+      if (!question.answer || !question.options.some(opt => opt.id === question.answer)) {
+        error.textContent = `Select a correct answer for question ${i + 1}.`;
+        return;
+      }
+      question.tags = question.tags.map(t => t.trim()).filter(Boolean);
+    }
+
+    const payload = {
+      ...exam,
+      examTitle: title,
+      updatedAt: Date.now()
+    };
+
+    await upsertExam(payload);
+    document.body.removeChild(overlay);
+    render();
+  });
+
+  overlay.appendChild(form);
+  overlay.addEventListener('click', e => {
+    if (e.target === overlay) document.body.removeChild(overlay);
+  });
+
+  document.body.appendChild(overlay);
+  titleInput.focus();
+}
+

--- a/style.css
+++ b/style.css
@@ -199,6 +199,14 @@ input[type="checkbox"]:checked::after {
   padding: 6px 12px;
   cursor: pointer;
 }
+.btn.secondary {
+  background: var(--muted);
+  color: var(--text);
+}
+.btn.danger {
+  background: #f97373;
+  color: #000;
+}
 
 .modal {
   position: fixed;
@@ -1030,3 +1038,566 @@ body.map-toolbox-dragging {
   fill: var(--pink);
   font-weight: 600;
 }
+
+/* Exams */
+.exam-view {
+  padding: var(--pad-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-lg);
+}
+
+.exam-controls {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+}
+
+.exam-heading h1 {
+  margin: 0;
+}
+
+.exam-heading p {
+  margin: 4px 0 0;
+  color: var(--gray);
+  font-size: 0.95rem;
+}
+
+.exam-control-actions {
+  display: flex;
+  gap: var(--pad);
+  flex-wrap: wrap;
+}
+
+.exam-status {
+  color: #f97373;
+  min-height: 1.2em;
+}
+
+.exam-grid {
+  display: grid;
+  gap: var(--pad-lg);
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.exam-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+}
+
+.exam-card-title {
+  margin: 0;
+}
+
+.exam-card-meta {
+  display: flex;
+  gap: var(--pad);
+  flex-wrap: wrap;
+  color: var(--gray);
+  font-size: 0.9rem;
+}
+
+.exam-card-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad);
+}
+
+.exam-stat {
+  background: var(--muted);
+  border-radius: var(--radius);
+  padding: var(--pad-sm) var(--pad);
+  min-width: 110px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.exam-stat-label {
+  font-size: 0.75rem;
+  color: var(--gray);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.exam-stat-value {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.exam-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad);
+}
+
+.exam-attempts {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+}
+
+.exam-attempts h3 {
+  margin: 0;
+}
+
+.exam-attempt-empty {
+  margin: 0;
+  color: var(--gray);
+}
+
+.exam-attempt-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+}
+
+.exam-attempt-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--pad);
+  background: var(--muted);
+  border-radius: var(--radius);
+  padding: var(--pad-sm) var(--pad);
+}
+
+.exam-attempt-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.exam-attempt-score {
+  font-weight: 600;
+}
+
+.exam-attempt-meta {
+  color: var(--gray);
+  font-size: 0.85rem;
+}
+
+.exam-empty {
+  text-align: center;
+  color: var(--gray);
+  padding: 80px 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  align-items: center;
+}
+
+.exam-session {
+  padding: var(--pad-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-lg);
+}
+
+.exam-runner {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-lg);
+}
+
+@media (min-width: 960px) {
+  .exam-runner {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+}
+
+.exam-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--pad-lg);
+}
+
+.exam-sidebar {
+  width: 280px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--pad-lg);
+}
+
+@media (max-width: 959px) {
+  .exam-sidebar {
+    width: 100%;
+  }
+}
+
+.exam-topbar {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--pad);
+  align-items: center;
+}
+
+.exam-progress {
+  font-weight: 600;
+}
+
+.flag-btn {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--gray);
+  padding: 6px 12px;
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+
+.flag-btn:hover {
+  transform: none;
+  box-shadow: none;
+}
+
+.flag-btn.active {
+  background: rgba(255, 144, 194, 0.15);
+  color: var(--pink);
+  border-color: var(--pink);
+}
+
+.flag-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.exam-stem {
+  white-space: pre-wrap;
+  line-height: 1.6;
+}
+
+.exam-media img,
+.exam-media video {
+  width: 100%;
+  max-height: 320px;
+  border-radius: var(--radius);
+  object-fit: contain;
+}
+
+.exam-media audio {
+  width: 100%;
+}
+
+.exam-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.exam-tag {
+  background: var(--muted);
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 0.8rem;
+  color: var(--gray);
+}
+
+.exam-options {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+}
+
+.exam-option {
+  background: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--pad);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.exam-option:hover {
+  transform: none;
+  box-shadow: none;
+  border-color: var(--blue);
+}
+
+.exam-option.selected {
+  border-color: var(--blue);
+  box-shadow: 0 0 0 2px rgba(166, 217, 255, 0.25);
+  background: rgba(166, 217, 255, 0.12);
+}
+
+.exam-option.correct-answer {
+  border-color: var(--green);
+  background: rgba(164, 251, 196, 0.18);
+}
+
+.exam-option.incorrect-answer {
+  border-color: #f97373;
+  background: rgba(249, 115, 115, 0.18);
+}
+
+.exam-option.chosen::after {
+  content: 'Your answer';
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  font-size: 0.75rem;
+  color: var(--gray);
+}
+
+.exam-option.chosen {
+  position: relative;
+}
+
+.exam-option.review {
+  cursor: default;
+}
+
+.exam-option.review:hover {
+  border-color: var(--border);
+}
+
+.exam-warning {
+  color: #fbbf24;
+}
+
+.exam-verdict {
+  font-weight: 600;
+  padding: 8px 12px;
+  border-radius: var(--radius);
+}
+
+.exam-verdict.correct {
+  background: rgba(164, 251, 196, 0.18);
+  color: var(--green);
+}
+
+.exam-verdict.incorrect {
+  background: rgba(249, 115, 115, 0.18);
+  color: #f97373;
+}
+
+.exam-verdict.neutral {
+  background: var(--muted);
+  color: var(--gray);
+}
+
+.exam-answer-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.exam-explanation {
+  background: var(--muted);
+  border-radius: var(--radius);
+  padding: var(--pad);
+}
+
+.exam-explanation h3 {
+  margin: 0 0 4px;
+}
+
+.exam-palette {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+}
+
+.exam-palette-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(40px, 1fr));
+  gap: 6px;
+}
+
+.palette-button {
+  background: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 8px 0;
+  cursor: pointer;
+  color: var(--text);
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.palette-button:hover {
+  transform: none;
+  box-shadow: none;
+  border-color: var(--blue);
+}
+
+.palette-button.active {
+  background: var(--blue);
+  color: #000;
+}
+
+.palette-button.answered {
+  border-color: var(--blue);
+}
+
+.palette-button.flagged {
+  border-color: var(--pink);
+}
+
+.exam-sidebar-info {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--gray);
+  font-size: 0.9rem;
+}
+
+.exam-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad);
+  justify-content: flex-end;
+}
+
+.exam-summary {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--pad-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  align-items: center;
+  text-align: center;
+}
+
+.exam-summary-score {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.score-number {
+  font-size: 2.5rem;
+  font-weight: 700;
+}
+
+.score-percent {
+  font-size: 1.2rem;
+  color: var(--gray);
+}
+
+.exam-summary-metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad);
+  justify-content: center;
+}
+
+.exam-summary-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad);
+  justify-content: center;
+}
+
+.exam-error {
+  color: #f97373;
+  min-height: 1.2em;
+}
+
+.exam-editor {
+  width: min(960px, 95vw);
+  max-height: 90vh;
+  overflow-y: auto;
+  gap: var(--pad);
+}
+
+.exam-timer-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad);
+}
+
+.exam-question-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+}
+
+.exam-question-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--pad);
+  margin-top: var(--pad);
+}
+
+.exam-question-empty {
+  color: var(--gray);
+  margin: 0;
+}
+
+.exam-question-editor {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--pad);
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  background: var(--panel);
+}
+
+.exam-question-editor-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.ghost-btn {
+  background: none;
+  border: 1px solid transparent;
+  color: var(--gray);
+  padding: 4px 8px;
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+
+.ghost-btn:hover {
+  border-color: var(--border);
+  color: var(--text);
+  transform: none;
+  box-shadow: none;
+}
+
+.exam-media-preview {
+  border: 1px dashed var(--border);
+  border-radius: var(--radius);
+  padding: var(--pad-sm);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 60px;
+}
+
+.exam-media-preview .exam-media {
+  width: 100%;
+}
+
+.exam-option-editor-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+}
+
+.exam-option-editor {
+  display: flex;
+  align-items: center;
+  gap: var(--pad);
+}
+
+.exam-option-editor .input {
+  flex: 1;
+}
+


### PR DESCRIPTION
## Summary
- overhaul the exams tab to support importing, creating, launching, reviewing and deleting exams with full attempt history
- implement a modern exam runner with navigation, flagging, scoring summaries and review flows tied to stored results
- add an in-app exam editor that supports rich question editing, media attachments and validation while refreshing the bundle and styles

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68c9d6c695908322ab8220bb25ca0f78