### PR TITLE
Add collapse toggles to study builder and settings lectures

### DIFF
--- a/js/ui/components/builder.js
+++ b/js/ui/components/builder.js
@@ -54,6 +54,18 @@ function renderBlockPanel(block, rerender) {
 
   const header = document.createElement('div');
   header.className = 'builder-block-header';
+
+  const blockCollapseBtn = createCollapseToggle({
+    collapsed: blockCollapsed,
+    label: blockCollapsed ? 'Show weeks' : 'Hide weeks',
+    onToggle: () => {
+      toggleBlockCollapsed(blockId);
+      rerender();
+    },
+    variant: 'block'
+  });
+  header.appendChild(blockCollapseBtn);
+
   const title = document.createElement('h3');
   title.textContent = block.title || blockId;
   header.appendChild(title);
@@ -78,12 +90,6 @@ function renderBlockPanel(block, rerender) {
   actions.appendChild(toggleBlockBtn);
 
   if (lectures.length) {
-    const toggleCollapseBtn = createAction(blockCollapsed ? 'Show weeks' : 'Hide weeks', () => {
-      toggleBlockCollapsed(blockId);
-      rerender();
-    });
-    actions.appendChild(toggleCollapseBtn);
-
     const allBtn = createAction('Select all lectures', () => {
       selectEntireBlock(block);
       rerender();
@@ -139,6 +145,16 @@ function renderWeek(block, week, lectures, rerender) {
   const header = document.createElement('div');
   header.className = 'builder-week-header';
 
+  const weekCollapseBtn = createCollapseToggle({
+    collapsed: weekCollapsed,
+    label: weekCollapsed ? 'Show lectures' : 'Hide lectures',
+    onToggle: () => {
+      toggleWeekCollapsed(blockId, week);
+      rerender();
+    }
+  });
+  header.appendChild(weekCollapseBtn);
+
   const label = createPill(selected, formatWeekLabel(week), () => {
     toggleWeek(block, week);
     rerender();
@@ -152,11 +168,6 @@ function renderWeek(block, week, lectures, rerender) {
 
   const actions = document.createElement('div');
   actions.className = 'builder-week-actions';
-  const toggleBtn = createAction(weekCollapsed ? 'Show lectures' : 'Hide lectures', () => {
-    toggleWeekCollapsed(blockId, week);
-    rerender();
-  });
-  actions.appendChild(toggleBtn);
   const allBtn = createAction('Select all', () => {
     selectWeek(block, week);
     rerender();
@@ -522,5 +533,17 @@ function createAction(label, onClick) {
   btn.className = 'builder-action';
   btn.textContent = label;
   btn.addEventListener('click', onClick);
+  return btn;
+}
+
+function createCollapseToggle({ collapsed, label, onToggle, variant = 'week' }) {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'builder-collapse-toggle';
+  if (variant === 'block') btn.classList.add('builder-collapse-toggle-block');
+  btn.setAttribute('aria-expanded', String(!collapsed));
+  btn.setAttribute('aria-label', label);
+  btn.textContent = collapsed ? '▸' : '▾';
+  btn.addEventListener('click', onToggle);
   return btn;
 }

--- a/style.css
+++ b/style.css
@@ -357,7 +357,38 @@ input[type="checkbox"]:checked::after {
   display: flex;
   flex-wrap: wrap;
   gap: var(--pad-sm);
-  align-items: baseline;
+  align-items: center;
+}
+
+.builder-collapse-toggle {
+  border: none;
+  background: transparent;
+  color: var(--gray);
+  padding: 0;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: var(--radius);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  transition: color 0.2s ease, background-color 0.2s ease;
+}
+
+.builder-collapse-toggle:hover {
+  color: var(--text);
+  background: var(--muted);
+}
+
+.builder-collapse-toggle:focus-visible {
+  outline: 2px solid var(--blue);
+  outline-offset: 2px;
+}
+
+.builder-collapse-toggle-block {
+  font-size: 1.2rem;
 }
 
 .builder-block-header h3 {
@@ -428,6 +459,18 @@ input[type="checkbox"]:checked::after {
   display: flex;
   flex-wrap: wrap;
   gap: var(--pad-sm);
+}
+
+.settings-lecture-toggle {
+  margin-top: var(--pad-sm);
+  align-self: flex-start;
+}
+
+.settings-lecture-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+  margin-top: var(--pad-sm);
 }
 
 .builder-controls {


### PR DESCRIPTION
## Summary
- add collapse toggles to Study builder blocks and individual weeks for easier browsing
- style the new collapse controls to match the existing UI
- allow lecture lists in Settings to be hidden and persist their collapsed state, and rebuild the bundle

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb1f2197f883228774af671a01a987