### PR TITLE
Enhance entry editor with rich text and UI improvements

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -1,3 +1,17 @@
+const contentFields = [
+  'etiology','pathophys','clinical','diagnosis','treatment','complications','mnemonic',
+  'class','source','moa','uses','sideEffects','contraindications',
+  'type','definition','mechanism','clinicalRelevance','example'
+];
+
+function stripHtml(value = '') {
+  return value
+    .replace(/<br\s*\/?>(\s*)/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&[#a-z0-9]+;/gi, ' ');
+}
+
 export function tokenize(str) {
   return str.toLowerCase().replace(/[^\p{L}\p{N}\s]/gu, ' ').split(/\s+/).filter(Boolean);
 }
@@ -8,5 +22,10 @@ export function buildTokens(item) {
   if (item.concept) fields.push(item.concept);
   fields.push(...(item.facts || []), ...(item.tags || []));
   if (item.lectures) fields.push(...item.lectures.map(l => l.name));
+  contentFields.forEach(field => {
+    if (typeof item[field] === 'string' && item[field]) {
+      fields.push(stripHtml(item[field]));
+    }
+  });
   return Array.from(new Set(tokenize(fields.join(' ')))).slice(0,200).join(' ');
 }

--- a/js/ui/components/block-mode.js
+++ b/js/ui/components/block-mode.js
@@ -1,4 +1,5 @@
 import { state, setBlockMode } from '../../state.js';
+import { sanitizeHtml } from './rich-text.js';
 import { sectionDefsForKind } from './sections.js';
 
 export function renderBlockMode(root) {
@@ -371,7 +372,10 @@ function entryIdFor(itemId, sectionKey) {
 function sectionValue(raw) {
   if (raw == null) return '';
   const text = typeof raw === 'string' ? raw : String(raw);
-  return text.trim();
+  const sanitized = sanitizeHtml(text);
+  const template = document.createElement('template');
+  template.innerHTML = sanitized;
+  return template.content.textContent?.trim() || '';
 }
 
 function normalized(text) {

--- a/js/ui/components/cardlist.js
+++ b/js/ui/components/cardlist.js
@@ -4,6 +4,7 @@ import { chipList } from './chips.js';
 import { openEditor } from './editor.js';
 import { confirmModal } from './confirm.js';
 import { openLinker } from './linker.js';
+import { renderRichText } from './rich-text.js';
 
 const kindColors = { disease: 'var(--pink)', drug: 'var(--blue)', concept: 'var(--green)' };
 const fieldDefs = {
@@ -170,8 +171,7 @@ export function createItemCard(item, onChange){
       sec.appendChild(tl);
       const txt = document.createElement('div');
       txt.className = 'section-content';
-      txt.textContent = item[f];
-      txt.style.whiteSpace = 'pre-wrap';
+      renderRichText(txt, item[f]);
       sec.appendChild(txt);
       body.appendChild(sec);
     });

--- a/js/ui/components/entry-controls.js
+++ b/js/ui/components/entry-controls.js
@@ -10,29 +10,56 @@ export function createEntryAddControl(onAdded, initialKind = 'disease') {
   const wrapper = document.createElement('div');
   wrapper.className = 'entry-add-control';
 
-  const select = document.createElement('select');
-  select.className = 'input entry-add-select';
-  defaultOptions.forEach(opt => {
-    const option = document.createElement('option');
-    option.value = opt.value;
-    option.textContent = opt.label;
-    select.appendChild(option);
-  });
-  if (initialKind) {
-    select.value = initialKind;
-  }
-
   const button = document.createElement('button');
   button.type = 'button';
   button.className = 'btn';
   button.textContent = 'Add';
-  button.addEventListener('click', () => {
-    const kind = select.value;
-    if (!kind) return;
-    openEditor(kind, onAdded);
+  const menu = document.createElement('div');
+  menu.className = 'entry-add-menu hidden';
+
+  const options = [...defaultOptions];
+  if (initialKind) {
+    const idx = options.findIndex(opt => opt.value === initialKind);
+    if (idx > 0) {
+      const [preferred] = options.splice(idx, 1);
+      options.unshift(preferred);
+    }
+  }
+
+  options.forEach(opt => {
+    const item = document.createElement('button');
+    item.type = 'button';
+    item.className = 'entry-add-menu-item';
+    item.textContent = opt.label;
+    item.addEventListener('click', () => {
+      closeMenu();
+      openEditor(opt.value, onAdded);
+    });
+    menu.appendChild(item);
   });
 
-  wrapper.appendChild(select);
+  function closeMenu() {
+    menu.classList.add('hidden');
+    document.removeEventListener('mousedown', handleOutside);
+  }
+
+  function handleOutside(e) {
+    if (!wrapper.contains(e.target)) {
+      closeMenu();
+    }
+  }
+
+  button.addEventListener('click', () => {
+    const willOpen = menu.classList.contains('hidden');
+    if (willOpen) {
+      menu.classList.remove('hidden');
+      document.addEventListener('mousedown', handleOutside);
+    } else {
+      closeMenu();
+    }
+  });
+
   wrapper.appendChild(button);
+  wrapper.appendChild(menu);
   return wrapper;
 }

--- a/js/ui/components/flashcards.js
+++ b/js/ui/components/flashcards.js
@@ -1,5 +1,6 @@
 import { state, setFlashSession } from '../../state.js';
 import { sectionDefsForKind } from './sections.js';
+import { renderRichText } from './rich-text.js';
 
 // Render flashcards session. Uses session.pool if provided, else state.cohort
 export function renderFlashcards(root, redraw) {
@@ -38,7 +39,7 @@ export function renderFlashcards(root, redraw) {
     head.textContent = label;
     const body = document.createElement('div');
     body.className = 'flash-body';
-    body.textContent = item[field] || '';
+    renderRichText(body, item[field] || '');
     sec.appendChild(head);
     sec.appendChild(body);
     sec.addEventListener('click', () => { sec.classList.toggle('revealed'); });

--- a/js/ui/components/popup.js
+++ b/js/ui/components/popup.js
@@ -1,3 +1,5 @@
+import { renderRichText } from './rich-text.js';
+
 const fieldDefs = {
   disease: [
     ['etiology','Etiology'],
@@ -50,8 +52,7 @@ export function showPopup(item){
     tl.textContent = label;
     sec.appendChild(tl);
     const txt = document.createElement('div');
-    txt.textContent = val;
-    txt.style.whiteSpace = 'pre-wrap';
+    renderRichText(txt, val);
     sec.appendChild(txt);
     card.appendChild(sec);
   });

--- a/js/ui/components/quiz.js
+++ b/js/ui/components/quiz.js
@@ -1,4 +1,5 @@
 import { state, setQuizSession } from '../../state.js';
+import { renderRichText } from './rich-text.js';
 
 function titleOf(item){
   return item.name || item.concept || '';
@@ -39,7 +40,7 @@ export function renderQuiz(root, redraw){
     head.className = 'section-title';
     head.textContent = label;
     const body = document.createElement('div');
-    body.textContent = item[field];
+    renderRichText(body, item[field]);
     sec.appendChild(head);
     sec.appendChild(body);
     info.appendChild(sec);

--- a/js/ui/components/rich-text.js
+++ b/js/ui/components/rich-text.js
@@ -1,0 +1,341 @@
+const allowedTags = new Set([
+  'a','b','strong','i','em','u','s','strike','del','mark','span','font','p','div','br','ul','ol','li','img','sub','sup','blockquote','code','pre','hr','video','audio','source','iframe'
+]);
+
+const allowedAttributes = {
+  'a': ['href', 'title', 'target', 'rel'],
+  'img': ['src', 'alt', 'title', 'width', 'height'],
+  'span': ['style'],
+  'div': ['style'],
+  'p': ['style'],
+  'font': ['style', 'color', 'face', 'size'],
+  'blockquote': ['style'],
+  'code': ['style'],
+  'pre': ['style'],
+  'video': ['src', 'controls', 'width', 'height', 'poster', 'preload', 'loop', 'muted', 'playsinline'],
+  'audio': ['src', 'controls', 'preload', 'loop', 'muted'],
+  'source': ['src', 'type'],
+  'iframe': ['src', 'title', 'width', 'height', 'allow', 'allowfullscreen', 'frameborder']
+};
+
+const allowedStyles = new Set([
+  'color',
+  'background-color',
+  'font-size',
+  'font-weight',
+  'font-style',
+  'text-decoration-line',
+  'text-decoration',
+  'text-decoration-color',
+  'text-decoration-style',
+  'text-align'
+]);
+
+function escapeHtml(str = ''){
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function isSafeUrl(value = '', { allowData = false, requireHttps = false } = {}){
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  if (/^javascript:/i.test(trimmed)) return false;
+  if (!allowData && /^data:/i.test(trimmed)) return false;
+  if (/^blob:/i.test(trimmed)) return true;
+  if (requireHttps) {
+    if (trimmed.startsWith('//')) return true;
+    if (trimmed.startsWith('/') || trimmed.startsWith('./') || trimmed.startsWith('../')) return true;
+    if (/^https:/i.test(trimmed)) return true;
+    return false;
+  }
+  return true;
+}
+
+function cleanStyles(node){
+  const style = node.getAttribute('style');
+  if (!style) return;
+  const cleaned = style
+    .split(';')
+    .map(part => part.trim())
+    .filter(Boolean)
+    .map(part => {
+      const [rawProp, ...valueParts] = part.split(':');
+      if (!rawProp || !valueParts.length) return null;
+      const prop = rawProp.trim().toLowerCase();
+      if (!allowedStyles.has(prop)) return null;
+      return `${prop}: ${valueParts.join(':').trim()}`;
+    })
+    .filter(Boolean)
+    .join('; ');
+  if (cleaned) node.setAttribute('style', cleaned);
+  else node.removeAttribute('style');
+}
+
+function sanitizeNode(node){
+  if (node.nodeType === Node.TEXT_NODE) return;
+  if (node.nodeType === Node.COMMENT_NODE) {
+    node.remove();
+    return;
+  }
+  const tag = node.tagName?.toLowerCase();
+  if (!tag) return;
+  if (!allowedTags.has(tag)) {
+    if (node.childNodes.length) {
+      const parent = node.parentNode;
+      while (node.firstChild) parent.insertBefore(node.firstChild, node);
+      node.remove();
+    } else {
+      node.remove();
+    }
+    return;
+  }
+  const attrs = Array.from(node.attributes || []);
+  const allowList = allowedAttributes[tag] || [];
+  attrs.forEach(attr => {
+    const name = attr.name.toLowerCase();
+    if (name === 'style') {
+      cleanStyles(node);
+      return;
+    }
+    if (!allowList.includes(name)) {
+      node.removeAttribute(attr.name);
+      return;
+    }
+    if (tag === 'a' && name === 'href') {
+      const value = attr.value.trim();
+      if (!value || value.startsWith('javascript:')) {
+        node.removeAttribute(attr.name);
+      } else {
+        node.setAttribute('target', '_blank');
+        node.setAttribute('rel', 'noopener noreferrer');
+      }
+    }
+    if (name === 'src' && ['img','video','audio','source','iframe'].includes(tag)) {
+      const allowData = tag === 'img';
+      const requireHttps = tag === 'iframe';
+      if (!isSafeUrl(attr.value || '', { allowData, requireHttps })) {
+        node.removeAttribute(attr.name);
+      }
+    }
+  });
+  Array.from(node.childNodes).forEach(sanitizeNode);
+}
+
+export function sanitizeHtml(html = ''){
+  const template = document.createElement('template');
+  template.innerHTML = html;
+  Array.from(template.content.childNodes).forEach(sanitizeNode);
+  return template.innerHTML;
+}
+
+function normalizeInput(value = ''){
+  if (!value) return '';
+  const looksHtml = /<([a-z][^>]*>)/i.test(value);
+  if (looksHtml) return sanitizeHtml(value);
+  return sanitizeHtml(escapeHtml(value).replace(/\n/g, '<br>'));
+}
+
+function isEmptyHtml(html = ''){
+  if (!html) return true;
+  const template = document.createElement('template');
+  template.innerHTML = html;
+  const hasMedia = template.content.querySelector('img,video,audio,iframe');
+  const text = template.content.textContent?.replace(/\u00a0/g, ' ').trim();
+  return !hasMedia && !text;
+}
+
+function createToolbarButton(label, title, onClick){
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'rich-editor-btn';
+  btn.textContent = label;
+  btn.title = title;
+  btn.addEventListener('mousedown', e => e.preventDefault());
+  btn.addEventListener('click', onClick);
+  return btn;
+}
+
+export function createRichTextEditor({ value = '' } = {}){
+  const wrapper = document.createElement('div');
+  wrapper.className = 'rich-editor';
+
+  const toolbar = document.createElement('div');
+  toolbar.className = 'rich-editor-toolbar';
+  wrapper.appendChild(toolbar);
+
+  const editable = document.createElement('div');
+  editable.className = 'rich-editor-area input';
+  editable.contentEditable = 'true';
+  editable.spellcheck = true;
+  editable.innerHTML = normalizeInput(value);
+  wrapper.appendChild(editable);
+
+  function focusEditor(){
+    editable.focus({ preventScroll: false });
+  }
+
+  function exec(command, arg = null){
+    focusEditor();
+    document.execCommand('styleWithCSS', false, true);
+    document.execCommand(command, false, arg);
+    editable.dispatchEvent(new Event('input'));
+  }
+
+  const controls = [
+    createToolbarButton('B', 'Bold', () => exec('bold')),
+    createToolbarButton('I', 'Italic', () => exec('italic')),
+    createToolbarButton('U', 'Underline', () => exec('underline')),
+    createToolbarButton('S', 'Strikethrough', () => exec('strikeThrough'))
+  ];
+  controls.forEach(btn => toolbar.appendChild(btn));
+
+  const colorWrap = document.createElement('label');
+  colorWrap.className = 'rich-editor-color';
+  colorWrap.title = 'Text color';
+  const colorInput = document.createElement('input');
+  colorInput.type = 'color';
+  colorInput.addEventListener('input', () => {
+    exec('foreColor', colorInput.value);
+  });
+  colorWrap.appendChild(colorInput);
+  toolbar.appendChild(colorWrap);
+
+  const highlightWrap = document.createElement('label');
+  highlightWrap.className = 'rich-editor-color';
+  highlightWrap.title = 'Highlight color';
+  const highlightInput = document.createElement('input');
+  highlightInput.type = 'color';
+  highlightInput.value = '#ffff00';
+  highlightInput.addEventListener('input', () => {
+    exec('hiliteColor', highlightInput.value);
+  });
+  highlightWrap.appendChild(highlightInput);
+  toolbar.appendChild(highlightWrap);
+
+  const sizeSelect = document.createElement('select');
+  sizeSelect.className = 'rich-editor-size';
+  const sizes = [
+    ['Default', ''],
+    ['Small', '0.85rem'],
+    ['Normal', '1rem'],
+    ['Large', '1.25rem'],
+    ['Huge', '1.5rem']
+  ];
+  sizes.forEach(([label, value]) => {
+    const opt = document.createElement('option');
+    opt.value = value;
+    opt.textContent = label;
+    sizeSelect.appendChild(opt);
+  });
+  sizeSelect.addEventListener('change', () => {
+    focusEditor();
+    document.execCommand('styleWithCSS', false, true);
+    document.execCommand('fontSize', false, 4);
+    const selection = window.getSelection();
+    if (selection?.rangeCount) {
+      const walker = document.createTreeWalker(editable, NodeFilter.SHOW_ELEMENT, {
+        acceptNode: (node) => node.tagName?.toLowerCase() === 'font' ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP
+      });
+      const toAdjust = [];
+      while (walker.nextNode()) {
+        toAdjust.push(walker.currentNode);
+      }
+      toAdjust.forEach(node => {
+        if (sizeSelect.value) {
+          const span = document.createElement('span');
+          span.style.fontSize = sizeSelect.value;
+          while (node.firstChild) span.appendChild(node.firstChild);
+          node.parentNode.replaceChild(span, node);
+        } else {
+          const parent = node.parentNode;
+          while (node.firstChild) parent.insertBefore(node.firstChild, node);
+          parent.removeChild(node);
+        }
+      });
+    }
+    editable.dispatchEvent(new Event('input'));
+    sizeSelect.value = '';
+  });
+  toolbar.appendChild(sizeSelect);
+
+  const bulletBtn = createToolbarButton('•', 'Bulleted list', () => exec('insertUnorderedList'));
+  toolbar.appendChild(bulletBtn);
+  const numberedBtn = createToolbarButton('1.', 'Numbered list', () => exec('insertOrderedList'));
+  toolbar.appendChild(numberedBtn);
+
+  const linkBtn = createToolbarButton('🔗', 'Insert link', () => {
+    focusEditor();
+    const url = prompt('Enter URL');
+    if (!url) return;
+    exec('createLink', url);
+  });
+  toolbar.appendChild(linkBtn);
+
+  const imageBtn = createToolbarButton('🖼', 'Insert image', () => {
+    focusEditor();
+    const url = prompt('Enter image URL');
+    if (!url) return;
+    exec('insertImage', url);
+  });
+  toolbar.appendChild(imageBtn);
+
+  const mediaBtn = createToolbarButton('🎬', 'Insert media', () => {
+    focusEditor();
+    const url = prompt('Enter media URL');
+    if (!url) return;
+    const typePrompt = prompt('Media type (video/audio/embed)', 'video');
+    const kind = (typePrompt || 'video').toLowerCase();
+    const safeUrl = escapeHtml(url);
+    let html = '';
+    if (kind.startsWith('a')) {
+      html = `<audio controls src="${safeUrl}"></audio>`;
+    } else if (kind.startsWith('e') || kind.startsWith('i')) {
+      html = `<iframe src="${safeUrl}" title="Embedded media" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`;
+    } else {
+      html = `<video controls src="${safeUrl}"></video>`;
+    }
+    document.execCommand('insertHTML', false, html);
+    editable.dispatchEvent(new Event('input'));
+  });
+  toolbar.appendChild(mediaBtn);
+
+  const clearBtn = createToolbarButton('⌫', 'Clear formatting', () => exec('removeFormat'));
+  toolbar.appendChild(clearBtn);
+
+  editable.addEventListener('keydown', (e) => {
+    if (e.key === 'Tab') {
+      e.preventDefault();
+      if (e.shiftKey) exec('outdent'); else exec('indent');
+    }
+  });
+
+  return {
+    element: wrapper,
+    getValue(){
+      const sanitized = sanitizeHtml(editable.innerHTML);
+      return isEmptyHtml(sanitized) ? '' : sanitized;
+    },
+    setValue(val){
+      editable.innerHTML = normalizeInput(val);
+    },
+    focus(){
+      focusEditor();
+    }
+  };
+}
+
+export function renderRichText(target, value){
+  const normalized = normalizeInput(value);
+  if (!normalized) {
+    target.textContent = '';
+    target.classList.remove('rich-content');
+    return;
+  }
+  target.classList.add('rich-content');
+  target.innerHTML = normalized;
+}
+

--- a/js/ui/components/table.js
+++ b/js/ui/components/table.js
@@ -1,6 +1,7 @@
 import { listBlocks } from '../../storage/storage.js';
 import { createTitleCell } from './titlecell.js';
 import { chipList } from './chips.js';
+import { renderRichText } from './rich-text.js';
 
 const columnMap = {
   disease: [
@@ -114,7 +115,7 @@ export async function renderTable(container, items, kind, onChange) {
             if (field === 'facts') {
               td2.appendChild(chipList(it.facts || []));
             } else {
-              td2.textContent = it[field] || '';
+              renderRichText(td2, it[field] || '');
             }
             tr.appendChild(td2);
           });

--- a/style.css
+++ b/style.css
@@ -86,10 +86,42 @@ button:hover {
   align-items: center;
   gap: var(--pad-sm);
   margin: var(--pad) var(--pad) 0;
+  position: relative;
 }
 
-.entry-add-select {
-  min-width: 160px;
+.entry-add-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
+  padding: 6px;
+  min-width: 180px;
+  z-index: 3000;
+}
+
+.entry-add-menu.hidden {
+  display: none;
+}
+
+.entry-add-menu-item {
+  background: transparent;
+  border: none;
+  border-radius: var(--radius);
+  color: var(--text);
+  padding: 8px 12px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.entry-add-menu-item:hover,
+.entry-add-menu-item:focus {
+  background: rgba(255, 255, 255, 0.08);
+  outline: none;
 }
 
 .tab-content {
@@ -251,6 +283,10 @@ input[type="checkbox"]:checked::after {
   flex-direction: column;
   max-height: 85vh;
   min-width: 320px;
+  min-height: 260px;
+  max-width: 90vw;
+  resize: both;
+  overflow: hidden;
   z-index: 2050;
 }
 
@@ -293,7 +329,11 @@ input[type="checkbox"]:checked::after {
 }
 
 .floating-body {
+  display: flex;
+  flex-direction: column;
   padding: var(--pad);
+  flex: 1;
+  min-height: 0;
   overflow: auto;
 }
 
@@ -305,6 +345,8 @@ input[type="checkbox"]:checked::after {
   display: flex;
   flex-direction: column;
   gap: var(--pad-sm);
+  flex: 1;
+  min-height: 0;
 }
 
 .editor-field {
@@ -312,6 +354,73 @@ input[type="checkbox"]:checked::after {
   flex-direction: column;
   gap: 4px;
   font-size: 0.95rem;
+}
+
+.rich-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.rich-editor-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.rich-editor-btn {
+  background: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 6px);
+  color: var(--text);
+  padding: 4px 8px;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.rich-editor-btn:hover,
+.rich-editor-btn:focus {
+  background: rgba(255, 255, 255, 0.08);
+  outline: none;
+}
+
+.rich-editor-color {
+  display: inline-flex;
+  align-items: center;
+}
+
+.rich-editor-color input {
+  width: 32px;
+  height: 28px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 6px);
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
+}
+
+.rich-editor-size {
+  background: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 6px);
+  color: var(--text);
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.rich-editor-area {
+  min-height: 140px;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: rgba(255, 255, 255, 0.02);
+  overflow: auto;
+  word-break: break-word;
+}
+
+.rich-editor-area:focus {
+  outline: 2px solid var(--blue);
+  outline-offset: 2px;
 }
 
 .editor-form textarea.input {
@@ -807,7 +916,7 @@ input[type="checkbox"]:checked::after {
 .flash-body {
   display: none;
   margin-top: 4px;
-  white-space: pre-wrap;
+  white-space: normal;
 }
 
 .flash-section.revealed .flash-body {
@@ -1038,9 +1147,33 @@ input[type="checkbox"]:checked::after {
   opacity:0.7;
 }
 
-.section div {
-  white-space:pre-wrap;
-  word-break:break-word;
+.rich-content {
+  white-space: normal;
+  word-break: break-word;
+}
+
+.rich-content p {
+  margin: 0 0 0.75em;
+}
+
+.rich-content p:last-child {
+  margin-bottom: 0;
+}
+
+.rich-content ul,
+.rich-content ol {
+  padding-left: 1.25em;
+}
+
+.rich-content img,
+.rich-content video,
+.rich-content iframe,
+.rich-content audio {
+  max-width: 100%;
+  height: auto;
+  border-radius: var(--radius-sm, 6px);
+  display: block;
+  margin: 0.5em 0;
 }
 
 .facts {

--- a/test/search.test.js
+++ b/test/search.test.js
@@ -13,3 +13,11 @@ test('buildTokens gathers fields', () => {
     assert(tokens.includes(tok));
   });
 });
+
+test('buildTokens includes rich text content', () => {
+  const item = { etiology: '<p>Heart <strong>Failure</strong> &amp; Shock</p>' };
+  const tokens = buildTokens(item).split(' ');
+  ['heart','failure','shock'].forEach(tok => {
+    assert(tokens.includes(tok));
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable rich text editor with sanitization, formatting controls, and media support for entry forms and displays
- make floating editor windows resizable, refresh entry add controls, and style rendered rich content across cards, tables, popups, and study views
- extend search token generation and tests to cover rich text content

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb39e258dc8322bd430073d5a90908