### PR TITLE
Add exam timer, session persistence, and navigation improvements

### DIFF
--- a/js/state.js
+++ b/js/state.js
@@ -17,6 +17,7 @@ export const state = {
   quizSession: null,
   flashSession: null,
   examSession: null,
+  examAttemptExpanded: {},
   map: { panzoom:false }
 };
 
@@ -31,3 +32,6 @@ export function setFlashSession(sess){ state.flashSession = sess; }
 export function setQuizSession(sess){ state.quizSession = sess; }
 export function setReviewConfig(patch){ Object.assign(state.review, patch); }
 export function setExamSession(sess){ state.examSession = sess; }
+export function setExamAttemptExpanded(examId, expanded){
+  state.examAttemptExpanded[examId] = expanded;
+}

--- a/js/storage/idb.js
+++ b/js/storage/idb.js
@@ -1,5 +1,5 @@
 const DB_NAME = 'sevenn-db';
-const DB_VERSION = 2;
+const DB_VERSION = 3;
 
 export function openDB() {
   return new Promise((resolve, reject) => {
@@ -40,6 +40,11 @@ export function openDB() {
 
       if (!db.objectStoreNames.contains('settings')) {
         db.createObjectStore('settings', { keyPath: 'id' });
+      }
+
+      if (!db.objectStoreNames.contains('exam_sessions')) {
+        const sessions = db.createObjectStore('exam_sessions', { keyPath: 'examId' });
+        sessions.createIndex('by_updatedAt', 'updatedAt');
       }
     };
     req.onsuccess = () => {

--- a/js/storage/storage.js
+++ b/js/storage/storage.js
@@ -283,5 +283,26 @@ export async function deleteExam(id) {
   await prom(e.delete(id));
 }
 
+export async function listExamSessions() {
+  const s = await store('exam_sessions');
+  return await prom(s.getAll());
+}
+
+export async function loadExamSession(examId) {
+  const s = await store('exam_sessions');
+  return await prom(s.get(examId));
+}
+
+export async function saveExamSessionProgress(progress) {
+  const s = await store('exam_sessions', 'readwrite');
+  const now = Date.now();
+  await prom(s.put({ ...progress, updatedAt: now }));
+}
+
+export async function deleteExamSessionProgress(examId) {
+  const s = await store('exam_sessions', 'readwrite');
+  await prom(s.delete(examId));
+}
+
 // export/import helpers
 export { exportJSON, importJSON, exportAnkiCSV };

--- a/style.css
+++ b/style.css
@@ -1104,6 +1104,15 @@ body.map-toolbox-dragging {
   gap: var(--pad);
 }
 
+.exam-saved-banner {
+  background: rgba(166, 217, 255, 0.15);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--pad-sm) var(--pad);
+  color: var(--blue);
+  font-size: 0.9rem;
+}
+
 .exam-stat {
   background: var(--muted);
   border-radius: var(--radius);
@@ -1140,6 +1149,32 @@ body.map-toolbox-dragging {
 
 .exam-attempts h3 {
   margin: 0;
+}
+
+.exam-attempts-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--pad);
+}
+
+.exam-attempts.collapsed .exam-attempt-list {
+  display: none;
+}
+
+.exam-attempt-toggle {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--gray);
+  font-size: 0.85rem;
+  padding: 4px 10px;
+}
+
+.exam-attempt-toggle:hover {
+  transform: none;
+  box-shadow: none;
+  border-color: var(--blue);
+  color: var(--blue);
 }
 
 .exam-attempt-empty {
@@ -1246,6 +1281,14 @@ body.map-toolbox-dragging {
 
 .exam-progress {
   font-weight: 600;
+}
+
+.exam-timer {
+  margin-left: auto;
+  font-weight: 600;
+  background: var(--muted);
+  border-radius: var(--radius);
+  padding: 6px 12px;
 }
 
 .flag-btn {


### PR DESCRIPTION
## Summary
- add a live countdown for timed exams and display remaining time in the runner sidebar
- allow exam attempts to be saved and resumed via a new Save & Exit flow and resume controls
- enhance the exam runner with per-question checking for untimed mode, arrow key navigation, export actions, and collapsible attempt history

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9f29b8228832286fc7a1118df5b23