### PR TITLE
Improve exam selection and palette styling

### DIFF
--- a/js/ui/components/exams.js
+++ b/js/ui/components/exams.js
@@ -828,8 +828,10 @@ export function renderExamRunner(root, render) {
     choice.className = 'exam-option';
     if (sess.mode === 'review') choice.classList.add('review');
     choice.textContent = opt.text || '(Empty option)';
+    const isSelected = selected === opt.id;
     if (sess.mode === 'taking') {
-      if (selected === opt.id) choice.classList.add('selected');
+      if (isSelected) choice.classList.add('selected');
+      choice.setAttribute('aria-pressed', isSelected ? 'true' : 'false');
       choice.addEventListener('click', () => {
         sess.answers[sess.idx] = opt.id;
         if (sess.exam.timerMode !== 'timed' && sess.checked) {
@@ -840,12 +842,12 @@ export function renderExamRunner(root, render) {
       if (isInstantCheck) {
         const cls = answerClass(question, selected, opt.id);
         if (cls) choice.classList.add(cls);
-        if (selected === opt.id) choice.classList.add('chosen');
+        if (isSelected) choice.classList.add('chosen');
       }
     } else {
       const cls = answerClass(question, selected, opt.id);
       if (cls) choice.classList.add(cls);
-      if (selected === opt.id) choice.classList.add('chosen');
+      if (isSelected) choice.classList.add('chosen');
     }
     optionsWrap.appendChild(choice);
   });

--- a/style.css
+++ b/style.css
@@ -2867,9 +2867,10 @@ body.map-toolbox-dragging {
 }
 
 .flag-btn.active {
-  background: rgba(255, 144, 194, 0.15);
-  color: var(--pink);
-  border-color: var(--pink);
+  background: linear-gradient(135deg, #fef3c7, #fde68a);
+  color: #854d0e;
+  border-color: rgba(251, 191, 36, 0.8);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
 }
 
 .flag-btn:disabled {
@@ -2916,34 +2917,52 @@ body.map-toolbox-dragging {
 
 .exam-option {
   background: var(--muted);
-  border: 1px solid var(--border);
+  border: 2px solid var(--border);
   border-radius: var(--radius);
   padding: var(--pad);
   text-align: left;
   cursor: pointer;
-  transition: border-color 0.15s ease, background 0.15s ease;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  position: relative;
+  box-shadow: none;
 }
 
 .exam-option:hover {
   transform: none;
   box-shadow: none;
-  border-color: var(--blue);
+  border-color: rgba(96, 165, 250, 0.6);
+}
+
+.exam-option:focus-visible {
+  outline: 2px solid rgba(56, 189, 248, 0.65);
+  outline-offset: 3px;
 }
 
 .exam-option.selected {
-  border-color: #60a5fa;
-  background: linear-gradient(135deg, rgba(191, 219, 254, 0.85), rgba(147, 197, 253, 0.9));
+  border-color: rgba(56, 189, 248, 0.85);
+  background: linear-gradient(135deg, #e0f2fe, #bae6fd);
   color: #0f172a;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.7);
 }
 
 .exam-option.correct-answer {
-  border-color: var(--green);
-  background: rgba(164, 251, 196, 0.18);
+  border-color: rgba(52, 211, 153, 0.9);
+  background: linear-gradient(135deg, rgba(187, 247, 208, 0.85), rgba(134, 239, 172, 0.8));
+  color: #064e3b;
 }
 
 .exam-option.incorrect-answer {
-  border-color: #f97373;
-  background: rgba(249, 115, 115, 0.18);
+  border-color: rgba(248, 113, 113, 0.9);
+  background: linear-gradient(135deg, rgba(254, 205, 211, 0.8), rgba(252, 165, 165, 0.78));
+  color: #7f1d1d;
+}
+
+.exam-option.selected.correct-answer {
+  box-shadow: inset 0 0 0 2px rgba(16, 185, 129, 0.35);
+}
+
+.exam-option.selected.incorrect-answer {
+  box-shadow: inset 0 0 0 2px rgba(248, 113, 113, 0.35);
 }
 
 .exam-option.chosen::after {
@@ -2952,7 +2971,7 @@ body.map-toolbox-dragging {
   top: 8px;
   right: 12px;
   font-size: 0.75rem;
-  color: var(--gray);
+  color: rgba(30, 41, 59, 0.7);
 }
 
 .exam-option.chosen {
@@ -3033,42 +3052,50 @@ body.map-toolbox-dragging {
   font-weight: 600;
   line-height: 1;
   min-height: 44px;
-  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+  box-shadow: none;
 }
 
 .palette-button:hover {
   transform: none;
-  box-shadow: 0 10px 18px rgba(2, 6, 23, 0.28);
-  border-color: rgba(56, 189, 248, 0.6);
+  box-shadow: none;
+  border-color: rgba(148, 163, 184, 0.7);
 }
 
 .palette-button.active {
   border-color: rgba(255, 255, 255, 0.65);
   color: #0f172a;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.5);
 }
 
 .palette-button.active:not(.flagged):not(.answered) {
-  background: linear-gradient(135deg, rgba(191, 219, 254, 0.92), rgba(147, 197, 253, 0.9));
+  background: linear-gradient(135deg, #e0f2fe, #bae6fd);
 }
 
 .palette-button.answered {
-  background: linear-gradient(135deg, rgba(219, 234, 254, 0.95), rgba(191, 219, 254, 0.9));
-  border-color: rgba(147, 197, 253, 0.6);
+  background: linear-gradient(135deg, #e0f2fe, #bae6fd);
+  border-color: rgba(96, 165, 250, 0.6);
   color: #0f172a;
 }
 
 .palette-button.flagged {
-  background: linear-gradient(135deg, rgba(254, 249, 195, 0.94), rgba(253, 230, 138, 0.9));
-  border-color: rgba(250, 204, 21, 0.4);
+  background: linear-gradient(135deg, #fef3c7, #fde68a);
+  border-color: rgba(250, 204, 21, 0.55);
   color: #854d0e;
 }
 
+.palette-button.flagged.answered {
+  background: linear-gradient(135deg, #fef3c7 0%, #fde68a 45%, #bae6fd 100%);
+  border-color: rgba(251, 191, 36, 0.65);
+  color: #78350f;
+}
+
 .palette-button.answered.active {
-  border-color: rgba(147, 197, 253, 0.9);
+  border-color: rgba(56, 189, 248, 0.85);
 }
 
 .palette-button.flagged.active {
-  border-color: rgba(250, 204, 21, 0.7);
+  border-color: rgba(251, 191, 36, 0.8);
 }
 
 .exam-sidebar-info {


### PR DESCRIPTION
## Summary
- ensure exam options expose their selection state so styling stays in sync during a session
- refresh option, palette, and flag button styles with pastel gradients for answered and flagged indicators

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cb7ae2fdc48322900497161140b82d