### PR TITLE
Revamp study builder and blocks mode

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -8,6 +8,7 @@ import { renderBuilder } from './ui/components/builder.js';
 import { renderFlashcards } from './ui/components/flashcards.js';
 import { renderReview } from './ui/components/review.js';
 import { renderQuiz } from './ui/components/quiz.js';
+import { renderBlockMode } from './ui/components/block-mode.js';
 import { renderExams, renderExamRunner } from './ui/components/exams.js';
 import { renderMap } from './ui/components/map.js';
 
@@ -84,7 +85,7 @@ async function render() {
 
       const subnav = document.createElement('div');
       subnav.className = 'tabs row subtabs';
-      ['Flashcards','Review','Quiz'].forEach(st => {
+      ['Flashcards','Review','Quiz','Blocks'].forEach(st => {
         const sb = document.createElement('button');
         sb.className = 'tab' + (state.subtab.Study === st ? ' active' : '');
         sb.textContent = st;
@@ -108,7 +109,7 @@ async function render() {
           main.appendChild(startBtn);
         } else if (state.subtab.Study === 'Review') {
           renderReview(main, render);
-        } else {
+        } else if (state.subtab.Study === 'Quiz') {
           const startBtn = document.createElement('button');
           startBtn.className = 'btn';
           startBtn.textContent = 'Start Quiz';
@@ -117,6 +118,8 @@ async function render() {
             render();
           });
           main.appendChild(startBtn);
+        } else if (state.subtab.Study === 'Blocks') {
+          renderBlockMode(main);
         }
       }
     }

--- a/js/state.js
+++ b/js/state.js
@@ -18,7 +18,8 @@ export const state = {
   flashSession: null,
   examSession: null,
   examAttemptExpanded: {},
-  map: { panzoom:false }
+  map: { panzoom:false },
+  blockMode: { section:"", assignments:{}, reveal:{}, order:{} }
 };
 
 export function setTab(t){ state.tab = t; }
@@ -35,3 +36,5 @@ export function setExamSession(sess){ state.examSession = sess; }
 export function setExamAttemptExpanded(examId, expanded){
   state.examAttemptExpanded[examId] = expanded;
 }
+export function setBlockMode(patch){ Object.assign(state.blockMode, patch); }
+export function resetBlockMode(){ state.blockMode = { section:"", assignments:{}, reveal:{}, order:{} }; }

--- a/js/ui/components/block-mode.js
+++ b/js/ui/components/block-mode.js
@@ -1,0 +1,414 @@
+import { state, setBlockMode } from '../../state.js';
+import { sectionDefsForKind } from './sections.js';
+
+export function renderBlockMode(root) {
+  const shell = document.createElement('section');
+  shell.className = 'block-mode-shell';
+  root.appendChild(shell);
+  drawBlockMode(shell);
+}
+
+function drawBlockMode(shell) {
+  shell.innerHTML = '';
+  const redraw = () => drawBlockMode(shell);
+  const items = state.cohort || [];
+
+  if (!items.length) {
+    shell.appendChild(messageCard('Build a study set to unlock Blocks mode. Use the filters above to assemble a cohort.'));
+    return;
+  }
+
+  const sections = collectSections(items);
+  if (!sections.length) {
+    shell.appendChild(messageCard('The selected cards do not have structured sections yet. Add cards with rich content to practice in Blocks mode.'));
+    return;
+  }
+
+  let activeKey = state.blockMode.section;
+  if (!activeKey || !sections.some(sec => sec.key === activeKey)) {
+    activeKey = sections[0].key;
+    if (activeKey !== state.blockMode.section) {
+      setBlockMode({ section: activeKey });
+    }
+  }
+  const sectionData = sections.find(sec => sec.key === activeKey) || sections[0];
+
+  const entryMap = new Map();
+  sectionData.items.forEach(info => {
+    entryMap.set(entryIdFor(info.itemId, sectionData.key), info);
+  });
+
+  const validAssignments = sanitizeAssignments(sectionData.key, entryMap);
+  const assignedSet = new Set(Object.values(validAssignments));
+  const reveal = !!(state.blockMode.reveal && state.blockMode.reveal[sectionData.key]);
+
+  const bankEntries = Array.from(entryMap.entries())
+    .filter(([id]) => !assignedSet.has(id))
+    .map(([entryId, info]) => ({ entryId, value: info.value, itemId: info.itemId }));
+
+  const orderedBank = orderEntries(sectionData.key, bankEntries);
+
+  const results = sectionData.items.map(info => {
+    const entryId = entryIdFor(info.itemId, sectionData.key);
+    const assignedId = validAssignments[info.itemId];
+    const assignedInfo = assignedId ? entryMap.get(assignedId) : null;
+    const assignedValue = assignedInfo ? assignedInfo.value : '';
+    const correct = assignedValue && normalized(assignedValue) === normalized(info.value);
+    return { ...info, entryId, assignedId, assignedValue, correct };
+  });
+
+  const filledCount = results.filter(r => r.assignedValue).length;
+  const correctCount = results.filter(r => r.correct).length;
+
+  shell.appendChild(renderHeader({
+    sections,
+    activeKey: sectionData.key,
+    filledCount,
+    correctCount,
+    total: results.length,
+    bankRemaining: orderedBank.length,
+    reveal,
+    onSectionChange: key => {
+      const nextReveal = { ...(state.blockMode.reveal || {}) };
+      delete nextReveal[key];
+      setBlockMode({ section: key, reveal: nextReveal });
+      redraw();
+    },
+    onCheck: () => {
+      const nextReveal = { ...(state.blockMode.reveal || {}) };
+      nextReveal[sectionData.key] = true;
+      setBlockMode({ reveal: nextReveal });
+      redraw();
+    },
+    onReset: () => {
+      const assignments = { ...(state.blockMode.assignments || {}) };
+      assignments[sectionData.key] = {};
+      const revealMap = { ...(state.blockMode.reveal || {}) };
+      delete revealMap[sectionData.key];
+      setBlockMode({ assignments, reveal: revealMap });
+      redraw();
+    }
+  }));
+
+  const board = document.createElement('div');
+  board.className = 'block-mode-board';
+  results.forEach(result => {
+    board.appendChild(renderBlockCard({
+      sectionLabel: sectionData.label,
+      reveal,
+      result,
+      onRemove: () => {
+        const assignments = { ...(state.blockMode.assignments || {}) };
+        const nextSectionAssignments = { ...(assignments[sectionData.key] || {}) };
+        delete nextSectionAssignments[result.itemId];
+        assignments[sectionData.key] = nextSectionAssignments;
+        const revealMap = { ...(state.blockMode.reveal || {}) };
+        delete revealMap[sectionData.key];
+        setBlockMode({ assignments, reveal: revealMap });
+        redraw();
+      },
+      onDrop: entryId => {
+        const info = entryMap.get(entryId);
+        if (!info) return;
+        const assignments = { ...(state.blockMode.assignments || {}) };
+        const nextSectionAssignments = { ...(assignments[sectionData.key] || {}) };
+        for (const [itemId, assigned] of Object.entries(nextSectionAssignments)) {
+          if (assigned === entryId) delete nextSectionAssignments[itemId];
+        }
+        nextSectionAssignments[result.itemId] = entryId;
+        assignments[sectionData.key] = nextSectionAssignments;
+        const revealMap = { ...(state.blockMode.reveal || {}) };
+        delete revealMap[sectionData.key];
+        setBlockMode({ assignments, reveal: revealMap });
+        redraw();
+      }
+    }));
+  });
+  shell.appendChild(board);
+
+  shell.appendChild(renderBank({
+    label: sectionData.label,
+    entries: orderedBank
+  }));
+}
+
+function renderHeader({ sections, activeKey, filledCount, correctCount, total, bankRemaining, reveal, onSectionChange, onCheck, onReset }) {
+  const card = document.createElement('div');
+  card.className = 'card block-mode-header';
+
+  const titleRow = document.createElement('div');
+  titleRow.className = 'block-mode-header-row';
+  const title = document.createElement('h2');
+  title.textContent = 'Blocks Mode';
+  titleRow.appendChild(title);
+
+  const selectWrap = document.createElement('label');
+  selectWrap.className = 'block-mode-select';
+  const selectLabel = document.createElement('span');
+  selectLabel.textContent = 'Section';
+  selectWrap.appendChild(selectLabel);
+  const select = document.createElement('select');
+  sections.forEach(sec => {
+    const opt = document.createElement('option');
+    opt.value = sec.key;
+    opt.textContent = sec.label;
+    if (sec.key === activeKey) opt.selected = true;
+    select.appendChild(opt);
+  });
+  select.addEventListener('change', () => onSectionChange(select.value));
+  selectWrap.appendChild(select);
+  titleRow.appendChild(selectWrap);
+  card.appendChild(titleRow);
+
+  const meta = document.createElement('div');
+  meta.className = 'block-mode-meta-row';
+  const placed = document.createElement('span');
+  placed.textContent = `Placed: ${filledCount}/${total}`;
+  meta.appendChild(placed);
+  if (reveal) {
+    const score = document.createElement('span');
+    score.textContent = `Correct: ${correctCount}/${total}`;
+    meta.appendChild(score);
+  }
+  const bankInfo = document.createElement('span');
+  bankInfo.textContent = `In bank: ${bankRemaining}`;
+  meta.appendChild(bankInfo);
+  card.appendChild(meta);
+
+  const actions = document.createElement('div');
+  actions.className = 'block-mode-actions';
+  const checkBtn = document.createElement('button');
+  checkBtn.type = 'button';
+  checkBtn.className = 'btn';
+  checkBtn.textContent = 'Check answers';
+  checkBtn.disabled = !filledCount;
+  checkBtn.addEventListener('click', onCheck);
+  actions.appendChild(checkBtn);
+
+  const resetBtn = document.createElement('button');
+  resetBtn.type = 'button';
+  resetBtn.className = 'btn secondary';
+  resetBtn.textContent = 'Reset section';
+  resetBtn.disabled = !filledCount;
+  resetBtn.addEventListener('click', onReset);
+  actions.appendChild(resetBtn);
+  card.appendChild(actions);
+
+  return card;
+}
+
+function renderBlockCard({ sectionLabel, reveal, result, onRemove, onDrop }) {
+  const card = document.createElement('div');
+  card.className = 'card block-mode-card';
+
+  const title = document.createElement('div');
+  title.className = 'block-mode-card-title';
+  title.textContent = itemTitle(result.item);
+  card.appendChild(title);
+
+  const subtitle = document.createElement('div');
+  subtitle.className = 'block-mode-card-subtitle';
+  subtitle.textContent = formatItemContext(result.item);
+  if (subtitle.textContent) card.appendChild(subtitle);
+
+  const slot = document.createElement('div');
+  slot.className = 'block-mode-slot';
+  slot.dataset.itemId = result.itemId;
+  slot.dataset.section = sectionLabel;
+
+  slot.addEventListener('dragover', event => {
+    event.preventDefault();
+    slot.classList.add('drag-over');
+  });
+  slot.addEventListener('dragenter', event => {
+    event.preventDefault();
+    slot.classList.add('drag-over');
+  });
+  slot.addEventListener('dragleave', () => {
+    slot.classList.remove('drag-over');
+  });
+  slot.addEventListener('drop', event => {
+    event.preventDefault();
+    slot.classList.remove('drag-over');
+    const entryId = event.dataTransfer.getData('text/plain');
+    if (entryId) onDrop(entryId);
+  });
+
+  if (result.assignedValue) {
+    slot.classList.add('filled');
+    const chip = document.createElement('div');
+    chip.className = 'block-chip assigned';
+    const text = document.createElement('div');
+    text.className = 'block-chip-text';
+    text.textContent = result.assignedValue;
+    chip.appendChild(text);
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.className = 'chip-remove';
+    removeBtn.textContent = '×';
+    removeBtn.addEventListener('click', onRemove);
+    chip.appendChild(removeBtn);
+    slot.appendChild(chip);
+  } else {
+    const placeholder = document.createElement('div');
+    placeholder.className = 'block-slot-placeholder';
+    placeholder.textContent = `Drop ${sectionLabel.toLowerCase()} here`;
+    slot.appendChild(placeholder);
+  }
+
+  card.appendChild(slot);
+
+  if (reveal) {
+    slot.classList.add(result.correct ? 'correct' : (result.assignedValue ? 'incorrect' : 'missing'));
+    if (!result.correct) {
+      const answer = document.createElement('div');
+      answer.className = 'block-mode-answer';
+      const label = document.createElement('span');
+      label.textContent = 'Answer';
+      const body = document.createElement('div');
+      body.textContent = result.value;
+      answer.appendChild(label);
+      answer.appendChild(body);
+      card.appendChild(answer);
+    }
+  }
+  return card;
+}
+
+function renderBank({ label, entries, onPick }) {
+  const card = document.createElement('div');
+  card.className = 'card block-mode-bank';
+  const title = document.createElement('div');
+  title.className = 'block-mode-bank-title';
+  title.textContent = `${label} bank`;
+  card.appendChild(title);
+
+  const list = document.createElement('div');
+  list.className = 'block-mode-bank-items';
+  if (!entries.length) {
+    const empty = document.createElement('div');
+    empty.className = 'block-mode-bank-empty';
+    empty.textContent = 'All matches placed!';
+    list.appendChild(empty);
+  } else {
+    entries.forEach(entry => {
+      const chip = document.createElement('div');
+      chip.className = 'block-chip';
+      chip.textContent = entry.value;
+      chip.draggable = true;
+      chip.addEventListener('dragstart', event => {
+        event.dataTransfer.effectAllowed = 'move';
+        event.dataTransfer.setData('text/plain', entry.entryId);
+        chip.classList.add('dragging');
+      });
+      chip.addEventListener('dragend', () => chip.classList.remove('dragging'));
+      if (onPick) {
+        chip.addEventListener('click', () => onPick(entry.entryId));
+      }
+      list.appendChild(chip);
+    });
+  }
+  card.appendChild(list);
+  return card;
+}
+
+function collectSections(items) {
+  const map = new Map();
+  items.forEach((item, index) => {
+    const itemId = resolveItemId(item, index);
+    sectionDefsForKind(item.kind).forEach(def => {
+      const value = sectionValue(item[def.key]);
+      if (!value) return;
+      let section = map.get(def.key);
+      if (!section) {
+        section = { key: def.key, label: def.label, items: [] };
+        map.set(def.key, section);
+      }
+      section.items.push({ item, itemId, value });
+    });
+  });
+  return Array.from(map.values()).sort((a, b) => a.label.localeCompare(b.label));
+}
+
+function sanitizeAssignments(sectionKey, entryMap) {
+  const current = (state.blockMode.assignments && state.blockMode.assignments[sectionKey]) || {};
+  let changed = false;
+  const valid = {};
+  for (const [itemId, entryId] of Object.entries(current)) {
+    if (entryMap.has(entryId)) {
+      valid[itemId] = entryId;
+    } else {
+      changed = true;
+    }
+  }
+  if (changed) {
+    const assignments = { ...(state.blockMode.assignments || {}) };
+    assignments[sectionKey] = valid;
+    setBlockMode({ assignments });
+  }
+  return valid;
+}
+
+function orderEntries(sectionKey, entries) {
+  const ids = entries.map(entry => entry.entryId);
+  const existing = (state.blockMode.order && state.blockMode.order[sectionKey]) || [];
+  const filtered = existing.filter(id => ids.includes(id));
+  const missing = ids.filter(id => !filtered.includes(id));
+  const next = filtered.concat(missing);
+  if (!arraysEqual(existing, next)) {
+    const order = { ...(state.blockMode.order || {}) };
+    order[sectionKey] = next;
+    setBlockMode({ order });
+  }
+  const byId = new Map(entries.map(entry => [entry.entryId, entry]));
+  return next.map(id => byId.get(id)).filter(Boolean);
+}
+
+function entryIdFor(itemId, sectionKey) {
+  return `${itemId}::${sectionKey}`;
+}
+
+function sectionValue(raw) {
+  if (raw == null) return '';
+  const text = typeof raw === 'string' ? raw : String(raw);
+  return text.trim();
+}
+
+function normalized(text) {
+  return sectionValue(text).replace(/\s+/g, ' ').toLowerCase();
+}
+
+function resolveItemId(item, index) {
+  return item.id || item.uid || item.slug || item.key || `${item.kind || 'item'}-${index}`;
+}
+
+function itemTitle(item) {
+  return item.name || item.concept || item.title || 'Card';
+}
+
+function formatItemContext(item) {
+  const parts = [];
+  if (item.kind) parts.push(capitalize(item.kind));
+  if (Array.isArray(item.lectures) && item.lectures.length) {
+    const lectureNames = item.lectures.map(l => l.name).filter(Boolean);
+    if (lectureNames.length) parts.push(lectureNames.join(', '));
+  }
+  return parts.join(' • ');
+}
+
+function capitalize(text) {
+  if (!text) return '';
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+function arraysEqual(a, b) {
+  if (a.length !== b.length) return false;
+  return a.every((val, idx) => val === b[idx]);
+}
+
+function messageCard(text) {
+  const card = document.createElement('div');
+  card.className = 'card block-mode-empty';
+  card.textContent = text;
+  return card;
+}

--- a/js/ui/components/builder.js
+++ b/js/ui/components/builder.js
@@ -1,155 +1,480 @@
-import { state, setBuilder, setCohort } from '../../state.js';
+import { state, setBuilder, setCohort, resetBlockMode } from '../../state.js';
 import { listBlocks, listItemsByKind } from '../../storage/storage.js';
 
-// Render Study Builder panel
 export async function renderBuilder(root) {
+  const blocks = await loadBlocks();
   root.innerHTML = '';
   const wrap = document.createElement('div');
   wrap.className = 'builder';
   root.appendChild(wrap);
+  drawBuilder(wrap, blocks);
+}
 
-  // Nested block -> week -> lecture selection
+async function loadBlocks() {
   const blocks = await listBlocks();
   blocks.push({ blockId: '__unlabeled', title: 'Unlabeled', weeks: 0, lectures: [] });
-  blocks.forEach(b => {
-    const blockDiv = document.createElement('div');
-    blockDiv.className = 'builder-section';
-    const blkLabel = document.createElement('label');
-    blkLabel.className = 'row';
-    const blkCb = document.createElement('input');
-    blkCb.type = 'checkbox';
-    blkCb.checked = state.builder.blocks.includes(b.blockId);
-    blkLabel.appendChild(blkCb);
-    blkLabel.appendChild(document.createTextNode(b.title || b.blockId));
-    blockDiv.appendChild(blkLabel);
+  return blocks;
+}
 
-    const weekWrap = document.createElement('div');
-    weekWrap.className = 'builder-sub';
-    weekWrap.style.display = blkCb.checked ? 'block' : 'none';
-    blockDiv.appendChild(weekWrap);
+function drawBuilder(container, blocks) {
+  container.innerHTML = '';
+  const rerender = () => drawBuilder(container, blocks);
 
-    blkCb.addEventListener('change', () => {
-      const set = new Set(state.builder.blocks);
-      if (blkCb.checked) set.add(b.blockId); else set.delete(b.blockId);
-      setBuilder({ blocks: Array.from(set) });
-      weekWrap.style.display = blkCb.checked ? 'block' : 'none';
-    });
+  const layout = document.createElement('div');
+  layout.className = 'builder-layout';
+  container.appendChild(layout);
 
-    const weeks = Array.from({ length: b.weeks || 8 }, (_, i) => i + 1);
-    weeks.forEach(w => {
-      const wkLabel = document.createElement('label');
-      wkLabel.className = 'row';
-      const wkCb = document.createElement('input');
-      wkCb.type = 'checkbox';
-      const wkKey = `${b.blockId}|${w}`;
-      wkCb.checked = state.builder.weeks.includes(wkKey);
-      wkLabel.appendChild(wkCb);
-      wkLabel.appendChild(document.createTextNode(`Week ${w}`));
-      weekWrap.appendChild(wkLabel);
-
-      const lecWrap = document.createElement('div');
-      lecWrap.className = 'builder-sub';
-      lecWrap.style.display = wkCb.checked ? 'block' : 'none';
-      wkLabel.appendChild(lecWrap);
-
-      wkCb.addEventListener('change', () => {
-        const set = new Set(state.builder.weeks);
-        if (wkCb.checked) set.add(wkKey); else set.delete(wkKey);
-        setBuilder({ weeks: Array.from(set) });
-        lecWrap.style.display = wkCb.checked ? 'block' : 'none';
-      });
-
-      (b.lectures || []).filter(l => l.week === w).forEach(l => {
-        const key = `${b.blockId}|${l.id}`;
-        const btn = document.createElement('button');
-        btn.type = 'button';
-        btn.className = 'chip' + (state.builder.lectures.includes(key) ? ' active' : '');
-        btn.textContent = l.name;
-        btn.addEventListener('click', () => {
-          const set = new Set(state.builder.lectures);
-          if (set.has(key)) set.delete(key); else set.add(key);
-          setBuilder({ lectures: Array.from(set) });
-          btn.classList.toggle('active');
-        });
-        lecWrap.appendChild(btn);
-      });
-    });
-
-    wrap.appendChild(blockDiv);
+  const blockColumn = document.createElement('div');
+  blockColumn.className = 'builder-blocks';
+  layout.appendChild(blockColumn);
+  blocks.forEach(block => {
+    blockColumn.appendChild(renderBlockPanel(block, rerender));
   });
 
-  // Type selection
-  const typeSection = document.createElement('div');
-  typeSection.className = 'builder-section';
-  const typeTitle = document.createElement('div');
-  typeTitle.textContent = 'Types:';
-  typeSection.appendChild(typeTitle);
+  const controls = renderControls(rerender);
+  layout.appendChild(controls);
+}
+
+function renderBlockPanel(block, rerender) {
+  const blockId = block.blockId;
+  const lectures = Array.isArray(block.lectures) ? [...block.lectures] : [];
+  lectures.sort((a, b) => {
+    const weekDiff = (a.week ?? 0) - (b.week ?? 0);
+    if (weekDiff !== 0) return weekDiff;
+    return (a.name || '').localeCompare(b.name || '');
+  });
+  const weeks = groupByWeek(lectures);
+  const hasSelections = hasBlockSelection(blockId);
+
+  const card = document.createElement('div');
+  card.className = 'card builder-block-card';
+  if (hasSelections) card.classList.add('active');
+
+  const header = document.createElement('div');
+  header.className = 'builder-block-header';
+  const title = document.createElement('h3');
+  title.textContent = block.title || blockId;
+  header.appendChild(title);
+
+  const meta = document.createElement('span');
+  meta.className = 'builder-block-meta';
+  const weekCount = weeks.length;
+  const lectureCount = lectures.length;
+  const metaParts = [];
+  if (weekCount) metaParts.push(`${weekCount} week${weekCount === 1 ? '' : 's'}`);
+  if (lectureCount) metaParts.push(`${lectureCount} lecture${lectureCount === 1 ? '' : 's'}`);
+  meta.textContent = metaParts.join(' • ') || 'No lectures linked yet';
+  header.appendChild(meta);
+
+  const actions = document.createElement('div');
+  actions.className = 'builder-block-actions';
+  const blockSelected = state.builder.blocks.includes(blockId);
+  const toggleBlockBtn = createPill(blockSelected, blockSelected ? 'Block added' : 'Add block', () => {
+    toggleBlock(block);
+    rerender();
+  });
+  actions.appendChild(toggleBlockBtn);
+
+  if (lectures.length) {
+    const allBtn = createAction('Select all lectures', () => {
+      selectEntireBlock(block);
+      rerender();
+    });
+    actions.appendChild(allBtn);
+  }
+
+  if (hasSelections) {
+    const clearBtn = createAction('Clear block', () => {
+      clearBlock(blockId);
+      rerender();
+    });
+    actions.appendChild(clearBtn);
+  }
+
+  header.appendChild(actions);
+  card.appendChild(header);
+
+  if (blockId === '__unlabeled') {
+    const note = document.createElement('div');
+    note.className = 'builder-unlabeled-note';
+    note.textContent = 'Include to study cards without block or lecture tags.';
+    card.appendChild(note);
+    return card;
+  }
+
+  const weekList = document.createElement('div');
+  weekList.className = 'builder-week-list';
+  if (!weeks.length) {
+    const empty = document.createElement('div');
+    empty.className = 'builder-empty';
+    empty.textContent = 'No lectures added yet.';
+    weekList.appendChild(empty);
+  } else {
+    weeks.forEach(({ week, items }) => {
+      weekList.appendChild(renderWeek(block, week, items, rerender));
+    });
+  }
+  card.appendChild(weekList);
+  return card;
+}
+
+function renderWeek(block, week, lectures, rerender) {
+  const blockId = block.blockId;
+  const weekKey = weekKeyFor(blockId, week);
+  const selected = state.builder.weeks.includes(weekKey);
+  const row = document.createElement('div');
+  row.className = 'builder-week-card';
+
+  const header = document.createElement('div');
+  header.className = 'builder-week-header';
+
+  const label = createPill(selected, formatWeekLabel(week), () => {
+    toggleWeek(block, week);
+    rerender();
+  }, 'week');
+  header.appendChild(label);
+
+  const meta = document.createElement('span');
+  meta.className = 'builder-week-meta';
+  meta.textContent = `${lectures.length} lecture${lectures.length === 1 ? '' : 's'}`;
+  header.appendChild(meta);
+
+  const actions = document.createElement('div');
+  actions.className = 'builder-week-actions';
+  const allBtn = createAction('Select all', () => {
+    selectWeek(block, week);
+    rerender();
+  });
+  actions.appendChild(allBtn);
+  header.appendChild(actions);
+
+  row.appendChild(header);
+
+  const lectureList = document.createElement('div');
+  lectureList.className = 'builder-lecture-list';
+  lectures.forEach(lecture => {
+    lectureList.appendChild(renderLecture(block, lecture, rerender));
+  });
+  row.appendChild(lectureList);
+
+  return row;
+}
+
+function renderLecture(block, lecture, rerender) {
+  const blockId = block.blockId;
+  const lectureKey = lectureKeyFor(blockId, lecture.id);
+  const active = state.builder.lectures.includes(lectureKey);
+  const pill = createPill(active, lecture.name || `Lecture ${lecture.id}`, () => {
+    toggleLecture(block, lecture);
+    rerender();
+  }, 'lecture');
+  return pill;
+}
+
+function renderControls(rerender) {
+  const aside = document.createElement('aside');
+  aside.className = 'builder-controls';
+
+  aside.appendChild(renderFilterCard(rerender));
+  aside.appendChild(renderSummaryCard(rerender));
+  return aside;
+}
+
+function renderFilterCard(rerender) {
+  const card = document.createElement('div');
+  card.className = 'card builder-filter-card';
+
+  const title = document.createElement('h3');
+  title.textContent = 'Filters';
+  card.appendChild(title);
+
+  const typeLabel = document.createElement('div');
+  typeLabel.className = 'builder-section-title';
+  typeLabel.textContent = 'Card types';
+  card.appendChild(typeLabel);
+
+  const pillRow = document.createElement('div');
+  pillRow.className = 'builder-pill-row';
   const typeMap = { disease: 'Disease', drug: 'Drug', concept: 'Concept' };
-  Object.entries(typeMap).forEach(([val, labelText]) => {
-    const label = document.createElement('label');
-    label.className = 'row';
-    const cb = document.createElement('input');
-    cb.type = 'checkbox';
-    cb.checked = state.builder.types.includes(val);
-    cb.addEventListener('change', () => {
-      const set = new Set(state.builder.types);
-      if (cb.checked) set.add(val); else set.delete(val);
-      setBuilder({ types: Array.from(set) });
-    });
-    label.appendChild(cb);
-    label.appendChild(document.createTextNode(labelText));
-    typeSection.appendChild(label);
+  Object.entries(typeMap).forEach(([value, label]) => {
+    const active = state.builder.types.includes(value);
+    const pill = createPill(active, label, () => {
+      toggleType(value);
+      rerender();
+    }, 'small');
+    pillRow.appendChild(pill);
   });
-  wrap.appendChild(typeSection);
+  card.appendChild(pillRow);
 
-  // Favorites toggle
-  const favSection = document.createElement('label');
-  favSection.className = 'row';
-  const favCb = document.createElement('input');
-  favCb.type = 'checkbox';
-  favCb.checked = state.builder.onlyFav;
-  favCb.addEventListener('change', () => setBuilder({ onlyFav: favCb.checked }));
-  favSection.appendChild(favCb);
-  favSection.appendChild(document.createTextNode('Only favorites'));
-  wrap.appendChild(favSection);
+  const favToggle = createPill(state.builder.onlyFav, 'Only favorites', () => {
+    setBuilder({ onlyFav: !state.builder.onlyFav });
+    rerender();
+  }, 'small outline');
+  card.appendChild(favToggle);
 
-  // Build button and result count
-  const buildBtn = document.createElement('button');
-  buildBtn.className = 'btn btn-primary';
-  buildBtn.textContent = 'Build Set';
+  return card;
+}
+
+function renderSummaryCard(rerender) {
+  const card = document.createElement('div');
+  card.className = 'card builder-summary-card';
+
+  const title = document.createElement('h3');
+  title.textContent = 'Study set';
+  card.appendChild(title);
+
+  const selectionMeta = document.createElement('div');
+  selectionMeta.className = 'builder-selection-meta';
+  selectionMeta.innerHTML = `
+    <span>Blocks: ${state.builder.blocks.length}</span>
+    <span>Weeks: ${state.builder.weeks.length}</span>
+    <span>Lectures: ${state.builder.lectures.length}</span>
+  `;
+  card.appendChild(selectionMeta);
+
   const count = document.createElement('div');
   count.className = 'builder-count';
   count.textContent = `Set size: ${state.cohort.length}`;
+  card.appendChild(count);
+
+  const actions = document.createElement('div');
+  actions.className = 'builder-summary-actions';
+
+  const buildBtn = document.createElement('button');
+  buildBtn.type = 'button';
+  buildBtn.className = 'btn';
+  buildBtn.textContent = 'Build set';
   buildBtn.addEventListener('click', async () => {
-    let items = [];
-    for (const kind of state.builder.types) {
-      items = items.concat(await listItemsByKind(kind));
-    }
-    items = items.filter(it => {
-      if (state.builder.onlyFav && !it.favorite) return false;
-      if (state.builder.blocks.length) {
-        const wantUnlabeled = state.builder.blocks.includes('__unlabeled');
-        const hasMatch = it.blocks?.some(b => state.builder.blocks.includes(b));
-        if (!hasMatch) {
-          if (!(wantUnlabeled && (!it.blocks || !it.blocks.length))) return false;
-        }
-      }
-      if (state.builder.weeks.length) {
-        const ok = state.builder.weeks.some(pair => {
-          const [b, w] = pair.split('|');
-          return it.blocks?.includes(b) && it.weeks?.includes(Number(w));
-        });
-        if (!ok) return false;
-      }
-      if (state.builder.lectures.length) {
-        const ok = it.lectures?.some(l => state.builder.lectures.includes(`${l.blockId}|${l.id}`));
-        if (!ok) return false;
-      }
-      return true;
-    });
-    setCohort(items);
-    count.textContent = `Set size: ${items.length}`;
+    await buildSet(buildBtn, count, rerender);
   });
-  wrap.appendChild(buildBtn);
-  wrap.appendChild(count);
+  actions.appendChild(buildBtn);
+
+  const clearBtn = document.createElement('button');
+  clearBtn.type = 'button';
+  clearBtn.className = 'btn secondary';
+  clearBtn.textContent = 'Clear selection';
+  clearBtn.disabled = !hasAnySelection();
+  clearBtn.addEventListener('click', () => {
+    setBuilder({ blocks: [], weeks: [], lectures: [] });
+    rerender();
+  });
+  actions.appendChild(clearBtn);
+
+  card.appendChild(actions);
+  return card;
+}
+
+async function buildSet(button, countEl, rerender) {
+  const original = button.textContent;
+  button.disabled = true;
+  button.textContent = 'Building…';
+  try {
+    const items = await gatherItems();
+    setCohort(items);
+    resetBlockMode();
+    countEl.textContent = `Set size: ${items.length}`;
+  } finally {
+    button.disabled = false;
+    button.textContent = original;
+  }
+  rerender();
+}
+
+async function gatherItems() {
+  let items = [];
+  for (const kind of state.builder.types) {
+    const byKind = await listItemsByKind(kind);
+    items = items.concat(byKind);
+  }
+  return items.filter(item => {
+    if (state.builder.onlyFav && !item.favorite) return false;
+    if (state.builder.blocks.length) {
+      const wantUnlabeled = state.builder.blocks.includes('__unlabeled');
+      const hasBlockMatch = item.blocks?.some(b => state.builder.blocks.includes(b));
+      if (!hasBlockMatch) {
+        const isUnlabeled = !item.blocks || !item.blocks.length;
+        if (!(wantUnlabeled && isUnlabeled)) return false;
+      }
+    }
+    if (state.builder.weeks.length) {
+      const ok = state.builder.weeks.some(pair => {
+        const [blockId, weekStr] = pair.split('|');
+        const weekNum = Number(weekStr);
+        return item.blocks?.includes(blockId) && item.weeks?.includes(weekNum);
+      });
+      if (!ok) return false;
+    }
+    if (state.builder.lectures.length) {
+      const ok = item.lectures?.some(lecture => {
+        const key = lectureKeyFor(lecture.blockId, lecture.id);
+        return state.builder.lectures.includes(key);
+      });
+      if (!ok) return false;
+    }
+    return true;
+  });
+}
+
+function toggleBlock(block) {
+  const blockId = block.blockId;
+  const set = new Set(state.builder.blocks);
+  const isActive = set.has(blockId);
+  if (isActive) {
+    set.delete(blockId);
+    const weeks = state.builder.weeks.filter(key => !key.startsWith(`${blockId}|`));
+    const lectures = state.builder.lectures.filter(key => !key.startsWith(`${blockId}|`));
+    setBuilder({ blocks: Array.from(set), weeks, lectures });
+  } else {
+    set.add(blockId);
+    setBuilder({ blocks: Array.from(set) });
+  }
+}
+
+function selectEntireBlock(block) {
+  const blockId = block.blockId;
+  const blockSet = new Set(state.builder.blocks);
+  const weekSet = new Set(state.builder.weeks);
+  const lectureSet = new Set(state.builder.lectures);
+  blockSet.add(blockId);
+  (block.lectures || []).forEach(lecture => {
+    if (lecture.week != null) weekSet.add(weekKeyFor(blockId, lecture.week));
+    lectureSet.add(lectureKeyFor(blockId, lecture.id));
+  });
+  setBuilder({
+    blocks: Array.from(blockSet),
+    weeks: Array.from(weekSet),
+    lectures: Array.from(lectureSet)
+  });
+}
+
+function clearBlock(blockId) {
+  const blocks = state.builder.blocks.filter(id => id !== blockId);
+  const weeks = state.builder.weeks.filter(key => !key.startsWith(`${blockId}|`));
+  const lectures = state.builder.lectures.filter(key => !key.startsWith(`${blockId}|`));
+  setBuilder({ blocks, weeks, lectures });
+}
+
+function toggleWeek(block, week) {
+  const weekKey = weekKeyFor(block.blockId, week);
+  const weekSet = new Set(state.builder.weeks);
+  const lectureSet = new Set(state.builder.lectures);
+  const blockSet = new Set(state.builder.blocks);
+  if (weekSet.has(weekKey)) {
+    weekSet.delete(weekKey);
+    (block.lectures || []).forEach(lecture => {
+      if (lecture.week === week) {
+        lectureSet.delete(lectureKeyFor(block.blockId, lecture.id));
+      }
+    });
+  } else {
+    weekSet.add(weekKey);
+    blockSet.add(block.blockId);
+  }
+  setBuilder({
+    weeks: Array.from(weekSet),
+    lectures: Array.from(lectureSet),
+    blocks: Array.from(blockSet)
+  });
+}
+
+function selectWeek(block, week) {
+  const weekKey = weekKeyFor(block.blockId, week);
+  const weekSet = new Set(state.builder.weeks);
+  const lectureSet = new Set(state.builder.lectures);
+  const blockSet = new Set(state.builder.blocks);
+  weekSet.add(weekKey);
+  blockSet.add(block.blockId);
+  (block.lectures || []).forEach(lecture => {
+    if (lecture.week === week) {
+      lectureSet.add(lectureKeyFor(block.blockId, lecture.id));
+    }
+  });
+  setBuilder({
+    weeks: Array.from(weekSet),
+    lectures: Array.from(lectureSet),
+    blocks: Array.from(blockSet)
+  });
+}
+
+function toggleLecture(block, lecture) {
+  const key = lectureKeyFor(block.blockId, lecture.id);
+  const lectureSet = new Set(state.builder.lectures);
+  const blockSet = new Set(state.builder.blocks);
+  const weekSet = new Set(state.builder.weeks);
+  if (lectureSet.has(key)) {
+    lectureSet.delete(key);
+  } else {
+    lectureSet.add(key);
+    blockSet.add(block.blockId);
+    if (lecture.week != null) weekSet.add(weekKeyFor(block.blockId, lecture.week));
+  }
+  setBuilder({
+    lectures: Array.from(lectureSet),
+    blocks: Array.from(blockSet),
+    weeks: Array.from(weekSet)
+  });
+}
+
+function toggleType(type) {
+  const types = new Set(state.builder.types);
+  if (types.has(type)) types.delete(type); else types.add(type);
+  setBuilder({ types: Array.from(types) });
+}
+
+function hasBlockSelection(blockId) {
+  return state.builder.blocks.includes(blockId)
+    || state.builder.weeks.some(key => key.startsWith(`${blockId}|`))
+    || state.builder.lectures.some(key => key.startsWith(`${blockId}|`));
+}
+
+function hasAnySelection() {
+  return state.builder.blocks.length || state.builder.weeks.length || state.builder.lectures.length;
+}
+
+function groupByWeek(lectures) {
+  const map = new Map();
+  lectures.forEach(lecture => {
+    const week = lecture.week != null ? lecture.week : -1;
+    if (!map.has(week)) map.set(week, []);
+    map.get(week).push(lecture);
+  });
+  return Array.from(map.entries())
+    .sort((a, b) => a[0] - b[0])
+    .map(([week, items]) => ({ week, items }));
+}
+
+function weekKeyFor(blockId, week) {
+  return `${blockId}|${week}`;
+}
+
+function lectureKeyFor(blockId, lectureId) {
+  return `${blockId}|${lectureId}`;
+}
+
+function formatWeekLabel(week) {
+  if (week == null || week < 0) return 'No week';
+  return `Week ${week}`;
+}
+
+function createPill(active, label, onClick, variant = '') {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'builder-pill';
+  if (variant) {
+    const variants = Array.isArray(variant) ? variant : variant.split(' ');
+    variants.filter(Boolean).forEach(name => btn.classList.add(`builder-pill-${name}`));
+  }
+  if (active) btn.classList.add('active');
+  btn.textContent = label;
+  btn.addEventListener('click', onClick);
+  return btn;
+}
+
+function createAction(label, onClick) {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'builder-action';
+  btn.textContent = label;
+  btn.addEventListener('click', onClick);
+  return btn;
 }

--- a/js/ui/components/flashcards.js
+++ b/js/ui/components/flashcards.js
@@ -1,4 +1,5 @@
 import { state, setFlashSession } from '../../state.js';
+import { sectionDefsForKind } from './sections.js';
 
 // Render flashcards session. Uses session.pool if provided, else state.cohort
 export function renderFlashcards(root, redraw) {
@@ -96,30 +97,5 @@ export function renderFlashcards(root, redraw) {
 }
 
 function sectionsFor(item) {
-  const map = {
-    disease: [
-      ['Etiology', 'etiology'],
-      ['Pathophys', 'pathophys'],
-      ['Clinical Presentation', 'clinical'],
-      ['Diagnosis', 'diagnosis'],
-      ['Treatment', 'treatment'],
-      ['Complications', 'complications'],
-      ['Mnemonic', 'mnemonic']
-    ],
-    drug: [
-      ['Mechanism', 'moa'],
-      ['Uses', 'uses'],
-      ['Side Effects', 'sideEffects'],
-      ['Contraindications', 'contraindications'],
-      ['Mnemonic', 'mnemonic']
-    ],
-    concept: [
-      ['Definition', 'definition'],
-      ['Mechanism', 'mechanism'],
-      ['Clinical Relevance', 'clinicalRelevance'],
-      ['Example', 'example'],
-      ['Mnemonic', 'mnemonic']
-    ]
-  };
-  return map[item.kind] || [];
+  return sectionDefsForKind(item.kind).map(def => [def.label, def.key]);
 }

--- a/js/ui/components/sections.js
+++ b/js/ui/components/sections.js
@@ -1,0 +1,33 @@
+const SECTION_DEFS = {
+  disease: [
+    { key: 'etiology', label: 'Etiology' },
+    { key: 'pathophys', label: 'Pathophys' },
+    { key: 'clinical', label: 'Clinical Presentation' },
+    { key: 'diagnosis', label: 'Diagnosis' },
+    { key: 'treatment', label: 'Treatment' },
+    { key: 'complications', label: 'Complications' },
+    { key: 'mnemonic', label: 'Mnemonic' }
+  ],
+  drug: [
+    { key: 'moa', label: 'Mechanism' },
+    { key: 'uses', label: 'Uses' },
+    { key: 'sideEffects', label: 'Side Effects' },
+    { key: 'contraindications', label: 'Contraindications' },
+    { key: 'mnemonic', label: 'Mnemonic' }
+  ],
+  concept: [
+    { key: 'definition', label: 'Definition' },
+    { key: 'mechanism', label: 'Mechanism' },
+    { key: 'clinicalRelevance', label: 'Clinical Relevance' },
+    { key: 'example', label: 'Example' },
+    { key: 'mnemonic', label: 'Mnemonic' }
+  ]
+};
+
+export function sectionDefsForKind(kind) {
+  return SECTION_DEFS[kind] || [];
+}
+
+export function allSectionDefs() {
+  return SECTION_DEFS;
+}

--- a/style.css
+++ b/style.css
@@ -317,25 +317,209 @@ input[type="checkbox"]:checked::after {
 
 /* Study Builder */
 .builder {
+  padding: var(--pad-lg);
+}
+
+.builder-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 2.5fr) minmax(260px, 1fr);
+  gap: var(--pad-lg);
+}
+
+@media (max-width: 960px) {
+  .builder-layout {
+    grid-template-columns: 1fr;
+  }
+  .builder-controls {
+    order: -1;
+  }
+}
+
+.builder-blocks {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-lg);
+}
+
+.builder-block-card {
   display: flex;
   flex-direction: column;
   gap: var(--pad);
-  padding: var(--pad);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.builder-section {
-  border: 1px solid var(--border);
-  padding: var(--pad);
+.builder-block-card.active {
+  border-color: var(--blue);
+  box-shadow: 0 0 0 1px var(--blue);
+}
+
+.builder-block-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad-sm);
+  align-items: baseline;
+}
+
+.builder-block-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.builder-block-meta {
+  color: var(--gray);
+  font-size: 0.9rem;
+}
+
+.builder-block-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad-sm);
+  margin-left: auto;
+}
+
+.builder-unlabeled-note {
+  color: var(--gray);
+  font-size: 0.95rem;
+}
+
+.builder-week-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+}
+
+.builder-week-card {
+  background: var(--muted);
   border-radius: var(--radius);
+  padding: var(--pad);
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
 }
 
-.builder-sub {
-  margin-left: var(--pad);
-  margin-top: 4px;
+.builder-week-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--pad-sm);
+}
+
+.builder-week-meta {
+  color: var(--gray);
+  font-size: 0.85rem;
+}
+
+.builder-week-actions {
+  margin-left: auto;
+}
+
+.builder-lecture-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad-sm);
+}
+
+.builder-controls {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-lg);
+}
+
+.builder-filter-card,
+.builder-summary-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+}
+
+.builder-section-title {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--gray);
+}
+
+.builder-pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad-sm);
+}
+
+.builder-selection-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad-sm);
+  font-size: 0.85rem;
+  color: var(--gray);
 }
 
 .builder-count {
-  margin-top: var(--pad);
+  font-weight: 600;
+}
+
+.builder-summary-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+}
+
+.builder-pill {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text);
+  padding: 6px 14px;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, transform 0.15s ease;
+}
+
+.builder-pill:hover {
+  transform: translateY(-1px);
+  border-color: var(--blue);
+}
+
+.builder-pill.active {
+  background: var(--blue);
+  color: #000;
+  border-color: var(--blue);
+}
+
+.builder-pill-week {
+  font-weight: 600;
+}
+
+.builder-pill-lecture {
+  font-size: 0.9rem;
+}
+
+.builder-pill-small {
+  font-size: 0.85rem;
+  padding: 4px 12px;
+}
+
+.builder-pill-outline {
+  border-style: dashed;
+}
+
+.builder-action {
+  background: none;
+  border: none;
+  color: var(--blue);
+  font-size: 0.85rem;
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: var(--radius);
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.builder-action:hover {
+  background: rgba(166, 217, 255, 0.1);
+  color: #fff;
+}
+
+.builder-empty {
+  color: var(--gray);
+  font-size: 0.9rem;
 }
 
 /* Flashcards */
@@ -1672,3 +1856,199 @@ body.map-toolbox-dragging {
   flex: 1;
 }
 
+.block-mode-shell {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-lg);
+  padding: var(--pad-lg);
+}
+
+.block-mode-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+}
+
+.block-mode-header-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad);
+  align-items: center;
+  justify-content: space-between;
+}
+
+.block-mode-header h2 {
+  margin: 0;
+}
+
+.block-mode-select {
+  display: flex;
+  align-items: center;
+  gap: var(--pad-sm);
+  color: var(--gray);
+  font-size: 0.95rem;
+}
+
+.block-mode-select select {
+  background: var(--muted);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 4px 12px;
+  cursor: pointer;
+}
+
+.block-mode-meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad-sm);
+  color: var(--gray);
+  font-size: 0.85rem;
+}
+
+.block-mode-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad-sm);
+}
+
+.block-mode-board {
+  display: grid;
+  gap: var(--pad);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.block-mode-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+}
+
+.block-mode-card-title {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.block-mode-card-subtitle {
+  color: var(--gray);
+  font-size: 0.9rem;
+}
+
+.block-mode-slot {
+  border: 1px dashed var(--border);
+  border-radius: var(--radius);
+  min-height: 90px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--pad);
+  text-align: center;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+.block-mode-slot.filled {
+  border-style: solid;
+  justify-content: flex-start;
+}
+
+.block-mode-slot.drag-over {
+  border-color: var(--blue);
+  box-shadow: 0 0 0 1px var(--blue);
+}
+
+.block-mode-slot.correct {
+  border-color: var(--green);
+  background: rgba(164, 251, 196, 0.1);
+}
+
+.block-mode-slot.incorrect {
+  border-color: #f87171;
+  background: rgba(248, 113, 113, 0.12);
+}
+
+.block-mode-slot.missing {
+  border-color: var(--yellow);
+  background: rgba(255, 227, 163, 0.12);
+}
+
+.block-slot-placeholder {
+  color: var(--gray);
+  font-size: 0.9rem;
+}
+
+.block-chip {
+  background: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--pad-sm);
+  cursor: grab;
+  display: flex;
+  align-items: center;
+  gap: var(--pad-sm);
+  width: 100%;
+  text-align: left;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+}
+
+.block-chip:hover {
+  border-color: var(--blue);
+}
+
+.block-chip.assigned {
+  cursor: default;
+  background: var(--panel);
+}
+
+.block-chip.dragging {
+  opacity: 0.6;
+  transform: scale(0.98);
+}
+
+.block-chip-text {
+  flex: 1;
+  white-space: pre-wrap;
+}
+
+.block-mode-answer {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: var(--radius);
+  padding: var(--pad-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.9rem;
+}
+
+.block-mode-answer span {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--gray);
+}
+
+.block-mode-bank {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+}
+
+.block-mode-bank-title {
+  font-weight: 600;
+}
+
+.block-mode-bank-items {
+  display: grid;
+  gap: var(--pad);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.block-mode-bank-empty {
+  color: var(--gray);
+  font-size: 0.95rem;
+}
+
+.block-mode-empty {
+  text-align: center;
+  color: var(--gray);
+  padding: var(--pad-lg);
+}


### PR DESCRIPTION
## Summary
- redesign the study builder with card-based blocks, select-all toggles, and refreshed filters
- add a drag-and-drop Blocks study mode that lets users rebuild cards by matching section content
- centralize section definitions for card kinds and update styling to match the rest of the app

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca551119cc8322bb2dc83002911ba4