### PR TITLE
Improve exam selection feedback and review palette

### DIFF
--- a/js/ui/components/exams.js
+++ b/js/ui/components/exams.js
@@ -674,13 +674,20 @@ function renderPalette(sidebar, sess, render) {
     ? (sess.result.flagged || [])
     : Object.entries(sess.flagged || {}).filter(([_, v]) => v).map(([idx]) => Number(idx)));
 
-  sess.exam.questions.forEach((_, idx) => {
+  sess.exam.questions.forEach((question, idx) => {
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.textContent = String(idx + 1);
     btn.className = 'palette-button';
     if (sess.idx === idx) btn.classList.add('active');
-    if (answers[idx] != null) btn.classList.add('answered');
+    const answer = answers[idx];
+    const hasAnswer = answer !== undefined && answer !== null && answer !== '';
+    if (hasAnswer) {
+      btn.classList.add('answered');
+      if (sess.mode === 'review') {
+        btn.classList.add(answer === question.answer ? 'correct' : 'incorrect');
+      }
+    }
     if (flaggedSet.has(idx)) btn.classList.add('flagged');
     btn.addEventListener('click', () => {
       sess.idx = idx;

--- a/style.css
+++ b/style.css
@@ -2939,10 +2939,10 @@ body.map-toolbox-dragging {
 }
 
 .exam-option.selected {
-  border-color: rgba(56, 189, 248, 0.85);
-  background: linear-gradient(135deg, #e0f2fe, #bae6fd);
+  border-color: rgba(59, 130, 246, 0.95);
+  background: linear-gradient(135deg, #bfdbfe, #60a5fa);
   color: #0f172a;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.7);
+  box-shadow: 0 8px 18px rgba(37, 99, 235, 0.15), inset 0 0 0 1px rgba(255, 255, 255, 0.8);
 }
 
 .exam-option.correct-answer {
@@ -3063,19 +3063,26 @@ body.map-toolbox-dragging {
 }
 
 .palette-button.active {
-  border-color: rgba(255, 255, 255, 0.65);
-  color: #0f172a;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.5);
-}
-
-.palette-button.active:not(.flagged):not(.answered) {
-  background: linear-gradient(135deg, #e0f2fe, #bae6fd);
+  border-color: #ffffff;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8);
 }
 
 .palette-button.answered {
   background: linear-gradient(135deg, #e0f2fe, #bae6fd);
   border-color: rgba(96, 165, 250, 0.6);
   color: #0f172a;
+}
+
+.palette-button.correct {
+  background: linear-gradient(135deg, rgba(187, 247, 208, 0.85), rgba(134, 239, 172, 0.8));
+  border-color: rgba(52, 211, 153, 0.7);
+  color: #064e3b;
+}
+
+.palette-button.incorrect {
+  background: linear-gradient(135deg, rgba(254, 205, 211, 0.85), rgba(252, 165, 165, 0.82));
+  border-color: rgba(248, 113, 113, 0.75);
+  color: #7f1d1d;
 }
 
 .palette-button.flagged {
@@ -3090,12 +3097,23 @@ body.map-toolbox-dragging {
   color: #78350f;
 }
 
-.palette-button.answered.active {
-  border-color: rgba(56, 189, 248, 0.85);
+.palette-button.flagged.correct {
+  background: linear-gradient(135deg, #fef3c7 0%, #fde68a 35%, rgba(187, 247, 208, 0.85) 100%);
+  border-color: rgba(251, 191, 36, 0.65);
+  color: #78350f;
 }
 
+.palette-button.flagged.incorrect {
+  background: linear-gradient(135deg, #fef3c7 0%, #fde68a 35%, rgba(252, 165, 165, 0.82) 100%);
+  border-color: rgba(251, 191, 36, 0.65);
+  color: #78350f;
+}
+
+.palette-button.correct.active,
+.palette-button.incorrect.active,
 .palette-button.flagged.active {
-  border-color: rgba(251, 191, 36, 0.8);
+  border-color: #ffffff;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8);
 }
 
 .exam-sidebar-info {


### PR DESCRIPTION
## Summary
- ensure the exam question map only marks questions as answered when a real choice is stored and highlight correctness during review
- update palette styling so the active question has a white border, answered items use pastel blue, and review states show green/red feedback while preserving flag indicators
- refresh option button styling to provide clearer visual feedback when a choice is selected

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb7d47e33883229466286e7694b394