### PR TITLE
Improve toggle feedback across study and exam views

### DIFF
--- a/js/ui/components/builder.js
+++ b/js/ui/components/builder.js
@@ -1,5 +1,6 @@
 import { state, setBuilder, setCohort, resetBlockMode } from '../../state.js';
 import { listBlocks, listItemsByKind } from '../../storage/storage.js';
+import { setToggleState } from '../../utils.js';
 
 export async function renderBuilder(root) {
   const blocks = await loadBlocks();
@@ -521,7 +522,7 @@ function createPill(active, label, onClick, variant = '') {
     const variants = Array.isArray(variant) ? variant : variant.split(' ');
     variants.filter(Boolean).forEach(name => btn.classList.add(`builder-pill-${name}`));
   }
-  if (active) btn.classList.add('active');
+  setToggleState(btn, active);
   btn.textContent = label;
   btn.addEventListener('click', onClick);
   return btn;

--- a/js/ui/components/cardlist.js
+++ b/js/ui/components/cardlist.js
@@ -1,5 +1,6 @@
 import { listBlocks, upsertItem, deleteItem } from '../../storage/storage.js';
 import { state, setEntryLayout } from '../../state.js';
+import { setToggleState } from '../../utils.js';
 import { openEditor } from './editor.js';
 import { confirmModal } from './confirm.js';
 import { openLinker } from './linker.js';
@@ -335,7 +336,8 @@ export async function renderCardList(container, items, kind, onChange){
 
   const listBtn = document.createElement('button');
   listBtn.type = 'button';
-  listBtn.className = 'layout-btn' + (layoutState.mode === 'list' ? ' active' : '');
+  listBtn.className = 'layout-btn';
+  setToggleState(listBtn, layoutState.mode === 'list');
   listBtn.textContent = 'List';
   listBtn.addEventListener('click', () => {
     if (layoutState.mode === 'list') return;
@@ -346,7 +348,8 @@ export async function renderCardList(container, items, kind, onChange){
 
   const gridBtn = document.createElement('button');
   gridBtn.type = 'button';
-  gridBtn.className = 'layout-btn' + (layoutState.mode === 'grid' ? ' active' : '');
+  gridBtn.className = 'layout-btn';
+  setToggleState(gridBtn, layoutState.mode === 'grid');
   gridBtn.textContent = 'Grid';
   gridBtn.addEventListener('click', () => {
     if (layoutState.mode === 'grid') return;
@@ -362,6 +365,7 @@ export async function renderCardList(container, items, kind, onChange){
   const controlsToggle = document.createElement('button');
   controlsToggle.type = 'button';
   controlsToggle.className = 'layout-advanced-toggle';
+  setToggleState(controlsToggle, layoutState.controlsVisible);
   controlsToggle.addEventListener('click', () => {
     setEntryLayout({ controlsVisible: !state.entryLayout.controlsVisible });
     updateToolbar();
@@ -421,14 +425,14 @@ export async function renderCardList(container, items, kind, onChange){
 
   function updateToolbar(){
     const { mode, controlsVisible } = state.entryLayout;
-    listBtn.classList.toggle('active', mode === 'list');
-    gridBtn.classList.toggle('active', mode === 'grid');
+    setToggleState(listBtn, mode === 'list');
+    setToggleState(gridBtn, mode === 'grid');
     columnWrap.style.display = mode === 'grid' ? '' : 'none';
     controlsWrap.style.display = controlsVisible ? '' : 'none';
     controlsWrap.setAttribute('aria-hidden', controlsVisible ? 'false' : 'true');
     controlsToggle.textContent = controlsVisible ? 'Hide layout tools' : 'Show layout tools';
     controlsToggle.setAttribute('aria-expanded', controlsVisible ? 'true' : 'false');
-    controlsToggle.classList.toggle('active', controlsVisible);
+    setToggleState(controlsToggle, controlsVisible);
   }
 
   function applyLayout(){

--- a/js/ui/components/editor.js
+++ b/js/ui/components/editor.js
@@ -1,4 +1,4 @@
-import { uid } from '../../utils.js';
+import { uid, setToggleState } from '../../utils.js';
 import { upsertItem, listBlocks } from '../../storage/storage.js';
 import { createFloatingWindow } from './window-manager.js';
 import { createRichTextEditor } from './rich-text.js';
@@ -182,7 +182,7 @@ export async function openEditor(kind, onSave, existing = null) {
     chip.type = 'button';
     chip.className = `tag-chip tag-chip-${variant}`;
     chip.textContent = label;
-    if (active) chip.classList.add('active');
+    setToggleState(chip, active);
     return chip;
   }
 
@@ -288,14 +288,14 @@ export async function openEditor(kind, onSave, existing = null) {
                 const key = `${blockId}|${l.id}`;
                 lectSet.delete(key);
                 const chip = lectureWrap.querySelector(`[data-lecture='${key}']`);
-                if (chip) chip.classList.remove('active');
+                if (chip) setToggleState(chip, false);
               });
             } else {
               weekSet.add(weekKey);
               section.classList.add('active');
               lectureWrap.classList.remove('collapsed');
             }
-            weekChip.classList.toggle('active', weekSet.has(weekKey));
+            setToggleState(weekChip, weekSet.has(weekKey));
           });
           section.appendChild(weekChip);
 
@@ -317,14 +317,14 @@ export async function openEditor(kind, onSave, existing = null) {
               lectureChip.addEventListener('click', () => {
                 if (lectSet.has(key)) {
                   lectSet.delete(key);
-                  lectureChip.classList.remove('active');
+                  setToggleState(lectureChip, false);
                 } else {
                   lectSet.add(key);
-                  lectureChip.classList.add('active');
+                  setToggleState(lectureChip, true);
                   if (!weekSet.has(weekKey)) {
                     weekSet.add(weekKey);
                     section.classList.add('active');
-                    weekChip.classList.add('active');
+                    setToggleState(weekChip, true);
                     lectureWrap.classList.remove('collapsed');
                   }
                 }

--- a/js/ui/components/exams.js
+++ b/js/ui/components/exams.js
@@ -1,6 +1,6 @@
 import { listExams, upsertExam, deleteExam, listExamSessions, loadExamSession, saveExamSessionProgress, deleteExamSessionProgress } from '../../storage/storage.js';
 import { state, setExamSession, setExamAttemptExpanded } from '../../state.js';
-import { uid } from '../../utils.js';
+import { uid, setToggleState } from '../../utils.js';
 import { confirmModal } from './confirm.js';
 
 const DEFAULT_SECONDS = 60;
@@ -679,7 +679,7 @@ function renderPalette(sidebar, sess, render) {
     btn.type = 'button';
     btn.textContent = String(idx + 1);
     btn.className = 'palette-button';
-    if (sess.idx === idx) btn.classList.add('active');
+    setToggleState(btn, sess.idx === idx);
     const answer = answers[idx];
 
     const hasAnswer = question.options.some(opt => opt.id === answer);
@@ -780,7 +780,7 @@ export function renderExamRunner(root, render) {
   const isFlagged = sess.mode === 'review'
     ? (sess.result.flagged || []).includes(sess.idx)
     : Boolean(sess.flagged?.[sess.idx]);
-  flagBtn.classList.toggle('active', isFlagged);
+  setToggleState(flagBtn, isFlagged);
   flagBtn.textContent = isFlagged ? '🚩 Flagged' : 'Flag question';
   if (sess.mode === 'taking') {
     flagBtn.addEventListener('click', () => {
@@ -847,8 +847,7 @@ export function renderExamRunner(root, render) {
     choice.appendChild(label);
     const isSelected = selected === opt.id;
     if (sess.mode === 'taking') {
-      if (isSelected) choice.classList.add('selected');
-      choice.setAttribute('aria-pressed', isSelected ? 'true' : 'false');
+      setToggleState(choice, isSelected, 'selected');
       choice.addEventListener('click', () => {
         sess.answers[sess.idx] = opt.id;
         if (sess.exam.timerMode !== 'timed' && sess.checked) {

--- a/js/ui/components/flashcards.js
+++ b/js/ui/components/flashcards.js
@@ -1,4 +1,5 @@
 import { state, setFlashSession } from '../../state.js';
+import { setToggleState } from '../../utils.js';
 import { sectionDefsForKind } from './sections.js';
 import { renderRichText } from './rich-text.js';
 
@@ -34,6 +35,8 @@ export function renderFlashcards(root, redraw) {
   sectionsFor(item).forEach(([label, field]) => {
     const sec = document.createElement('div');
     sec.className = 'flash-section';
+    sec.setAttribute('role', 'button');
+    sec.tabIndex = 0;
     const head = document.createElement('div');
     head.className = 'flash-heading';
     head.textContent = label;
@@ -42,7 +45,18 @@ export function renderFlashcards(root, redraw) {
     renderRichText(body, item[field] || '');
     sec.appendChild(head);
     sec.appendChild(body);
-    sec.addEventListener('click', () => { sec.classList.toggle('revealed'); });
+    setToggleState(sec, false, 'revealed');
+    const toggleReveal = () => {
+      const next = sec.dataset.active !== 'true';
+      setToggleState(sec, next, 'revealed');
+    };
+    sec.addEventListener('click', toggleReveal);
+    sec.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        toggleReveal();
+      }
+    });
     card.appendChild(sec);
   });
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -14,3 +14,21 @@ export function debounce(fn, delay = 150) {
 export function clamp(value, min, max) {
   return Math.min(max, Math.max(min, value));
 }
+
+export function setToggleState(element, active, className = 'active') {
+  if (!element) return;
+  const isActive = Boolean(active);
+  if (element.dataset) {
+    element.dataset.toggle = 'true';
+    element.dataset.active = isActive ? 'true' : 'false';
+  }
+  if (className && element.classList) {
+    element.classList.toggle(className, isActive);
+  }
+  if (typeof HTMLElement !== 'undefined' && element instanceof HTMLElement) {
+    const role = element.getAttribute('role');
+    if ((element.tagName === 'BUTTON' || role === 'button') && typeof element.setAttribute === 'function') {
+      element.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    }
+  }
+}

--- a/style.css
+++ b/style.css
@@ -101,6 +101,17 @@ button:not(.tab):not(.fab-btn):hover {
   background: rgba(148, 163, 184, 0.22);
 }
 
+[data-toggle="true"] {
+  transition: background 0.25s ease, color 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
+}
+
+[data-toggle="true"][data-active="true"] {
+  background: rgba(56, 189, 248, 0.16);
+  border-color: rgba(56, 189, 248, 0.42);
+  color: var(--text);
+  box-shadow: 0 10px 22px rgba(2, 6, 23, 0.35);
+}
+
 .header {
   padding: var(--pad) var(--pad-lg);
   background: var(--panel);
@@ -1571,6 +1582,25 @@ input[type="checkbox"]:checked::after {
 .flash-section {
   margin-top: var(--pad);
   cursor: pointer;
+  border-radius: var(--radius);
+  padding: var(--pad-sm);
+  border: 1px solid transparent;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
+}
+
+.flash-section:focus-visible {
+  outline: 2px solid rgba(56, 189, 248, 0.75);
+  outline-offset: 3px;
+}
+
+.flash-section[data-active="true"] {
+  background: rgba(148, 163, 184, 0.16);
+  border-color: rgba(148, 163, 184, 0.35);
+  box-shadow: 0 12px 26px rgba(2, 6, 23, 0.28);
+}
+
+.flash-section[data-active="true"] .flash-heading {
+  color: var(--accent);
 }
 
 .flash-heading {


### PR DESCRIPTION
## Summary
- add a shared toggle helper that keeps classes, aria-pressed, and data attributes in sync
- apply the helper in study, exam, and builder controls so toggled buttons visibly change state
- refresh flashcard reveal styling and add a fallback toggle style for elements that lacked feedback

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb847d045c8322a90237606315920b