### PR TITLE
Refine entry controls and highlight tooling

### DIFF
--- a/js/ui/components/cardlist.js
+++ b/js/ui/components/cardlist.js
@@ -314,6 +314,9 @@ export async function renderCardList(container, items, kind, onChange){
   viewToggle.appendChild(gridBtn);
   toolbar.appendChild(viewToggle);
 
+  const advancedWrap = document.createElement('div');
+  advancedWrap.className = 'layout-advanced-controls';
+
   const columnWrap = document.createElement('label');
   columnWrap.className = 'layout-control';
   columnWrap.textContent = 'Columns';
@@ -333,7 +336,7 @@ export async function renderCardList(container, items, kind, onChange){
   });
   columnWrap.appendChild(columnInput);
   columnWrap.appendChild(columnValue);
-  toolbar.appendChild(columnWrap);
+  advancedWrap.appendChild(columnWrap);
 
   const scaleWrap = document.createElement('label');
   scaleWrap.className = 'layout-control';
@@ -354,7 +357,20 @@ export async function renderCardList(container, items, kind, onChange){
   });
   scaleWrap.appendChild(scaleInput);
   scaleWrap.appendChild(scaleValue);
-  toolbar.appendChild(scaleWrap);
+  advancedWrap.appendChild(scaleWrap);
+
+  toolbar.appendChild(advancedWrap);
+
+  const advancedToggle = document.createElement('button');
+  advancedToggle.type = 'button';
+  advancedToggle.className = 'layout-advanced-toggle icon-btn ghost';
+  advancedToggle.title = 'Layout options';
+  advancedToggle.setAttribute('aria-expanded', 'false');
+  advancedToggle.setAttribute('aria-label', 'Toggle layout options');
+  advancedToggle.textContent = '⋯';
+  toolbar.appendChild(advancedToggle);
+
+  let advancedOpen = state.entryLayout.mode === 'grid';
 
   container.appendChild(toolbar);
 
@@ -364,6 +380,21 @@ export async function renderCardList(container, items, kind, onChange){
     gridBtn.classList.toggle('active', mode === 'grid');
     columnWrap.style.display = mode === 'grid' ? '' : 'none';
   }
