### PR TITLE
Revamp top navigation styling and search

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -16,20 +16,43 @@ const tabs = ["Diseases","Drugs","Concepts","Cards","Study","Exams","Map","Setti
 
 async function render() {
   const root = document.getElementById('app');
+  const prevFocused = document.activeElement;
+  const shouldPreserveSearch =
+    prevFocused && prevFocused.dataset && prevFocused.dataset.persistFocus === 'main-search';
+  let prevSelection = null;
+  if (shouldPreserveSearch) {
+    try {
+      prevSelection = {
+        start: prevFocused.selectionStart ?? prevFocused.value.length,
+        end: prevFocused.selectionEnd ?? prevFocused.value.length
+      };
+    } catch (_) {
+      prevSelection = null;
+    }
+  }
+
   root.innerHTML = '';
 
   const header = document.createElement('header');
-  header.className = 'header row';
+  header.className = 'header';
+
+  const headerInner = document.createElement('div');
+  headerInner.className = 'header-inner';
+  header.appendChild(headerInner);
 
   const brand = document.createElement('div');
   brand.className = 'brand';
   brand.textContent = '✨ Sevenn';
-  header.appendChild(brand);
+  const headerLeft = document.createElement('div');
+  headerLeft.className = 'header-left';
+  headerLeft.appendChild(brand);
+
+  const primaryTabs = tabs.filter(t => t !== 'Settings');
 
   const nav = document.createElement('nav');
-  nav.className = 'tabs row';
+  nav.className = 'tabs';
 
-  tabs.forEach(t => {
+  primaryTabs.forEach(t => {
     const btn = document.createElement('button');
     const kindClass = { Diseases:'disease', Drugs:'drug', Concepts:'concept' }[t];
     btn.className = 'tab' + (state.tab === t ? ' active' : '');
@@ -42,15 +65,54 @@ async function render() {
     nav.appendChild(btn);
   });
 
-  header.appendChild(nav);
+  headerLeft.appendChild(nav);
+  headerInner.appendChild(headerLeft);
 
   const search = document.createElement('input');
   search.type = 'search';
+  search.className = 'search-input';
   search.placeholder = 'Search';
   search.value = state.query;
-  search.addEventListener('input', e => { setQuery(e.target.value); render(); });
-  header.appendChild(search);
+  search.dataset.persistFocus = 'main-search';
+  search.addEventListener('input', e => {
+    setQuery(e.target.value);
+    render();
+  });
+
+  const headerControls = document.createElement('div');
+  headerControls.className = 'header-controls';
+  headerControls.appendChild(search);
+
+  const settingsButton = document.createElement('button');
+  settingsButton.type = 'button';
+  settingsButton.className = 'icon-button settings-btn' + (state.tab === 'Settings' ? ' active' : '');
+  settingsButton.setAttribute('aria-label', 'Open settings');
+  settingsButton.innerHTML = `
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M12 15.5a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7Zm9.18-3.5a1 1 0 0 1-.17 1.12l-1.54 1.77c.06.33.1.67.1 1.01s-.04.68-.1 1.01l1.54 1.77a1 1 0 0 1 .17 1.12l-1.3 2.25a1 1 0 0 1-1.07.49l-2.24-.45a8.2 8.2 0 0 1-1.75 1.01l-.34 2.26a1 1 0 0 1-.98.84h-2.6a1 1 0 0 1-.98-.84l-.34-2.26a8.2 8.2 0 0 1-1.75-1.01l-2.24.45a1 1 0 0 1-1.07-.49l-1.3-2.25a1 1 0 0 1 .17-1.12l1.54-1.77A7.6 7.6 0 0 1 4 15.9c0-.34.04-.68.1-1.01L2.56 13.1a1 1 0 0 1-.17-1.12l1.3-2.25a1 1 0 0 1 1.07-.49l2.24.45c.54-.4 1.13-.73 1.75-1.01l.34-2.26a1 1 0 0 1 .98-.84h2.6a1 1 0 0 1 .98.84l.34 2.26c.62.28 1.21.61 1.75 1.01l2.24-.45a1 1 0 0 1 1.07.49l1.3 2.25Zm-3.62.5c0-3.05-2.51-5.54-5.56-5.54-3.05 0-5.56 2.49-5.56 5.54 0 3.05 2.51 5.54 5.56 5.54 3.05 0 5.56-2.49 5.56-5.54Z" />
+    </svg>
+  `;
+  settingsButton.addEventListener('click', () => {
+    setTab('Settings');
+    render();
+  });
+  headerControls.appendChild(settingsButton);
+
+  headerInner.appendChild(headerControls);
   root.appendChild(header);
+
+  if (shouldPreserveSearch) {
+    queueMicrotask(() => {
+      search.focus();
+      if (prevSelection && typeof prevSelection.start === 'number' && typeof prevSelection.end === 'number') {
+        try {
+          search.setSelectionRange(prevSelection.start, prevSelection.end);
+        } catch (_) {
+          // Ignore if the browser disallows selection on search inputs
+        }
+      }
+    });
+  }
 
   const main = document.createElement('main');
   if (state.tab === 'Map') main.className = 'map-main';

--- a/style.css
+++ b/style.css
@@ -92,11 +92,34 @@ button:hover {
   box-shadow: none;
 }
 
+
 .header {
-  padding: var(--pad);
-  background: var(--panel);
-  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 200;
+  padding: 18px var(--pad-lg);
+  background: rgba(8, 13, 23, 0.85);
+  backdrop-filter: blur(22px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 12px 36px rgba(2, 6, 23, 0.55);
   color: var(--text);
+}
+
+.header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--pad);
+  max-width: 1200px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: var(--pad);
+  flex-wrap: wrap;
 }
 
 .row {
@@ -107,6 +130,87 @@ button:hover {
 
 .brand {
   font-weight: 600;
+  font-size: 1.25rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text);
+  text-shadow: 0 8px 26px rgba(2, 6, 23, 0.45);
+}
+
+.header-controls {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.search-input {
+  width: 280px;
+  max-width: 100%;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: rgba(15, 23, 42, 0.65);
+  color: var(--text);
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25), 0 10px 28px rgba(2, 6, 23, 0.35);
+  transition: box-shadow 0.2s ease, background 0.2s ease, transform 0.2s ease;
+}
+
+.search-input::placeholder {
+  color: rgba(248, 250, 252, 0.6);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.search-input:focus {
+  outline: none;
+  background: rgba(8, 47, 73, 0.75);
+  box-shadow: 0 0 0 3px var(--accent-soft), 0 14px 36px rgba(2, 6, 23, 0.55);
+  transform: translateY(-1px);
+}
+
+.search-input::-webkit-search-cancel-button,
+.search-input::-webkit-search-decoration {
+  display: none;
+}
+
+.icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text);
+  width: 44px;
+  height: 44px;
+  box-shadow: 0 10px 24px rgba(2, 6, 23, 0.45);
+  transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+}
+
+.icon-button svg {
+  width: 22px;
+  height: 22px;
+  fill: currentColor;
+}
+
+.icon-button:hover {
+  transform: translateY(-1px);
+  background: rgba(30, 41, 59, 0.75);
+  border-color: rgba(56, 189, 248, 0.45);
+}
+
+.icon-button.active {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.95), rgba(192, 132, 252, 0.95));
+  color: #041021;
+  border-color: transparent;
+  box-shadow: 0 14px 34px rgba(2, 6, 23, 0.55);
+}
+
+.settings-btn svg {
+  width: 20px;
+  height: 20px;
 }
 
 
@@ -190,6 +294,55 @@ button:hover {
   }
 }
 
+@media (max-width: 1024px) {
+  .header {
+    padding: 16px var(--pad);
+  }
+
+  .header-inner {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 18px;
+  }
+
+  .header-left {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .header-controls {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .search-input {
+    flex: 1;
+  }
+}
+
+@media (max-width: 640px) {
+  .header-left {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .header-controls {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .search-input {
+    width: 100%;
+  }
+
+  .settings-btn {
+    width: 100%;
+    height: 46px;
+  }
+}
+
 .tab-content {
   padding: 0 var(--pad) var(--pad);
   display: flex;
@@ -208,25 +361,108 @@ button:hover {
   flex: 1;
 }
 
+.tabs {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.08), 0 12px 30px rgba(2, 6, 23, 0.45);
+}
+
 .tabs .tab {
-  background: var(--muted);
-  color: var(--text);
-  padding: 6px 12px;
+  background: rgba(148, 163, 184, 0.18);
+  color: rgba(248, 250, 252, 0.82);
+  padding: 8px 18px;
   cursor: pointer;
-  border-radius: var(--radius);
-  border: 1px solid var(--border);
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.tabs .tab:hover {
+  background: rgba(148, 163, 184, 0.26);
+  color: var(--text);
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(2, 6, 23, 0.4);
 }
 
 .tab.active {
-  background: var(--blue);
-  color: #000;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.95), rgba(192, 132, 252, 0.95));
+  color: #081326;
+  box-shadow: 0 12px 28px rgba(2, 6, 23, 0.45);
 }
-.tab.disease { background: var(--purple); color:#000; opacity:0.7; }
-.tab.disease.active { opacity:1; }
-.tab.drug { background: var(--blue); color:#000; opacity:0.7; }
-.tab.drug.active { opacity:1; }
-.tab.concept { background: var(--green); color:#000; opacity:0.7; }
-.tab.concept.active { opacity:1; }
+
+.tab.disease {
+  background: rgba(192, 132, 252, 0.22);
+  color: rgba(248, 250, 252, 0.88);
+}
+
+.tab.disease:hover {
+  background: rgba(192, 132, 252, 0.32);
+}
+
+.tab.disease.active {
+  background: linear-gradient(135deg, rgba(192, 132, 252, 0.95), rgba(244, 114, 182, 0.95));
+  color: #081326;
+}
+
+.tab.drug {
+  background: rgba(96, 165, 250, 0.22);
+  color: rgba(248, 250, 252, 0.88);
+}
+
+.tab.drug:hover {
+  background: rgba(96, 165, 250, 0.32);
+}
+
+.tab.drug.active {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.95), rgba(56, 189, 248, 0.95));
+  color: #061121;
+}
+
+.tab.concept {
+  background: rgba(74, 222, 128, 0.22);
+  color: rgba(15, 23, 42, 0.9);
+}
+
+.tab.concept:hover {
+  background: rgba(74, 222, 128, 0.32);
+}
+
+.tab.concept.active {
+  background: linear-gradient(135deg, rgba(74, 222, 128, 0.95), rgba(250, 204, 21, 0.95));
+  color: #05291b;
+}
+
+.tabs.subtabs {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  padding: 0;
+  gap: 12px;
+}
+
+.tabs.subtabs .tab {
+  background: rgba(148, 163, 184, 0.16);
+  color: rgba(248, 250, 252, 0.8);
+  border-radius: var(--radius);
+  padding: 6px 14px;
+  text-transform: none;
+  letter-spacing: 0.01em;
+}
+
+.tabs.subtabs .tab.active {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.9), rgba(99, 102, 241, 0.9));
+  color: #041021;
+  box-shadow: 0 8px 20px rgba(2, 6, 23, 0.45);
+}
 
 .card {
   background: linear-gradient(150deg, rgba(15, 23, 42, 0.85), rgba(8, 13, 23, 0.9));


### PR DESCRIPTION
## Summary
- restyle the top navigation with pastel idle states, vibrant active states, and a floating settings gear button
- refresh the header layout, search bar visuals, and typography to align with the sleek modern theme
- preserve search focus between renders so typing feels natural

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb61504c2c832281d74e2b9b2542a6