### PR TITLE
Add IndexedDB fallback to memory storage

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -57,17 +57,280 @@ var Sevenn = (() => {
   // js/storage/idb.js
   var DB_NAME = "sevenn-db";
   var DB_VERSION = 3;
+  var MEMORY_STORAGE_KEY = "sevenn-memory-db";
+  var STORE_KEY_PATHS = {
+    items: "id",
+    blocks: "blockId",
+    exams: "id",
+    settings: "id",
+    exam_sessions: "examId"
+  };
+  var enqueue = typeof queueMicrotask === "function" ? queueMicrotask.bind(globalThis) : ((cb) => Promise.resolve().then(cb));
+  function clone(value) {
+    if (value == null) return value;
+    return JSON.parse(JSON.stringify(value));
+  }
+  var MemoryRequest = class {
+    constructor(tx, executor) {
+      this.result = void 0;
+      this.error = null;
+      this.onsuccess = null;
+      this.onerror = null;
+      tx._requestStarted();
+      enqueue(() => {
+        try {
+          this.result = executor();
+          if (typeof this.onsuccess === "function") {
+            this.onsuccess({ target: this });
+          }
+          tx._requestFinished();
+        } catch (err) {
+          this.error = err;
+          if (typeof this.onerror === "function") {
+            this.onerror({ target: this });
+          }
+          tx._requestFailed(err);
+        }
+      });
+    }
+  };
+  var MemoryIndex = class {
+    constructor(store2, extractor, multiEntry = false) {
+      this.store = store2;
+      this.extractor = extractor;
+      this.multiEntry = multiEntry;
+    }
+    getAll(value) {
+      return new MemoryRequest(this.store.tx, () => {
+        const results = [];
+        for (const item of this.store._map().values()) {
+          const extracted = this.extractor(item);
+          if (this.multiEntry && Array.isArray(extracted)) {
+            if (extracted.includes(value)) results.push(clone(item));
+          } else if (extracted === value) {
+            results.push(clone(item));
+          }
+        }
+        return results;
+      });
+    }
+  };
+  var MemoryStore = class {
+    constructor(tx, name) {
+      this.tx = tx;
+      this.name = name;
+    }
+    _map() {
+      if (!this.tx.db.maps[this.name]) {
+        this.tx.db.maps[this.name] = /* @__PURE__ */ new Map();
+      }
+      return this.tx.db.maps[this.name];
+    }
+    _keyFromValue(value) {
+      const keyPath = STORE_KEY_PATHS[this.name];
+      if (!keyPath) return void 0;
+      return value?.[keyPath];
+    }
+    get(key) {
+      return new MemoryRequest(this.tx, () => {
+        const found = this._map().get(key);
+        return clone(found);
+      });
+    }
+    getAll() {
+      return new MemoryRequest(this.tx, () => {
+        return Array.from(this._map().values()).map(clone);
+      });
+    }
+    put(value) {
+      return new MemoryRequest(this.tx, () => {
+        const key = this._keyFromValue(value);
+        if (key == null) throw new Error(`Missing key for store ${this.name}`);
+        this._map().set(key, clone(value));
+        this.tx.db._persist();
+        return clone(value);
+      });
+    }
+    delete(key) {
+      return new MemoryRequest(this.tx, () => {
+        this._map().delete(key);
+        this.tx.db._persist();
+        return void 0;
+      });
+    }
+    clear() {
+      return new MemoryRequest(this.tx, () => {
+        this._map().clear();
+        this.tx.db._persist();
+        return void 0;
+      });
+    }
+    index(name) {
+      if (this.name === "items" && name === "by_kind") {
+        return new MemoryIndex(this, (item) => item.kind || null);
+      }
+      return {
+        getAll: () => new MemoryRequest(this.tx, () => [])
+      };
+    }
+  };
+  var MemoryTransaction = class {
+    constructor(db, names, mode) {
+      this.db = db;
+      this.names = Array.isArray(names) ? names : [names];
+      this.mode = mode;
+      this._stores = /* @__PURE__ */ new Map();
+      this._pending = 0;
+      this._failed = false;
+      this._completePending = false;
+      this._errorPending = null;
+      this._oncomplete = null;
+      this._onerror = null;
+      Object.defineProperty(this, "oncomplete", {
+        get: () => this._oncomplete,
+        set: (fn) => {
+          this._oncomplete = fn;
+          if (this._completePending && typeof fn === "function") {
+            this._completePending = false;
+            enqueue(() => fn({ target: this }));
+          }
+        }
+      });
+      Object.defineProperty(this, "onerror", {
+        get: () => this._onerror,
+        set: (fn) => {
+          this._onerror = fn;
+          if (this._errorPending && typeof fn === "function") {
+            const err = this._errorPending;
+            this._errorPending = null;
+            enqueue(() => fn({ target: this, error: err }));
+          }
+        }
+      });
+    }
+    objectStore(name) {
+      if (!this._stores.has(name)) {
+        this._stores.set(name, new MemoryStore(this, name));
+      }
+      return this._stores.get(name);
+    }
+    _requestStarted() {
+      this._pending += 1;
+    }
+    _requestFinished() {
+      if (this._pending > 0) this._pending -= 1;
+      if (this._pending === 0 && !this._failed) {
+        if (typeof this._oncomplete === "function") {
+          enqueue(() => this._oncomplete({ target: this }));
+        } else {
+          this._completePending = true;
+        }
+      }
+    }
+    _requestFailed(error) {
+      this._failed = true;
+      if (typeof this._onerror === "function") {
+        enqueue(() => this._onerror({ target: this, error }));
+      } else {
+        this._errorPending = error;
+      }
+    }
+  };
+  var MemoryDB = class {
+    constructor() {
+      this.maps = {};
+      this.persistKey = MEMORY_STORAGE_KEY;
+      this.canPersist = false;
+      if (typeof localStorage !== "undefined") {
+        try {
+          const testKey = `${MEMORY_STORAGE_KEY}-test`;
+          localStorage.setItem(testKey, "1");
+          localStorage.removeItem(testKey);
+          this.canPersist = true;
+        } catch (err) {
+          this.canPersist = false;
+        }
+      }
+      for (const name of Object.keys(STORE_KEY_PATHS)) {
+        this.maps[name] = /* @__PURE__ */ new Map();
+      }
+      this._load();
+    }
+    _load() {
+      if (!this.canPersist) return;
+      try {
+        const raw = localStorage.getItem(this.persistKey);
+        if (!raw) return;
+        const parsed = JSON.parse(raw);
+        for (const name of Object.keys(STORE_KEY_PATHS)) {
+          const list = parsed?.[name];
+          if (Array.isArray(list)) {
+            for (const entry of list) {
+              const keyPath = STORE_KEY_PATHS[name];
+              const key = entry?.[keyPath];
+              if (key != null) {
+                this.maps[name].set(key, clone(entry));
+              }
+            }
+          }
+        }
+      } catch (err) {
+        console.warn("Failed to load memory DB from storage", err);
+        for (const name of Object.keys(STORE_KEY_PATHS)) {
+          this.maps[name].clear();
+        }
+      }
+    }
+    _persist() {
+      if (!this.canPersist) return;
+      try {
+        const payload = {};
+        for (const name of Object.keys(STORE_KEY_PATHS)) {
+          payload[name] = Array.from(this.maps[name].values()).map(clone);
+        }
+        localStorage.setItem(this.persistKey, JSON.stringify(payload));
+      } catch (err) {
+        console.warn("Failed to persist memory DB", err);
+        this.canPersist = false;
+      }
+    }
+    transaction(names, mode = "readonly") {
+      return new MemoryTransaction(this, names, mode);
+    }
+    close() {
+    }
+  };
+  function fallbackToMemory(message, error) {
+    if (message) {
+      console.warn(message, error);
+    }
+    return new MemoryDB();
+  }
   function openDB() {
-    return new Promise((resolve, reject) => {
-      if (!("indexedDB" in globalThis)) {
-        reject(new Error("IndexedDB not supported"));
+    if (!("indexedDB" in globalThis)) {
+      return Promise.resolve(fallbackToMemory("IndexedDB unavailable, using in-memory storage."));
+    }
+    return new Promise((resolve) => {
+      let settled = false;
+      let req;
+      try {
+        req = indexedDB.open(DB_NAME, DB_VERSION);
+      } catch (err) {
+        settled = true;
+        resolve(fallbackToMemory("IndexedDB threw during open, using in-memory storage.", err));
         return;
       }
-      const req = indexedDB.open(DB_NAME, DB_VERSION);
-      const timer = setTimeout(() => reject(new Error("IndexedDB open timeout")), 5e3);
+      const timer = setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          resolve(fallbackToMemory("IndexedDB open timeout, using in-memory storage."));
+        }
+      }, 5e3);
       req.onerror = () => {
+        if (settled) return;
+        settled = true;
         clearTimeout(timer);
-        reject(req.error);
+        resolve(fallbackToMemory("IndexedDB failed to open, using in-memory storage.", req.error));
       };
       req.onupgradeneeded = () => {
         const db = req.result;
@@ -99,6 +362,8 @@ var Sevenn = (() => {
         }
       };
       req.onsuccess = () => {
+        if (settled) return;
+        settled = true;
         clearTimeout(timer);
         resolve(req.result);
       };
@@ -2075,7 +2340,7 @@ var Sevenn = (() => {
   var keyHandler = null;
   var keyHandlerSession = null;
   var lastExamStatusMessage = "";
-  function clone(value) {
+  function clone2(value) {
     return value ? JSON.parse(JSON.stringify(value)) : value;
   }
   function totalExamTimeMs(exam) {
@@ -2201,7 +2466,7 @@ var Sevenn = (() => {
     }
   }
   function ensureExamShape(exam) {
-    const next = clone(exam) || {};
+    const next = clone2(exam) || {};
     let changed = false;
     if (!next.id) {
       next.id = uid();
@@ -2317,7 +2582,7 @@ var Sevenn = (() => {
     };
   }
   function createTakingSession(exam) {
-    const snapshot = clone(exam);
+    const snapshot = clone2(exam);
     const totalMs = snapshot.timerMode === "timed" ? totalExamTimeMs(snapshot) : null;
     return {
       mode: "taking",
@@ -2333,7 +2598,7 @@ var Sevenn = (() => {
   }
   function hydrateSavedSession(saved, fallbackExam) {
     const baseExam = saved?.exam ? ensureExamShape(saved.exam).exam : fallbackExam;
-    const exam = clone(baseExam);
+    const exam = clone2(baseExam);
     const questionCount = exam.questions.length;
     const idx = Math.min(Math.max(Number(saved?.idx) || 0, 0), Math.max(0, questionCount - 1));
     const remaining = typeof saved?.remainingMs === "number" ? Math.max(0, saved.remainingMs) : exam.timerMode === "timed" ? totalExamTimeMs(exam) : null;
@@ -2518,7 +2783,7 @@ var Sevenn = (() => {
       reviewBtn.className = "btn secondary";
       reviewBtn.textContent = "Review Last Attempt";
       reviewBtn.addEventListener("click", () => {
-        setExamSession({ mode: "review", exam: clone(exam), result: clone(last), idx: 0 });
+        setExamSession({ mode: "review", exam: clone2(exam), result: clone2(last), idx: 0 });
         render2();
       });
       actions.appendChild(reviewBtn);
@@ -2613,7 +2878,7 @@ var Sevenn = (() => {
     review.className = "btn secondary";
     review.textContent = "Review";
     review.addEventListener("click", () => {
-      setExamSession({ mode: "review", exam: clone(exam), result: clone(result), idx: 0 });
+      setExamSession({ mode: "review", exam: clone2(exam), result: clone2(result), idx: 0 });
       render2();
     });
     row.appendChild(review);
@@ -3021,7 +3286,7 @@ var Sevenn = (() => {
     stopTimer(sess);
     const payload = {
       examId: sess.exam.id,
-      exam: clone(sess.exam),
+      exam: clone2(sess.exam),
       idx: sess.idx,
       answers: { ...sess.answers || {} },
       flagged: { ...sess.flagged || {} },
@@ -3066,7 +3331,7 @@ var Sevenn = (() => {
       durationMs: sess.elapsedMs || 0,
       answered: answeredCount
     };
-    const updatedExam = clone(sess.exam);
+    const updatedExam = clone2(sess.exam);
     updatedExam.results = [...updatedExam.results || [], result];
     updatedExam.updatedAt = Date.now();
     await upsertExam(updatedExam);
@@ -3104,10 +3369,10 @@ var Sevenn = (() => {
     reviewBtn.addEventListener("click", () => {
       setExamSession({
         mode: "review",
-        exam: clone(sess.exam),
-        result: clone(sess.latestResult),
+        exam: clone2(sess.exam),
+        result: clone2(sess.latestResult),
         idx: 0,
-        fromSummary: clone(sess.latestResult)
+        fromSummary: clone2(sess.latestResult)
       });
       render2();
     });

--- a/js/storage/idb.js
+++ b/js/storage/idb.js
@@ -1,17 +1,309 @@
 const DB_NAME = 'sevenn-db';
 const DB_VERSION = 3;
+const MEMORY_STORAGE_KEY = 'sevenn-memory-db';
+
+const STORE_KEY_PATHS = {
+  items: 'id',
+  blocks: 'blockId',
+  exams: 'id',
+  settings: 'id',
+  exam_sessions: 'examId'
+};
+
+const enqueue = typeof queueMicrotask === 'function'
+  ? queueMicrotask.bind(globalThis)
+  : (cb => Promise.resolve().then(cb));
+
+function clone(value) {
+  if (value == null) return value;
+  return JSON.parse(JSON.stringify(value));
+}
+
+class MemoryRequest {
+  constructor(tx, executor) {
+    this.result = undefined;
+    this.error = null;
+    this.onsuccess = null;
+    this.onerror = null;
+    tx._requestStarted();
+    enqueue(() => {
+      try {
+        this.result = executor();
+        if (typeof this.onsuccess === 'function') {
+          this.onsuccess({ target: this });
+        }
+        tx._requestFinished();
+      } catch (err) {
+        this.error = err;
+        if (typeof this.onerror === 'function') {
+          this.onerror({ target: this });
+        }
+        tx._requestFailed(err);
+      }
+    });
+  }
+}
+
+class MemoryIndex {
+  constructor(store, extractor, multiEntry = false) {
+    this.store = store;
+    this.extractor = extractor;
+    this.multiEntry = multiEntry;
+  }
+
+  getAll(value) {
+    return new MemoryRequest(this.store.tx, () => {
+      const results = [];
+      for (const item of this.store._map().values()) {
+        const extracted = this.extractor(item);
+        if (this.multiEntry && Array.isArray(extracted)) {
+          if (extracted.includes(value)) results.push(clone(item));
+        } else if (extracted === value) {
+          results.push(clone(item));
+        }
+      }
+      return results;
+    });
+  }
+}
+
+class MemoryStore {
+  constructor(tx, name) {
+    this.tx = tx;
+    this.name = name;
+  }
+
+  _map() {
+    if (!this.tx.db.maps[this.name]) {
+      this.tx.db.maps[this.name] = new Map();
+    }
+    return this.tx.db.maps[this.name];
+  }
+
+  _keyFromValue(value) {
+    const keyPath = STORE_KEY_PATHS[this.name];
+    if (!keyPath) return undefined;
+    return value?.[keyPath];
+  }
+
+  get(key) {
+    return new MemoryRequest(this.tx, () => {
+      const found = this._map().get(key);
+      return clone(found);
+    });
+  }
+
+  getAll() {
+    return new MemoryRequest(this.tx, () => {
+      return Array.from(this._map().values()).map(clone);
+    });
+  }
+
+  put(value) {
+    return new MemoryRequest(this.tx, () => {
+      const key = this._keyFromValue(value);
+      if (key == null) throw new Error(`Missing key for store ${this.name}`);
+      this._map().set(key, clone(value));
+      this.tx.db._persist();
+      return clone(value);
+    });
+  }
+
+  delete(key) {
+    return new MemoryRequest(this.tx, () => {
+      this._map().delete(key);
+      this.tx.db._persist();
+      return undefined;
+    });
+  }
+
+  clear() {
+    return new MemoryRequest(this.tx, () => {
+      this._map().clear();
+      this.tx.db._persist();
+      return undefined;
+    });
+  }
+
+  index(name) {
+    if (this.name === 'items' && name === 'by_kind') {
+      return new MemoryIndex(this, item => item.kind || null);
+    }
+    return {
+      getAll: () => new MemoryRequest(this.tx, () => [])
+    };
+  }
+}
+
+class MemoryTransaction {
+  constructor(db, names, mode) {
+    this.db = db;
+    this.names = Array.isArray(names) ? names : [names];
+    this.mode = mode;
+    this._stores = new Map();
+    this._pending = 0;
+    this._failed = false;
+    this._completePending = false;
+    this._errorPending = null;
+    this._oncomplete = null;
+    this._onerror = null;
+
+    Object.defineProperty(this, 'oncomplete', {
+      get: () => this._oncomplete,
+      set: fn => {
+        this._oncomplete = fn;
+        if (this._completePending && typeof fn === 'function') {
+          this._completePending = false;
+          enqueue(() => fn({ target: this }));
+        }
+      }
+    });
+
+    Object.defineProperty(this, 'onerror', {
+      get: () => this._onerror,
+      set: fn => {
+        this._onerror = fn;
+        if (this._errorPending && typeof fn === 'function') {
+          const err = this._errorPending;
+          this._errorPending = null;
+          enqueue(() => fn({ target: this, error: err }));
+        }
+      }
+    });
+  }
+
+  objectStore(name) {
+    if (!this._stores.has(name)) {
+      this._stores.set(name, new MemoryStore(this, name));
+    }
+    return this._stores.get(name);
+  }
+
+  _requestStarted() {
+    this._pending += 1;
+  }
+
+  _requestFinished() {
+    if (this._pending > 0) this._pending -= 1;
+    if (this._pending === 0 && !this._failed) {
+      if (typeof this._oncomplete === 'function') {
+        enqueue(() => this._oncomplete({ target: this }));
+      } else {
+        this._completePending = true;
+      }
+    }
+  }
+
+  _requestFailed(error) {
+    this._failed = true;
+    if (typeof this._onerror === 'function') {
+      enqueue(() => this._onerror({ target: this, error }));
+    } else {
+      this._errorPending = error;
+    }
+  }
+}
+
+class MemoryDB {
+  constructor() {
+    this.maps = {};
+    this.persistKey = MEMORY_STORAGE_KEY;
+    this.canPersist = false;
+    if (typeof localStorage !== 'undefined') {
+      try {
+        const testKey = `${MEMORY_STORAGE_KEY}-test`;
+        localStorage.setItem(testKey, '1');
+        localStorage.removeItem(testKey);
+        this.canPersist = true;
+      } catch (err) {
+        this.canPersist = false;
+      }
+    }
+    for (const name of Object.keys(STORE_KEY_PATHS)) {
+      this.maps[name] = new Map();
+    }
+    this._load();
+  }
+
+  _load() {
+    if (!this.canPersist) return;
+    try {
+      const raw = localStorage.getItem(this.persistKey);
+      if (!raw) return;
+      const parsed = JSON.parse(raw);
+      for (const name of Object.keys(STORE_KEY_PATHS)) {
+        const list = parsed?.[name];
+        if (Array.isArray(list)) {
+          for (const entry of list) {
+            const keyPath = STORE_KEY_PATHS[name];
+            const key = entry?.[keyPath];
+            if (key != null) {
+              this.maps[name].set(key, clone(entry));
+            }
+          }
+        }
+      }
+    } catch (err) {
+      console.warn('Failed to load memory DB from storage', err);
+      for (const name of Object.keys(STORE_KEY_PATHS)) {
+        this.maps[name].clear();
+      }
+    }
+  }
+
+  _persist() {
+    if (!this.canPersist) return;
+    try {
+      const payload = {};
+      for (const name of Object.keys(STORE_KEY_PATHS)) {
+        payload[name] = Array.from(this.maps[name].values()).map(clone);
+      }
+      localStorage.setItem(this.persistKey, JSON.stringify(payload));
+    } catch (err) {
+      console.warn('Failed to persist memory DB', err);
+      this.canPersist = false;
+    }
+  }
+
+  transaction(names, mode = 'readonly') {
+    return new MemoryTransaction(this, names, mode);
+  }
+
+  close() {}
+}
+
+function fallbackToMemory(message, error) {
+  if (message) {
+    console.warn(message, error);
+  }
+  return new MemoryDB();
+}
 
 export function openDB() {
-  return new Promise((resolve, reject) => {
-    if (!('indexedDB' in globalThis)) {
-      reject(new Error('IndexedDB not supported'));
+  if (!('indexedDB' in globalThis)) {
+    return Promise.resolve(fallbackToMemory('IndexedDB unavailable, using in-memory storage.'));
+  }
+  return new Promise(resolve => {
+    let settled = false;
+    let req;
+    try {
+      req = indexedDB.open(DB_NAME, DB_VERSION);
+    } catch (err) {
+      settled = true;
+      resolve(fallbackToMemory('IndexedDB threw during open, using in-memory storage.', err));
       return;
     }
-    const req = indexedDB.open(DB_NAME, DB_VERSION);
-    const timer = setTimeout(() => reject(new Error('IndexedDB open timeout')), 5000);
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        resolve(fallbackToMemory('IndexedDB open timeout, using in-memory storage.'));
+      }
+    }, 5000);
     req.onerror = () => {
+      if (settled) return;
+      settled = true;
       clearTimeout(timer);
-      reject(req.error);
+      resolve(fallbackToMemory('IndexedDB failed to open, using in-memory storage.', req.error));
     };
     req.onupgradeneeded = () => {
       const db = req.result;
@@ -48,6 +340,8 @@ export function openDB() {
       }
     };
     req.onsuccess = () => {
+      if (settled) return;
+      settled = true;
       clearTimeout(timer);
       resolve(req.result);
     };


### PR DESCRIPTION
## Summary
- add a lightweight in-memory/localStorage IndexedDB shim so the app still boots when IndexedDB APIs are unavailable
- update the production bundle to include the new storage fallback implementation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca409285b08322adab1dec8071b657