+
+  function updateAdvancedVisibility(){
+    if (advancedOpen) {
+      advancedWrap.removeAttribute('hidden');
+    } else {
+      advancedWrap.setAttribute('hidden', '');
+    }
+    toolbar.classList.toggle('advanced-open', advancedOpen);
+    advancedToggle.setAttribute('aria-expanded', String(advancedOpen));
+  }
+
+  advancedToggle.addEventListener('click', () => {
+    advancedOpen = !advancedOpen;
+    updateAdvancedVisibility();
+  });
 
   function applyLayout(){
     const lists = container.querySelectorAll('.card-list');
@@ -375,6 +406,7 @@ export async function renderCardList(container, items, kind, onChange){
   }
 
   updateToolbar();
+  updateAdvancedVisibility();
 
   sortedBlocks.forEach(b => {
     const blockSec = document.createElement('section');

--- a/js/ui/components/editor.js
+++ b/js/ui/components/editor.js
@@ -183,12 +183,12 @@ export async function openEditor(kind, onSave, existing = null) {
 
     const weekWrap = document.createElement('div');
     weekWrap.className = 'builder-sub';
-    weekWrap.style.display = blkCb.checked ? 'block' : 'none';
+    weekWrap.style.display = blkCb.checked ? 'flex' : 'none';
     blockDiv.appendChild(weekWrap);
 
     blkCb.addEventListener('change', () => {
       if (blkCb.checked) blockSet.add(b.blockId); else blockSet.delete(b.blockId);
-      weekWrap.style.display = blkCb.checked ? 'block' : 'none';
+      weekWrap.style.display = blkCb.checked ? 'flex' : 'none';
     });
 
     const weeks = Array.from({ length: b.weeks || 0 }, (_, i) => i + 1);
@@ -205,12 +205,12 @@ export async function openEditor(kind, onSave, existing = null) {
 
       const lecWrap = document.createElement('div');
       lecWrap.className = 'builder-sub';
-      lecWrap.style.display = wkCb.checked ? 'block' : 'none';
+      lecWrap.style.display = wkCb.checked ? 'flex' : 'none';
       wkLabel.appendChild(lecWrap);
 
       wkCb.addEventListener('change', () => {
         if (wkCb.checked) weekSet.add(wkKey); else weekSet.delete(wkKey);
-        lecWrap.style.display = wkCb.checked ? 'block' : 'none';
+        lecWrap.style.display = wkCb.checked ? 'flex' : 'none';
       });
 
       (b.lectures || []).filter(l => l.week === w).forEach(l => {

--- a/js/ui/components/entry-controls.js
+++ b/js/ui/components/entry-controls.js
@@ -12,10 +12,14 @@ export function createEntryAddControl(onAdded, initialKind = 'disease') {
 
   const button = document.createElement('button');
   button.type = 'button';
-  button.className = 'btn';
-  button.textContent = 'Add';
+  button.className = 'entry-add-fab';
+  button.innerHTML = '<span>＋</span>';
+  button.setAttribute('aria-label', 'Add new entry');
+  button.setAttribute('aria-expanded', 'false');
+
   const menu = document.createElement('div');
-  menu.className = 'entry-add-menu hidden';
+  menu.className = 'entry-add-menu';
+  menu.setAttribute('role', 'menu');
 
   const options = [...defaultOptions];
   if (initialKind) {
@@ -31,6 +35,7 @@ export function createEntryAddControl(onAdded, initialKind = 'disease') {
     item.type = 'button';
     item.className = 'entry-add-menu-item';
     item.textContent = opt.label;
+    item.setAttribute('role', 'menuitem');
     item.addEventListener('click', () => {
       closeMenu();
       openEditor(opt.value, onAdded);
@@ -39,7 +44,8 @@ export function createEntryAddControl(onAdded, initialKind = 'disease') {
   });
 
   function closeMenu() {
-    menu.classList.add('hidden');
+    wrapper.classList.remove('open');
+    button.setAttribute('aria-expanded', 'false');
     document.removeEventListener('mousedown', handleOutside);
   }
 
@@ -49,17 +55,29 @@ export function createEntryAddControl(onAdded, initialKind = 'disease') {
     }
   }
 
+  wrapper.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+      closeMenu();
+      button.focus();
+    }
+  });
+
   button.addEventListener('click', () => {
-    const willOpen = menu.classList.contains('hidden');
+    const willOpen = !wrapper.classList.contains('open');
     if (willOpen) {
-      menu.classList.remove('hidden');
+      wrapper.classList.add('open');
+      button.setAttribute('aria-expanded', 'true');
       document.addEventListener('mousedown', handleOutside);
+      const firstItem = menu.querySelector('.entry-add-menu-item');
+      if (firstItem) {
+        setTimeout(() => firstItem.focus(), 0);
+      }
     } else {
       closeMenu();
     }
   });
 
-  wrapper.appendChild(button);
   wrapper.appendChild(menu);
+  wrapper.appendChild(button);
   return wrapper;
 }

--- a/js/ui/components/rich-text.js
+++ b/js/ui/components/rich-text.js
@@ -230,23 +230,35 @@ export function createRichTextEditor({ value = '' } = {}){
   const colorGroup = createGroup();
   colorGroup.appendChild(colorWrap);
 
-  const highlightWrap = document.createElement('label');
-  highlightWrap.className = 'rich-editor-color';
-  highlightWrap.title = 'Highlight color';
-  const highlightInput = document.createElement('input');
-  highlightInput.type = 'color';
-  highlightInput.value = '#ffff00';
-  highlightInput.dataset.lastColor = '#ffff00';
-  highlightInput.addEventListener('input', () => {
-    if (!hasActiveSelection()) {
-      highlightInput.value = highlightInput.dataset.lastColor || '#ffff00';
-      return;
-    }
-    exec('hiliteColor', highlightInput.value);
-    highlightInput.dataset.lastColor = highlightInput.value;
+  const highlightPalette = document.createElement('div');
+  highlightPalette.className = 'rich-editor-highlight';
+  const highlightLabel = document.createElement('span');
+  highlightLabel.className = 'rich-editor-highlight-label';
+  highlightLabel.textContent = 'Highlight';
+  highlightPalette.appendChild(highlightLabel);
+
+  const highlightColors = [
+    ['#facc15', 'Yellow'],
+    ['#f472b6', 'Pink'],
+    ['#f87171', 'Red'],
+    ['#4ade80', 'Green'],
+    ['#38bdf8', 'Blue']
+  ];
+
+  highlightColors.forEach(([color, label]) => {
+    const swatch = document.createElement('button');
+    swatch.type = 'button';
+    swatch.className = 'rich-editor-highlight-swatch';
+    swatch.style.setProperty('--swatch-color', color);
+    swatch.title = label;
+    swatch.addEventListener('click', () => {
+      if (!hasActiveSelection()) return;
+      exec('hiliteColor', color);
+    });
+    highlightPalette.appendChild(swatch);
   });
-  highlightWrap.appendChild(highlightInput);
-  colorGroup.appendChild(highlightWrap);
+
+  colorGroup.appendChild(highlightPalette);
 
   const listGroup = createGroup();
   const listSelect = document.createElement('select');
@@ -388,11 +400,8 @@ export function createRichTextEditor({ value = '' } = {}){
   utilityGroup.appendChild(clearBtn);
 
   const clearHighlightBtn = createToolbarButton('⨯', 'Remove highlight', () => {
-    focusEditor();
-    document.execCommand('hiliteColor', false, 'transparent');
-    highlightInput.value = '#ffff00';
-    highlightInput.dataset.lastColor = '#ffff00';
-    editable.dispatchEvent(new Event('input'));
+    if (!hasActiveSelection()) return;
+    exec('hiliteColor', 'transparent');
   });
   utilityGroup.appendChild(clearHighlightBtn);
 

--- a/style.css
+++ b/style.css
@@ -68,7 +68,7 @@ button {
   background: transparent;
   border: none;
   cursor: pointer;
-  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  transition: background 0.2s ease, transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
 button:focus-visible {
@@ -80,14 +80,16 @@ button {
   background: var(--muted);
   color: var(--text);
   border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 6px 12px;
-  cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  border-radius: var(--radius-sm);
+  padding: 4px 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 button:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(0,0,0,0.3);
+  background: rgba(148, 163, 184, 0.2);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 14px rgba(2, 6, 23, 0.35);
 }
 
 .header {
@@ -108,45 +110,86 @@ button:hover {
 }
 
 .entry-add-control {
+  position: fixed;
+  bottom: clamp(16px, 2vw, 32px);
+  right: clamp(16px, 3vw, 36px);
   display: flex;
-  align-items: center;
-  gap: var(--pad-sm);
-  margin: var(--pad) var(--pad) 0;
-  position: relative;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 10px;
+  z-index: 2600;
+  pointer-events: none;
+}
+
+.entry-add-control > * {
+  pointer-events: auto;
+}
+
+.entry-add-fab {
+  width: 54px;
+  height: 54px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--accent), rgba(56, 189, 248, 0.7));
+  border: none;
+  color: #02111d;
+  font-weight: 600;
+  font-size: 1.75rem;
+  box-shadow: 0 18px 38px rgba(2, 6, 23, 0.45);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.entry-add-fab span {
+  transform: translateY(-1px);
+}
+
+.entry-add-fab:hover {
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 22px 44px rgba(2, 6, 23, 0.55);
+}
+
+.entry-add-control.open .entry-add-fab {
+  transform: rotate(45deg);
 }
 
 .entry-add-menu {
-  position: absolute;
-  top: calc(100% + 6px);
-  left: 0;
   display: flex;
   flex-direction: column;
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
-  padding: 6px;
-  min-width: 180px;
-  z-index: 3000;
+  gap: 8px;
+  padding: 10px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-strong);
+  background: rgba(8, 13, 23, 0.92);
+  box-shadow: 0 18px 40px rgba(2, 6, 23, 0.5);
+  min-width: 160px;
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 0.18s ease, transform 0.18s ease;
+  pointer-events: none;
 }
 
-.entry-add-menu.hidden {
-  display: none;
+.entry-add-control.open .entry-add-menu {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
 }
 
 .entry-add-menu-item {
-  background: transparent;
-  border: none;
+  background: rgba(15, 23, 42, 0.55);
   border-radius: var(--radius);
   color: var(--text);
   padding: 8px 12px;
-  text-align: left;
-  cursor: pointer;
+  text-align: right;
+  border: 1px solid transparent;
+  font-size: 0.95rem;
+  justify-content: flex-end;
+  width: 100%;
 }
 
 .entry-add-menu-item:hover,
 .entry-add-menu-item:focus {
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(56, 189, 248, 0.12);
+  border-color: rgba(56, 189, 248, 0.35);
+  color: var(--accent);
   outline: none;
 }
 
@@ -289,27 +332,27 @@ input[type="checkbox"]:checked::after {
 }
 
 .btn {
-  background: linear-gradient(135deg, rgba(56, 189, 248, 0.85), rgba(129, 140, 248, 0.85));
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.7), rgba(129, 140, 248, 0.7));
   color: #041021;
   border: 1px solid transparent;
   border-radius: var(--radius-sm);
-  padding: 10px 18px;
+  padding: 8px 16px;
   font-weight: 600;
   letter-spacing: 0.01em;
-  box-shadow: 0 12px 28px rgba(2, 6, 23, 0.35);
+  box-shadow: 0 10px 24px rgba(2, 6, 23, 0.3);
 }
 .btn:hover {
   transform: translateY(-1px);
-  box-shadow: 0 18px 36px rgba(2, 6, 23, 0.45);
+  box-shadow: 0 16px 30px rgba(2, 6, 23, 0.4);
 }
 .btn:active {
   transform: translateY(0);
-  box-shadow: 0 8px 16px rgba(2, 6, 23, 0.35);
+  box-shadow: 0 6px 14px rgba(2, 6, 23, 0.3);
 }
 .btn.secondary {
-  background: transparent;
+  background: rgba(15, 23, 42, 0.35);
   color: var(--text);
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--border);
   box-shadow: none;
 }
 .btn.subtle {
@@ -401,6 +444,8 @@ input[type="checkbox"]:checked::after {
   gap: var(--pad-sm);
   flex: 1;
   min-height: 0;
+  overflow-y: auto;
+  padding-right: 4px;
 }
 
 .editor-field {
@@ -521,6 +566,40 @@ input[type="checkbox"]:checked::after {
   cursor: pointer;
 }
 
+.rich-editor-highlight {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.rich-editor-highlight-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.rich-editor-highlight-swatch {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  border: 2px solid rgba(2, 6, 23, 0.6);
+  background: var(--swatch-color, var(--accent));
+  padding: 0;
+  box-shadow: 0 2px 4px rgba(2, 6, 23, 0.4);
+}
+
+.rich-editor-highlight-swatch:hover {
+  background: var(--swatch-color, var(--accent));
+  transform: translateY(-1px);
+  box-shadow: 0 4px 8px rgba(2, 6, 23, 0.45);
+}
+
+.rich-editor-highlight-swatch:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .rich-editor-select,
 .rich-editor-size {
   background: rgba(15, 23, 42, 0.6);
@@ -595,10 +674,22 @@ input[type="checkbox"]:checked::after {
   padding: 8px;
   border-radius: var(--radius-sm);
   background: rgba(8, 13, 23, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .editor-tag-block:last-child {
   margin-bottom: 0;
+}
+
+.builder-sub {
+  margin-left: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-left: 8px;
+  border-left: 1px solid rgba(148, 163, 184, 0.2);
 }
 
 .window-dock {
@@ -1140,10 +1231,11 @@ input[type="checkbox"]:checked::after {
   flex-wrap: wrap;
   gap: var(--pad);
   align-items: center;
-  margin-bottom: var(--pad);
+  justify-content: space-between;
+  margin: 0 var(--pad) var(--pad);
   padding: var(--pad-sm) var(--pad);
-  background: rgba(15, 23, 42, 0.45);
-  border: 1px solid var(--border);
+  background: rgba(8, 13, 23, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.2);
   border-radius: var(--radius);
 }
 
@@ -1159,7 +1251,7 @@ input[type="checkbox"]:checked::after {
   background: transparent;
   border: none;
   color: var(--text-muted);
-  padding: 8px 18px;
+  padding: 8px 16px;
   cursor: pointer;
 }
 
@@ -1173,15 +1265,75 @@ input[type="checkbox"]:checked::after {
   color: #041021;
 }
 
+.layout-advanced-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--pad);
+}
+
+.layout-advanced-controls[hidden] {
+  display: none;
+}
+
 .layout-control {
   display: flex;
   align-items: center;
   gap: var(--pad-sm);
-  font-size: 0.9rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
 }
 
 .layout-control input[type="range"] {
   width: 140px;
+  accent-color: var(--accent);
+  -webkit-appearance: none;
+  background: rgba(148, 163, 184, 0.2);
+  height: 4px;
+  border-radius: 999px;
+}
+
+.layout-control input[type="range"]:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.layout-control input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid rgba(2, 6, 23, 0.6);
+  box-shadow: 0 2px 6px rgba(2, 6, 23, 0.45);
+}
+
+.layout-control input[type="range"]::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid rgba(2, 6, 23, 0.6);
+  box-shadow: 0 2px 6px rgba(2, 6, 23, 0.45);
+}
+
+.layout-control input[type="range"]::-ms-thumb {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid rgba(2, 6, 23, 0.6);
+}
+
+.layout-advanced-toggle {
+  margin-left: auto;
+  width: 34px !important;
+  height: 34px !important;
+  border-radius: 999px;
+}
+
+.entry-layout-toolbar.advanced-open .layout-advanced-toggle {
+  background: rgba(56, 189, 248, 0.15);
+  color: var(--accent);
 }
 
 .layout-value {
@@ -1217,20 +1369,23 @@ input[type="checkbox"]:checked::after {
   justify-content: flex-start;
   align-items: flex-start;
   padding: calc(var(--pad-sm) * var(--card-scale));
+  padding-right: calc((var(--pad-sm) + 32px) * var(--card-scale));
   position: relative;
 }
 
-.card-title-btn {
-  background: none;
-  border: none;
-  color: inherit;
-  text-align: left;
-  flex: 1;
-  font-size: calc(1.35rem * var(--card-scale));
-  font-weight: 700;
-  cursor:pointer;
-  line-height: 1.2;
-}
+  .card-title-btn {
+    background: none;
+    border: none;
+    color: inherit;
+    text-align: left;
+    flex: 1;
+    font-size: calc(1.35rem * var(--card-scale));
+    font-weight: 700;
+    cursor:pointer;
+    line-height: 1.2;
+    white-space: normal;
+    word-break: break-word;
+  }
 
 .card-title-btn:hover {
   color: var(--accent);
@@ -1249,6 +1404,7 @@ input[type="checkbox"]:checked::after {
 .card-menu {
   display:flex;
   gap:6px;
+  flex-wrap: wrap;
   margin-right:6px;
 }
 
@@ -1268,8 +1424,8 @@ input[type="checkbox"]:checked::after {
   color: var(--text-muted);
   padding:4px;
   border-radius: var(--radius-sm);
-  width:32px;
-  height:32px;
+  width:28px;
+  height:28px;
   display:flex;
   align-items:center;
   justify-content:center;
@@ -1334,6 +1490,8 @@ input[type="checkbox"]:checked::after {
   border-radius: calc(8px * var(--card-scale));
   padding: calc(10px * var(--card-scale));
   border: 1px solid rgba(148, 163, 184, 0.18);
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .table-extra {


### PR DESCRIPTION
## Summary
- replace the inline add button with a floating action button that exposes the entry-type menu on demand
- introduce a collapsible advanced layout section with accent-coloured sliders to simplify the list toolbar
- smooth editor and card ergonomics with scrollable curriculum tags, preset highlight swatches, and tighter button/card sizing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb4cf2f88c8322b5c6a98b5ebfc360