### PR TITLE
Refresh settings and cards UI

### DIFF
--- a/js/ui/components/cards.js
+++ b/js/ui/components/cards.js
@@ -1,102 +1,359 @@
+import { listBlocks } from '../../storage/storage.js';
 import { createItemCard } from './cardlist.js';
 
+function createDeckObject({
+  id,
+  title,
+  subtitle = '',
+  blockId = null,
+  blockLabel = '',
+  week = null,
+  lectureId = null,
+  lectureName = '',
+  kind = 'lecture'
+}) {
+  return { id, title, subtitle, blockId, blockLabel, week, lectureId, lectureName, kind, cards: [] };
+}
+
 /**
- * Render lecture-based decks combining all item types.
+ * Render lecture-based decks combining all item types with structured navigation.
  * @param {HTMLElement} container
  * @param {import('../../types.js').Item[]} items
  * @param {Function} onChange
  */
-export function renderCards(container, items, onChange){
+export async function renderCards(container, items, onChange) {
   container.innerHTML = '';
-  const decks = new Map();
-  items.forEach(it => {
-    if (it.lectures && it.lectures.length){
-      it.lectures.forEach(l => {
-        const key = l.name || `Lecture ${l.id}`;
-        if (!decks.has(key)) decks.set(key, []);
-        decks.get(key).push(it);
+
+  const blocks = await listBlocks();
+  const blockOrder = new Map(blocks.map((block, index) => [block.blockId, index]));
+  const blockMeta = new Map(blocks.map(block => [block.blockId, block]));
+
+  /** @type {Map<string, any>} */
+  const structure = new Map();
+
+  function getBlockGroup(blockId) {
+    const key = blockId ?? '__unassigned__';
+    if (!structure.has(key)) {
+      const meta = blockMeta.get(blockId);
+      structure.set(key, {
+        id: blockId,
+        label: meta?.title || blockId || 'Unassigned',
+        color: meta?.color || '',
+        order: blockOrder.get(blockId) ?? Number.MAX_SAFE_INTEGER,
+        generalDeck: null,
+        weeks: new Map(),
+      });
+    }
+    return structure.get(key);
+  }
+
+  function ensureBlockGeneralDeck(group) {
+    if (!group.generalDeck) {
+      const title = group.id ? 'Block overview' : 'Unassigned cards';
+      const subtitle = group.id ? 'Cards tagged without a week' : 'Cards without curriculum tags';
+      group.generalDeck = createDeckObject({
+        id: `${group.id || 'unassigned'}::block`,
+        title,
+        subtitle,
+        blockId: group.id,
+        blockLabel: group.label,
+        kind: group.id ? 'block' : 'unassigned'
+      });
+    }
+    return group.generalDeck;
+  }
+
+  function ensureWeek(group, week) {
+    const key = String(week);
+    if (!group.weeks.has(key)) {
+      group.weeks.set(key, {
+        week,
+        lectureDecks: new Map(),
+        generalDeck: null
+      });
+    }
+    return group.weeks.get(key);
+  }
+
+  function ensureWeekGeneralDeck(group, weekGroup) {
+    if (!weekGroup.generalDeck) {
+      weekGroup.generalDeck = createDeckObject({
+        id: `${group.id || 'unassigned'}::week-${weekGroup.week}::general`,
+        title: `Week ${weekGroup.week} overview`,
+        subtitle: 'Tagged without a lecture',
+        blockId: group.id,
+        blockLabel: group.label,
+        week: weekGroup.week,
+        kind: 'week-general'
+      });
+    }
+    return weekGroup.generalDeck;
+  }
+
+  function ensureLectureDeck(group, weekGroup, lecture) {
+    const key = lecture?.id != null ? String(lecture.id) : lecture?.name || 'general';
+    if (!weekGroup.lectureDecks.has(key)) {
+      const title = lecture?.name || (lecture?.id != null ? `Lecture ${lecture.id}` : 'Lecture deck');
+      weekGroup.lectureDecks.set(key, createDeckObject({
+        id: `${group.id || 'unassigned'}::week-${weekGroup.week}::lecture-${key}`,
+        title,
+        subtitle: group.label,
+        blockId: group.id,
+        blockLabel: group.label,
+        week: weekGroup.week,
+        lectureId: lecture?.id ?? null,
+        lectureName: lecture?.name || '',
+        kind: 'lecture'
+      }));
+    }
+    return weekGroup.lectureDecks.get(key);
+  }
+
+  items.forEach(item => {
+    const hasLectures = Array.isArray(item.lectures) && item.lectures.length;
+    if (hasLectures) {
+      item.lectures.forEach(lecture => {
+        const blockId = lecture.blockId || (Array.isArray(item.blocks) && item.blocks.length ? item.blocks[0] : null);
+        const group = getBlockGroup(blockId);
+        const week = Number.isFinite(lecture.week) ? lecture.week : null;
+        if (week == null) {
+          const deck = ensureBlockGeneralDeck(group);
+          deck.cards.push(item);
+          return;
+        }
+        const weekGroup = ensureWeek(group, week);
+        const deck = ensureLectureDeck(group, weekGroup, lecture);
+        deck.cards.push(item);
       });
     } else {
-      if (!decks.has('Unassigned')) decks.set('Unassigned', []);
-      decks.get('Unassigned').push(it);
+      const blockIds = Array.isArray(item.blocks) && item.blocks.length ? item.blocks : [null];
+      const weeks = Array.isArray(item.weeks) && item.weeks.length ? item.weeks : [null];
+      blockIds.forEach(blockId => {
+        const group = getBlockGroup(blockId);
+        if (!weeks.length || weeks[0] == null) {
+          const deck = ensureBlockGeneralDeck(group);
+          deck.cards.push(item);
+        } else {
+          weeks.forEach(week => {
+            const weekGroup = ensureWeek(group, week);
+            const deck = ensureWeekGeneralDeck(group, weekGroup);
+            deck.cards.push(item);
+          });
+        }
+      });
     }
   });
 
-  const list = document.createElement('div');
-  list.className = 'deck-list';
-  container.appendChild(list);
+  const blockGroups = Array.from(structure.values()).sort((a, b) => {
+    if (a.id == null && b.id != null) return 1;
+    if (b.id == null && a.id != null) return -1;
+    if (a.order !== b.order) return a.order - b.order;
+    return a.label.localeCompare(b.label);
+  });
 
+  const navigation = document.createElement('div');
+  navigation.className = 'cards-navigation';
   const viewer = document.createElement('div');
-  viewer.className = 'deck-viewer hidden';
-  container.appendChild(viewer);
+  viewer.className = 'cards-viewer hidden';
 
-  decks.forEach((cards, lecture) => {
-    const deck = document.createElement('div');
-    deck.className = 'deck';
-    const title = document.createElement('div');
-    title.className = 'deck-title';
-    title.textContent = lecture;
-    const meta = document.createElement('div');
-    meta.className = 'deck-meta';
-    const blocks = Array.from(new Set(cards.flatMap(c => c.blocks || []))).join(', ');
-    const weeks = Array.from(new Set(cards.flatMap(c => c.weeks || []))).join(', ');
-    meta.textContent = `${blocks}${blocks && weeks ? ' • ' : ''}${weeks ? 'Week ' + weeks : ''}`;
-    deck.appendChild(title);
-    deck.appendChild(meta);
-    deck.addEventListener('click', () => { stopPreview(deck); openDeck(lecture, cards); });
-    let hoverTimer;
-    deck.addEventListener('mouseenter', () => {
-      hoverTimer = setTimeout(() => startPreview(deck, cards), 3000);
-    });
-    deck.addEventListener('mouseleave', () => {
-      clearTimeout(hoverTimer);
-      stopPreview(deck);
-    });
-    list.appendChild(deck);
+  container.append(navigation, viewer);
+
+  blockGroups.forEach(group => {
+    navigation.appendChild(renderBlockSection(group));
   });
 
-  function startPreview(deckEl, cards){
-    if (deckEl._preview) return;
-    deckEl.classList.add('pop');
-    const fan = document.createElement('div');
-    fan.className = 'deck-fan';
-    deckEl.appendChild(fan);
-    const show = cards.slice(0,5);
-    const spread = 20;
-    const offset = (show.length - 1) * spread / 2;
-    show.forEach((c,i) => {
-      const mini = document.createElement('div');
-      mini.className = 'fan-card';
-      mini.textContent = c.name || c.concept || '';
-      fan.appendChild(mini);
-      const angle = -offset + i * spread;
-      mini.style.transform = `rotate(${angle}deg) translateY(-80px)`;
-      setTimeout(() => { mini.style.opacity = 1; }, i * 100);
+  function renderBlockSection(group) {
+    const section = document.createElement('section');
+    section.className = 'cards-block';
+    if (group.color) section.style.setProperty('--block-color', group.color);
+
+    const header = document.createElement('button');
+    header.type = 'button';
+    header.className = 'cards-block-header';
+    header.setAttribute('aria-expanded', 'true');
+
+    const title = document.createElement('span');
+    title.className = 'cards-block-title';
+    title.textContent = group.label;
+
+    const meta = document.createElement('span');
+    meta.className = 'cards-block-meta';
+    const weekCount = group.weeks.size;
+    const deckCount = countDecks(group);
+    const metaParts = [];
+    if (weekCount) metaParts.push(`${weekCount} week${weekCount === 1 ? '' : 's'}`);
+    if (deckCount) metaParts.push(`${deckCount} deck${deckCount === 1 ? '' : 's'}`);
+    meta.textContent = metaParts.join(' • ') || 'No decks yet';
+
+    const chevron = document.createElement('span');
+    chevron.className = 'cards-chevron';
+
+    header.append(title, meta, chevron);
+    section.appendChild(header);
+
+    const body = document.createElement('div');
+    body.className = 'cards-block-body';
+    section.appendChild(body);
+
+    header.addEventListener('click', () => {
+      const collapsed = section.classList.toggle('collapsed');
+      header.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
     });
-    deckEl._preview = { fan };
-  }
 
-  function stopPreview(deckEl){
-    const prev = deckEl._preview;
-    if (prev){
-      prev.fan.remove();
-      deckEl.classList.remove('pop');
-      deckEl._preview = null;
+    if (group.generalDeck && group.generalDeck.cards.length) {
+      body.appendChild(renderOverview(group.generalDeck));
     }
+
+    const weeks = Array.from(group.weeks.values()).sort((a, b) => a.week - b.week);
+    weeks.forEach(weekGroup => {
+      body.appendChild(renderWeekSection(group, weekGroup));
+    });
+
+    if (!body.childElementCount) {
+      const empty = document.createElement('div');
+      empty.className = 'cards-empty subtle';
+      empty.textContent = group.id ? 'No cards tagged to this block yet.' : 'No unassigned cards found.';
+      body.appendChild(empty);
+    }
+
+    return section;
   }
 
-  function openDeck(title, cards){
-    list.classList.add('hidden');
+  function renderOverview(deck) {
+    const wrap = document.createElement('div');
+    wrap.className = 'cards-overview';
+    const label = document.createElement('div');
+    label.className = 'cards-overview-title';
+    label.textContent = deck.title;
+    const grid = document.createElement('div');
+    grid.className = 'cards-deck-grid';
+    grid.appendChild(createDeckTile(deck));
+    wrap.append(label, grid);
+    return wrap;
+  }
+
+  function renderWeekSection(group, weekGroup) {
+    const section = document.createElement('section');
+    section.className = 'cards-week';
+
+    const header = document.createElement('button');
+    header.type = 'button';
+    header.className = 'cards-week-header';
+    header.setAttribute('aria-expanded', 'true');
+
+    const title = document.createElement('span');
+    title.className = 'cards-week-title';
+    title.textContent = `Week ${weekGroup.week}`;
+
+    const deckList = [];
+    if (weekGroup.generalDeck && weekGroup.generalDeck.cards.length) {
+      deckList.push(weekGroup.generalDeck);
+    }
+    deckList.push(...Array.from(weekGroup.lectureDecks.values()).sort((a, b) => a.title.localeCompare(b.title)));
+
+    const meta = document.createElement('span');
+    meta.className = 'cards-week-meta';
+    meta.textContent = `${deckList.length} deck${deckList.length === 1 ? '' : 's'}`;
+
+    const chevron = document.createElement('span');
+    chevron.className = 'cards-chevron';
+
+    header.append(title, meta, chevron);
+    section.appendChild(header);
+
+    const body = document.createElement('div');
+    body.className = 'cards-week-body';
+    section.appendChild(body);
+
+    header.addEventListener('click', () => {
+      const collapsed = section.classList.toggle('collapsed');
+      header.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+    });
+
+    if (!deckList.length) {
+      const empty = document.createElement('div');
+      empty.className = 'cards-empty subtle';
+      empty.textContent = 'No decks for this week yet.';
+      body.appendChild(empty);
+    } else {
+      const grid = document.createElement('div');
+      grid.className = 'cards-deck-grid';
+      deckList.forEach(deck => {
+        grid.appendChild(createDeckTile(deck));
+      });
+      body.appendChild(grid);
+    }
+
+    return section;
+  }
+
+  function createDeckTile(deck) {
+    const tile = document.createElement('button');
+    tile.type = 'button';
+    tile.className = 'cards-deck';
+    tile.dataset.kind = deck.kind;
+
+    const title = document.createElement('span');
+    title.className = 'cards-deck-title';
+    title.textContent = deck.title;
+    tile.appendChild(title);
+
+    if (deck.subtitle) {
+      const subtitle = document.createElement('span');
+      subtitle.className = 'cards-deck-subtitle';
+      subtitle.textContent = deck.subtitle;
+      tile.appendChild(subtitle);
+    }
+
+    const meta = document.createElement('span');
+    meta.className = 'cards-deck-meta';
+    const metaParts = [];
+    if (deck.week != null && deck.kind !== 'block') {
+      metaParts.push(`Week ${deck.week}`);
+    }
+    metaParts.push(`${deck.cards.length} card${deck.cards.length === 1 ? '' : 's'}`);
+    meta.textContent = metaParts.join(' • ');
+    tile.appendChild(meta);
+
+    tile.addEventListener('click', () => openDeck(deck));
+    return tile;
+  }
+
+  function openDeck(deck) {
+    navigation.classList.add('hidden');
     viewer.classList.remove('hidden');
     viewer.innerHTML = '';
 
-    const header = document.createElement('h2');
-    header.textContent = title;
+    const header = document.createElement('div');
+    header.className = 'cards-viewer-header';
+    const heading = document.createElement('h2');
+    heading.textContent = deck.title;
+    header.appendChild(heading);
+
+    const meta = document.createElement('div');
+    meta.className = 'cards-viewer-meta';
+    const metaParts = [];
+    if (deck.blockLabel) metaParts.push(deck.blockLabel);
+    if (deck.week != null) metaParts.push(`Week ${deck.week}`);
+    metaParts.push(`${deck.cards.length} card${deck.cards.length === 1 ? '' : 's'}`);
+    meta.textContent = metaParts.join(' • ');
+    header.appendChild(meta);
+
+    const close = document.createElement('button');
+    close.type = 'button';
+    close.className = 'btn secondary cards-viewer-close';
+    close.textContent = 'Back to decks';
+    header.appendChild(close);
+
     viewer.appendChild(header);
+
+    const body = document.createElement('div');
+    body.className = 'cards-viewer-body';
+    viewer.appendChild(body);
 
     const cardHolder = document.createElement('div');
     cardHolder.className = 'deck-card';
-    viewer.appendChild(cardHolder);
+    body.appendChild(cardHolder);
 
     const prev = document.createElement('button');
     prev.className = 'deck-prev';
@@ -104,38 +361,33 @@ export function renderCards(container, items, onChange){
     const next = document.createElement('button');
     next.className = 'deck-next';
     next.textContent = '▶';
-    viewer.appendChild(prev);
-    viewer.appendChild(next);
+    body.append(prev, next);
 
     const toggle = document.createElement('button');
-    toggle.className = 'deck-related-toggle btn';
-    toggle.textContent = 'Show Related';
+    toggle.type = 'button';
+    toggle.className = 'deck-related-toggle btn secondary';
+    toggle.textContent = 'Show related';
     viewer.appendChild(toggle);
 
     const relatedWrap = document.createElement('div');
     relatedWrap.className = 'deck-related hidden';
     viewer.appendChild(relatedWrap);
 
-    const close = document.createElement('button');
-    close.className = 'deck-close btn';
-    close.textContent = 'Close';
-    viewer.appendChild(close);
-
     let idx = 0;
     let showRelated = false;
 
-    function renderCard(){
+    function renderCard() {
       cardHolder.innerHTML = '';
-      cardHolder.appendChild(createItemCard(cards[idx], onChange));
+      cardHolder.appendChild(createItemCard(deck.cards[idx], onChange));
       renderRelated();
     }
 
-    function renderRelated(){
+    function renderRelated() {
       relatedWrap.innerHTML = '';
       if (!showRelated) return;
-      const current = cards[idx];
-      (current.links || []).forEach(l => {
-        const item = items.find(it => it.id === l.id);
+      const current = deck.cards[idx];
+      (current.links || []).forEach(link => {
+        const item = items.find(candidate => candidate.id === link.id);
         if (item) {
           const el = createItemCard(item, onChange);
           el.classList.add('related-card');
@@ -146,35 +398,47 @@ export function renderCards(container, items, onChange){
     }
 
     prev.addEventListener('click', () => {
-      idx = (idx - 1 + cards.length) % cards.length;
+      idx = (idx - 1 + deck.cards.length) % deck.cards.length;
       renderCard();
     });
     next.addEventListener('click', () => {
-      idx = (idx + 1) % cards.length;
+      idx = (idx + 1) % deck.cards.length;
       renderCard();
     });
 
     toggle.addEventListener('click', () => {
       showRelated = !showRelated;
-      toggle.textContent = showRelated ? 'Hide Related' : 'Show Related';
+      toggle.textContent = showRelated ? 'Hide related' : 'Show related';
       relatedWrap.classList.toggle('hidden', !showRelated);
       renderRelated();
     });
 
-    close.addEventListener('click', () => {
+    function closeViewer() {
       document.removeEventListener('keydown', keyHandler);
       viewer.classList.add('hidden');
       viewer.innerHTML = '';
-      list.classList.remove('hidden');
-    });
-
-    function keyHandler(e){
-      if (e.key === 'ArrowLeft') prev.click();
-      if (e.key === 'ArrowRight') next.click();
-      if (e.key === 'Escape') close.click();
+      navigation.classList.remove('hidden');
     }
-    document.addEventListener('keydown', keyHandler);
 
+    close.addEventListener('click', closeViewer);
+
+    function keyHandler(event) {
+      if (event.key === 'ArrowLeft') prev.click();
+      if (event.key === 'ArrowRight') next.click();
+      if (event.key === 'Escape') closeViewer();
+    }
+
+    document.addEventListener('keydown', keyHandler);
     renderCard();
+  }
+
+  function countDecks(group) {
+    let total = 0;
+    if (group.generalDeck && group.generalDeck.cards.length) total += 1;
+    group.weeks.forEach(weekGroup => {
+      if (weekGroup.generalDeck && weekGroup.generalDeck.cards.length) total += 1;
+      total += weekGroup.lectureDecks.size;
+    });
+    return total;
   }
 }

--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -18,330 +18,545 @@ function toggleLectureListCollapse(blockId) {
 export async function renderSettings(root) {
   root.innerHTML = '';
 
-  const settings = await getSettings();
+  const [settings, blocksRaw] = await Promise.all([getSettings(), listBlocks()]);
+  const blocks = blocksRaw
+    .slice()
+    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0) || a.blockId.localeCompare(b.blockId));
 
-  const settingsCard = document.createElement('section');
-  settingsCard.className = 'card';
-  const heading = document.createElement('h2');
-  heading.textContent = 'Settings';
-  settingsCard.appendChild(heading);
+  const page = document.createElement('div');
+  page.className = 'settings-page';
 
-  const dailyLabel = document.createElement('label');
-  dailyLabel.textContent = 'Daily review target:';
-  const dailyInput = document.createElement('input');
-  dailyInput.type = 'number';
-  dailyInput.className = 'input';
-  dailyInput.min = '1';
-  dailyInput.value = settings.dailyCount;
-  dailyInput.addEventListener('change', () => {
-    saveSettings({ dailyCount: Number(dailyInput.value) });
-  });
-  dailyLabel.appendChild(dailyInput);
-  settingsCard.appendChild(dailyLabel);
+  const hero = document.createElement('section');
+  hero.className = 'settings-hero';
+  const title = document.createElement('h1');
+  title.textContent = 'Workspace settings';
+  const subtitle = document.createElement('p');
+  subtitle.textContent = 'Tune your study cadence and organise the curriculum structure in one place.';
+  hero.append(title, subtitle);
+  page.appendChild(hero);
 
-  root.appendChild(settingsCard);
+  const overview = document.createElement('div');
+  overview.className = 'settings-overview';
+  overview.appendChild(createDailyCard(settings));
+  overview.appendChild(createDataCard());
+  page.appendChild(overview);
 
-  const blocksCard = document.createElement('section');
-  blocksCard.className = 'card';
-  const bHeading = document.createElement('h2');
-  bHeading.textContent = 'Blocks';
-  blocksCard.appendChild(bHeading);
+  const blockSection = document.createElement('section');
+  blockSection.className = 'settings-section';
+  const blockHeader = document.createElement('div');
+  blockHeader.className = 'settings-section-header';
+  const blockTitle = document.createElement('h2');
+  blockTitle.textContent = 'Curriculum blocks';
+  const blockDesc = document.createElement('p');
+  blockDesc.className = 'settings-section-description';
+  blockDesc.textContent = 'Reorder blocks, manage lecture details, and keep tagging effortless.';
+  blockHeader.append(blockTitle, blockDesc);
+  blockSection.appendChild(blockHeader);
 
-  const list = document.createElement('div');
-  list.className = 'block-list';
-  blocksCard.appendChild(list);
+  const blockList = document.createElement('div');
+  blockList.className = 'settings-block-list';
+  if (!blocks.length) {
+    const empty = document.createElement('div');
+    empty.className = 'settings-empty';
+    empty.textContent = 'No blocks yet. Add one below to start mapping your curriculum.';
+    blockList.appendChild(empty);
+  } else {
+    blocks.forEach((block, index) => {
+      blockList.appendChild(createBlockCard(block, index, blocks.length));
+    });
+  }
+  blockSection.appendChild(blockList);
+  blockSection.appendChild(createAddBlockForm());
+  page.appendChild(blockSection);
 
-  const blocks = await listBlocks();
-  blocks.forEach((b,i) => {
-    const wrap = document.createElement('div');
-    wrap.className = 'block';
-    const lectures = (b.lectures || []).slice().sort((a,b)=> b.week - a.week || b.id - a.id);
-    const lecturesCollapsed = isLectureListCollapsed(b.blockId);
-    const title = document.createElement('h3');
-    title.textContent = `${b.blockId} – ${b.title}`;
-    wrap.appendChild(title);
+  root.appendChild(page);
 
-    const wkInfo = document.createElement('div');
-    wkInfo.textContent = `Weeks: ${b.weeks}`;
-    wrap.appendChild(wkInfo);
+  function createDailyCard(currentSettings) {
+    const card = document.createElement('section');
+    card.className = 'settings-card';
 
-    if (lectures.length || lecturesCollapsed) {
-      const toggleLecturesBtn = document.createElement('button');
-      toggleLecturesBtn.type = 'button';
-      toggleLecturesBtn.className = 'btn secondary settings-lecture-toggle';
-      toggleLecturesBtn.textContent = lecturesCollapsed ? 'Show lectures' : 'Hide lectures';
-      toggleLecturesBtn.addEventListener('click', async () => {
-        toggleLectureListCollapse(b.blockId);
-        await renderSettings(root);
-      });
-      wrap.appendChild(toggleLecturesBtn);
+    const header = document.createElement('div');
+    header.className = 'settings-card-header';
+    const heading = document.createElement('h2');
+    heading.className = 'settings-card-title';
+    heading.textContent = 'Daily pacing';
+    const description = document.createElement('p');
+    description.className = 'settings-card-description';
+    description.textContent = 'Set a realistic daily review target to keep your spaced repetition flow on track.';
+    header.append(heading, description);
+    card.appendChild(header);
+
+    const field = document.createElement('label');
+    field.className = 'settings-field';
+    field.textContent = 'Daily review target';
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.className = 'input';
+    input.min = '1';
+    input.value = currentSettings.dailyCount;
+    input.addEventListener('change', () => {
+      const value = Number(input.value) || currentSettings.dailyCount;
+      saveSettings({ dailyCount: Math.max(1, value) });
+    });
+    field.appendChild(input);
+
+    const helper = document.createElement('p');
+    helper.className = 'settings-card-helper';
+    helper.textContent = 'We use this number to pace upcoming reviews across tabs.';
+
+    card.append(field, helper);
+    return card;
+  }
+
+  function createDataCard() {
+    const card = document.createElement('section');
+    card.className = 'settings-card';
+
+    const header = document.createElement('div');
+    header.className = 'settings-card-header';
+    const heading = document.createElement('h2');
+    heading.className = 'settings-card-title';
+    heading.textContent = 'Data management';
+    const description = document.createElement('p');
+    description.className = 'settings-card-description';
+    description.textContent = 'Safely export your workspace or bring in updates from teammates.';
+    header.append(heading, description);
+    card.appendChild(header);
+
+    const actions = document.createElement('div');
+    actions.className = 'settings-card-actions';
+
+    const exportBtn = document.createElement('button');
+    exportBtn.type = 'button';
+    exportBtn.className = 'btn secondary';
+    exportBtn.textContent = 'Export JSON';
+    exportBtn.addEventListener('click', async () => {
+      const dump = await exportJSON();
+      const blob = new Blob([JSON.stringify(dump, null, 2)], { type: 'application/json' });
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(blob);
+      link.download = 'sevenn-export.json';
+      link.click();
+      URL.revokeObjectURL(link.href);
+    });
+    actions.appendChild(exportBtn);
+
+    const importInput = document.createElement('input');
+    importInput.type = 'file';
+    importInput.accept = 'application/json';
+    importInput.className = 'settings-hidden-file';
+    importInput.addEventListener('change', async () => {
+      const file = importInput.files?.[0];
+      if (!file) return;
+      try {
+        const text = await file.text();
+        const json = JSON.parse(text);
+        const res = await importJSON(json);
+        alert(res.message);
+        location.reload();
+      } catch (err) {
+        alert('Import failed');
+      }
+    });
+
+    const importBtn = document.createElement('button');
+    importBtn.type = 'button';
+    importBtn.className = 'btn secondary';
+    importBtn.textContent = 'Import JSON';
+    importBtn.addEventListener('click', () => importInput.click());
+    actions.append(importBtn, importInput);
+
+    const ankiBtn = document.createElement('button');
+    ankiBtn.type = 'button';
+    ankiBtn.className = 'btn secondary';
+    ankiBtn.textContent = 'Export Anki CSV';
+    ankiBtn.addEventListener('click', async () => {
+      const dump = await exportJSON();
+      const blob = await exportAnkiCSV('qa', dump.items || []);
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(blob);
+      link.download = 'sevenn-anki.csv';
+      link.click();
+      URL.revokeObjectURL(link.href);
+    });
+    actions.appendChild(ankiBtn);
+
+    card.appendChild(actions);
+    return card;
+  }
+
+  function createBlockCard(block, index, total) {
+    const card = document.createElement('article');
+    card.className = 'settings-block-card';
+    card.dataset.blockId = block.blockId;
+    if (block.color) {
+      card.style.setProperty('--block-accent', block.color);
     }
 
+    const header = document.createElement('div');
+    header.className = 'settings-block-header';
+
+    const identity = document.createElement('div');
+    identity.className = 'settings-block-identity';
+
+    const colorSwatch = document.createElement('span');
+    colorSwatch.className = 'settings-block-color';
+    colorSwatch.style.background = block.color || 'rgba(148, 163, 184, 0.4)';
+
+    const textWrap = document.createElement('div');
+    textWrap.className = 'settings-block-text';
+
+    const heading = document.createElement('h3');
+    heading.className = 'settings-block-title';
+    heading.textContent = `${block.blockId} — ${block.title}`;
+
+    const meta = document.createElement('span');
+    meta.className = 'settings-block-meta';
+    const lectureCount = block.lectures?.length || 0;
+    const weekCount = block.weeks || 0;
+    meta.textContent = `${weekCount} week${weekCount === 1 ? '' : 's'} • ${lectureCount} lecture${lectureCount === 1 ? '' : 's'}`;
+
+    textWrap.append(heading, meta);
+    identity.append(colorSwatch, textWrap);
+    header.appendChild(identity);
+
     const controls = document.createElement('div');
-    controls.className = 'row';
+    controls.className = 'settings-block-controls';
+
+    const collapsed = isLectureListCollapsed(block.blockId);
+    const collapseBtn = document.createElement('button');
+    collapseBtn.type = 'button';
+    collapseBtn.className = 'settings-collapse-btn';
+    collapseBtn.textContent = collapsed ? 'Show lectures' : 'Hide lectures';
+    collapseBtn.setAttribute('aria-expanded', (!collapsed).toString());
+    controls.appendChild(collapseBtn);
+
+    const iconGroup = document.createElement('div');
+    iconGroup.className = 'settings-icon-group';
 
     const upBtn = document.createElement('button');
-    upBtn.className = 'btn';
+    upBtn.type = 'button';
+    upBtn.className = 'icon-btn ghost';
+    upBtn.title = 'Move block up';
     upBtn.textContent = '↑';
-    upBtn.disabled = i === 0;
+    upBtn.disabled = index === 0;
     upBtn.addEventListener('click', async () => {
-      const other = blocks[i-1];
-      const tmp = b.order; b.order = other.order; other.order = tmp;
-      await upsertBlock(b); await upsertBlock(other);
+      if (index === 0) return;
+      const other = blocks[index - 1];
+      const tmp = block.order;
+      block.order = other.order;
+      other.order = tmp;
+      await upsertBlock(block);
+      await upsertBlock(other);
       await renderSettings(root);
     });
-    controls.appendChild(upBtn);
+    iconGroup.appendChild(upBtn);
 
     const downBtn = document.createElement('button');
-    downBtn.className = 'btn';
+    downBtn.type = 'button';
+    downBtn.className = 'icon-btn ghost';
+    downBtn.title = 'Move block down';
     downBtn.textContent = '↓';
-    downBtn.disabled = i === blocks.length - 1;
+    downBtn.disabled = index === total - 1;
     downBtn.addEventListener('click', async () => {
-      const other = blocks[i+1];
-      const tmp = b.order; b.order = other.order; other.order = tmp;
-      await upsertBlock(b); await upsertBlock(other);
+      if (index === total - 1) return;
+      const other = blocks[index + 1];
+      const tmp = block.order;
+      block.order = other.order;
+      other.order = tmp;
+      await upsertBlock(block);
+      await upsertBlock(other);
       await renderSettings(root);
     });
-    controls.appendChild(downBtn);
+    iconGroup.appendChild(downBtn);
 
-    const edit = document.createElement('button');
-    edit.className = 'btn';
-    edit.textContent = 'Edit';
-    controls.appendChild(edit);
+    const editBtn = document.createElement('button');
+    editBtn.type = 'button';
+    editBtn.className = 'icon-btn ghost';
+    editBtn.title = 'Edit block';
+    editBtn.textContent = '✎';
+    iconGroup.appendChild(editBtn);
 
-    const del = document.createElement('button');
-    del.className = 'btn';
-    del.textContent = 'Delete';
-    del.addEventListener('click', async () => {
+    const deleteBtn = document.createElement('button');
+    deleteBtn.type = 'button';
+    deleteBtn.className = 'icon-btn danger';
+    deleteBtn.title = 'Delete block';
+    deleteBtn.textContent = '✕';
+    deleteBtn.addEventListener('click', async () => {
       if (await confirmModal('Delete block?')) {
-        await deleteBlock(b.blockId);
+        await deleteBlock(block.blockId);
         await renderSettings(root);
       }
     });
-    controls.appendChild(del);
-    wrap.appendChild(controls);
+    iconGroup.appendChild(deleteBtn);
+
+    controls.appendChild(iconGroup);
+    header.appendChild(controls);
+    card.appendChild(header);
 
     const editForm = document.createElement('form');
-    editForm.className = 'row';
-    editForm.style.display = 'none';
+    editForm.className = 'settings-inline-form settings-block-edit';
+    editForm.hidden = true;
+
     const titleInput = document.createElement('input');
     titleInput.className = 'input';
-    titleInput.value = b.title;
+    titleInput.value = block.title;
+    titleInput.placeholder = 'Block title';
+
     const weeksInput = document.createElement('input');
     weeksInput.className = 'input';
     weeksInput.type = 'number';
-    weeksInput.value = b.weeks;
+    weeksInput.min = '1';
+    weeksInput.value = block.weeks ?? '';
+    weeksInput.placeholder = 'Weeks';
+
     const colorInput = document.createElement('input');
     colorInput.className = 'input';
     colorInput.type = 'color';
-    colorInput.value = b.color || '#ffffff';
+    colorInput.value = block.color || '#ffffff';
+
     const saveBtn = document.createElement('button');
-    saveBtn.className = 'btn';
     saveBtn.type = 'submit';
-    saveBtn.textContent = 'Save';
-    editForm.append(titleInput, weeksInput, colorInput, saveBtn);
-    editForm.addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const updated = { ...b, title: titleInput.value.trim(), weeks: Number(weeksInput.value), color: colorInput.value };
+    saveBtn.className = 'btn';
+    saveBtn.textContent = 'Save changes';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.className = 'settings-link-btn';
+    cancelBtn.textContent = 'Cancel';
+    cancelBtn.addEventListener('click', () => {
+      editForm.hidden = true;
+      editBtn.setAttribute('aria-expanded', 'false');
+    });
+
+    editForm.append(titleInput, weeksInput, colorInput, saveBtn, cancelBtn);
+    editForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const updated = {
+        ...block,
+        title: titleInput.value.trim() || block.title,
+        weeks: Number(weeksInput.value) || 0,
+        color: colorInput.value || block.color,
+      };
       await upsertBlock(updated);
       await renderSettings(root);
     });
-    wrap.appendChild(editForm);
+    card.appendChild(editForm);
 
-    edit.addEventListener('click', () => {
-      editForm.style.display = editForm.style.display === 'none' ? 'flex' : 'none';
+    editBtn.addEventListener('click', () => {
+      const expanded = editForm.hidden;
+      editForm.hidden = !expanded;
+      editBtn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
     });
 
-    const lectureSection = document.createElement('div');
+    const lectureSection = document.createElement('section');
     lectureSection.className = 'settings-lecture-section';
-    lectureSection.hidden = lecturesCollapsed;
+    lectureSection.classList.toggle('collapsed', collapsed);
 
-    const lecList = document.createElement('ul');
-    lectures.forEach(l => {
-      const li = document.createElement('li');
-      li.className = 'row';
-      const span = document.createElement('span');
-      span.textContent = `${l.id}: ${l.name} (W${l.week})`;
-      li.appendChild(span);
+    const lectureList = document.createElement('div');
+    lectureList.className = 'settings-lecture-list';
 
-      const editLec = document.createElement('button');
-      editLec.className = 'btn';
-      editLec.textContent = 'Edit';
-      const delLec = document.createElement('button');
-      delLec.className = 'btn';
-      delLec.textContent = 'Delete';
+    const sortedLectures = (block.lectures || [])
+      .slice()
+      .sort((a, b) => (a.week ?? 0) - (b.week ?? 0) || a.id - b.id);
 
-      editLec.addEventListener('click', () => {
-        li.innerHTML = '';
-        li.className = 'row';
-        const nameInput = document.createElement('input');
-        nameInput.className = 'input';
-        nameInput.value = l.name;
-        const weekInput = document.createElement('input');
-        weekInput.className = 'input';
-        weekInput.type = 'number';
-        weekInput.value = l.week;
-        const saveBtn = document.createElement('button');
-        saveBtn.className = 'btn';
-        saveBtn.textContent = 'Save';
-        const cancelBtn = document.createElement('button');
-        cancelBtn.className = 'btn';
-        cancelBtn.textContent = 'Cancel';
-        li.append(nameInput, weekInput, saveBtn, cancelBtn);
-        saveBtn.addEventListener('click', async () => {
-          const name = nameInput.value.trim();
-          const week = Number(weekInput.value);
-          if (!name || !week || week < 1 || week > b.weeks) return;
-          await updateLecture(b.blockId, { id: l.id, name, week });
-          await renderSettings(root);
-        });
-        cancelBtn.addEventListener('click', async () => {
-          await renderSettings(root);
-        });
+    if (!sortedLectures.length) {
+      const empty = document.createElement('div');
+      empty.className = 'settings-empty subtle';
+      empty.textContent = 'No lectures defined for this block yet.';
+      lectureList.appendChild(empty);
+    } else {
+      sortedLectures.forEach((lecture) => {
+        lectureList.appendChild(createLectureRow(lecture));
       });
+    }
 
-      delLec.addEventListener('click', async () => {
+    lectureSection.appendChild(lectureList);
+
+    const lectureForm = document.createElement('form');
+    lectureForm.className = 'settings-inline-form settings-lecture-form';
+
+    const idInput = document.createElement('input');
+    idInput.className = 'input';
+    idInput.type = 'number';
+    idInput.placeholder = 'ID';
+
+    const nameInput = document.createElement('input');
+    nameInput.className = 'input';
+    nameInput.placeholder = 'Lecture name';
+
+    const weekInput = document.createElement('input');
+    weekInput.className = 'input';
+    weekInput.type = 'number';
+    weekInput.placeholder = 'Week';
+
+    const addBtn = document.createElement('button');
+    addBtn.type = 'submit';
+    addBtn.className = 'btn subtle';
+    addBtn.textContent = 'Add lecture';
+
+    lectureForm.append(idInput, nameInput, weekInput, addBtn);
+    lectureForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const lecture = {
+        id: Number(idInput.value),
+        name: nameInput.value.trim(),
+        week: Number(weekInput.value),
+      };
+      if (!lecture.id || !lecture.name || !lecture.week) return;
+      if (block.weeks && (lecture.week < 1 || lecture.week > block.weeks)) return;
+      const nextLectures = Array.isArray(block.lectures) ? block.lectures.slice() : [];
+      nextLectures.push(lecture);
+      const updated = { ...block, lectures: nextLectures };
+      await upsertBlock(updated);
+      await renderSettings(root);
+    });
+    lectureSection.appendChild(lectureForm);
+
+    collapseBtn.addEventListener('click', () => {
+      toggleLectureListCollapse(block.blockId);
+      const nowCollapsed = isLectureListCollapsed(block.blockId);
+      lectureSection.classList.toggle('collapsed', nowCollapsed);
+      collapseBtn.textContent = nowCollapsed ? 'Show lectures' : 'Hide lectures';
+      collapseBtn.setAttribute('aria-expanded', (!nowCollapsed).toString());
+    });
+
+    card.appendChild(lectureSection);
+    return card;
+
+    function createLectureRow(lecture) {
+      const row = document.createElement('div');
+      row.className = 'settings-lecture-row';
+
+      const info = document.createElement('div');
+      info.className = 'settings-lecture-info';
+      const name = document.createElement('div');
+      name.className = 'settings-lecture-name';
+      name.textContent = lecture.name || `Lecture ${lecture.id}`;
+      const details = document.createElement('div');
+      details.className = 'settings-lecture-meta';
+      details.textContent = `ID ${lecture.id} • Week ${lecture.week}`;
+      info.append(name, details);
+      row.appendChild(info);
+
+      const actions = document.createElement('div');
+      actions.className = 'settings-lecture-actions';
+
+      const editLecture = document.createElement('button');
+      editLecture.type = 'button';
+      editLecture.className = 'settings-pill-btn';
+      editLecture.textContent = 'Edit';
+
+      const deleteLectureBtn = document.createElement('button');
+      deleteLectureBtn.type = 'button';
+      deleteLectureBtn.className = 'settings-pill-btn danger';
+      deleteLectureBtn.textContent = 'Delete';
+
+      deleteLectureBtn.addEventListener('click', async () => {
         if (await confirmModal('Delete lecture?')) {
-          await deleteLecture(b.blockId, l.id);
+          await deleteLecture(block.blockId, lecture.id);
           await renderSettings(root);
         }
       });
 
-      li.append(editLec, delLec);
-      lecList.appendChild(li);
-    });
-    lectureSection.appendChild(lecList);
+      editLecture.addEventListener('click', () => {
+        const editor = document.createElement('form');
+        editor.className = 'settings-inline-form settings-lecture-edit';
 
-    const lecForm = document.createElement('form');
-    lecForm.className = 'row';
-    const idInput = document.createElement('input');
-    idInput.className = 'input';
-    idInput.placeholder = 'id';
-    idInput.type = 'number';
-    const nameInput = document.createElement('input');
-    nameInput.className = 'input';
-    nameInput.placeholder = 'name';
-    const weekInput = document.createElement('input');
-    weekInput.className = 'input';
-    weekInput.placeholder = 'week';
-    weekInput.type = 'number';
-    const addBtn = document.createElement('button');
-    addBtn.className = 'btn';
-    addBtn.type = 'submit';
-    addBtn.textContent = 'Add lecture';
-    lecForm.append(idInput, nameInput, weekInput, addBtn);
-    lecForm.addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const lecture = { id: Number(idInput.value), name: nameInput.value.trim(), week: Number(weekInput.value) };
-      if (!lecture.id || !lecture.name || !lecture.week) return;
-      if (lecture.week < 1 || lecture.week > b.weeks) return;
-      const updated = { ...b, lectures: [...b.lectures, lecture] };
-      await upsertBlock(updated);
+        const editName = document.createElement('input');
+        editName.className = 'input';
+        editName.value = lecture.name || '';
+        editName.placeholder = 'Lecture name';
+
+        const editWeek = document.createElement('input');
+        editWeek.className = 'input';
+        editWeek.type = 'number';
+        editWeek.value = lecture.week ?? '';
+        editWeek.placeholder = 'Week';
+
+        const save = document.createElement('button');
+        save.type = 'submit';
+        save.className = 'btn subtle';
+        save.textContent = 'Save';
+
+        const cancel = document.createElement('button');
+        cancel.type = 'button';
+        cancel.className = 'settings-link-btn';
+        cancel.textContent = 'Cancel';
+        cancel.addEventListener('click', () => {
+          renderSettings(root);
+        });
+
+        editor.append(editName, editWeek, save, cancel);
+        editor.addEventListener('submit', async (event) => {
+          event.preventDefault();
+          const nameValue = editName.value.trim();
+          const weekValue = Number(editWeek.value);
+          if (!nameValue || !weekValue) return;
+          if (block.weeks && (weekValue < 1 || weekValue > block.weeks)) return;
+          await updateLecture(block.blockId, { id: lecture.id, name: nameValue, week: weekValue });
+          await renderSettings(root);
+        });
+
+        row.replaceChildren(editor);
+      });
+
+      actions.append(editLecture, deleteLectureBtn);
+      row.appendChild(actions);
+      return row;
+    }
+  }
+
+  function createAddBlockForm() {
+    const wrap = document.createElement('div');
+    wrap.className = 'settings-add-block-card';
+
+    const heading = document.createElement('h3');
+    heading.textContent = 'Add new block';
+    wrap.appendChild(heading);
+
+    const form = document.createElement('form');
+    form.className = 'settings-inline-form settings-add-block';
+
+    const id = document.createElement('input');
+    id.className = 'input';
+    id.placeholder = 'Block ID';
+
+    const title = document.createElement('input');
+    title.className = 'input';
+    title.placeholder = 'Title';
+
+    const weeks = document.createElement('input');
+    weeks.className = 'input';
+    weeks.type = 'number';
+    weeks.placeholder = 'Weeks';
+
+    const color = document.createElement('input');
+    color.className = 'input';
+    color.type = 'color';
+    color.value = '#ffffff';
+
+    const submit = document.createElement('button');
+    submit.type = 'submit';
+    submit.className = 'btn';
+    submit.textContent = 'Create block';
+
+    form.append(id, title, weeks, color, submit);
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const def = {
+        blockId: id.value.trim(),
+        title: title.value.trim(),
+        weeks: Number(weeks.value),
+        color: color.value,
+        lectures: [],
+      };
+      if (!def.blockId || !def.title || !def.weeks) return;
+      await upsertBlock(def);
       await renderSettings(root);
     });
-    lectureSection.appendChild(lecForm);
 
-    wrap.appendChild(lectureSection);
-
-    list.appendChild(wrap);
-  });
-
-  const form = document.createElement('form');
-  form.className = 'row';
-  const id = document.createElement('input');
-  id.className = 'input';
-  id.placeholder = 'ID';
-  const titleInput = document.createElement('input');
-  titleInput.className = 'input';
-  titleInput.placeholder = 'Title';
-  const weeks = document.createElement('input');
-  weeks.className = 'input';
-  weeks.type = 'number';
-  weeks.placeholder = 'Weeks';
-  const color = document.createElement('input');
-  color.className = 'input';
-  color.type = 'color';
-  color.value = '#ffffff';
-  const add = document.createElement('button');
-  add.className = 'btn';
-  add.type = 'submit';
-  add.textContent = 'Add block';
-  form.append(id, titleInput, weeks, color, add);
-  form.addEventListener('submit', async (e) => {
-    e.preventDefault();
-    const def = {
-      blockId: id.value.trim(),
-      title: titleInput.value.trim(),
-      weeks: Number(weeks.value),
-      color: color.value,
-      lectures: [],
-    };
-    if (!def.blockId || !def.title || !def.weeks) return;
-    await upsertBlock(def);
-    await renderSettings(root);
-  });
-  blocksCard.appendChild(form);
-
-  root.appendChild(blocksCard);
-
-  const dataCard = document.createElement('section');
-  dataCard.className = 'card';
-  const dHeading = document.createElement('h2');
-  dHeading.textContent = 'Data';
-  dataCard.appendChild(dHeading);
-
-  const exportBtn = document.createElement('button');
-  exportBtn.className = 'btn';
-  exportBtn.textContent = 'Export DB';
-  exportBtn.addEventListener('click', async () => {
-    const dump = await exportJSON();
-    const blob = new Blob([JSON.stringify(dump, null, 2)], { type: 'application/json' });
-    const a = document.createElement('a');
-    a.href = URL.createObjectURL(blob);
-    a.download = 'sevenn-export.json';
-    a.click();
-    URL.revokeObjectURL(a.href);
-  });
-  dataCard.appendChild(exportBtn);
-
-  const importInput = document.createElement('input');
-  importInput.type = 'file';
-  importInput.accept = 'application/json';
-  importInput.style.display = 'none';
-  importInput.addEventListener('change', async () => {
-    const file = importInput.files[0];
-    if (!file) return;
-    try {
-      const text = await file.text();
-      const json = JSON.parse(text);
-      const res = await importJSON(json);
-      alert(res.message);
-      location.reload();
-    } catch (e) {
-      alert('Import failed');
-    }
-  });
-
-  const importBtn = document.createElement('button');
-  importBtn.className = 'btn';
-  importBtn.textContent = 'Import DB';
-  importBtn.addEventListener('click', () => importInput.click());
-  dataCard.appendChild(importBtn);
-  dataCard.appendChild(importInput);
-
-  const ankiBtn = document.createElement('button');
-  ankiBtn.className = 'btn';
-  ankiBtn.textContent = 'Export Anki CSV';
-  ankiBtn.addEventListener('click', async () => {
-    const dump = await exportJSON();
-    const blob = await exportAnkiCSV('qa', dump.items || []);
-    const a = document.createElement('a');
-    a.href = URL.createObjectURL(blob);
-    a.download = 'sevenn-anki.csv';
-    a.click();
-    URL.revokeObjectURL(a.href);
-  });
-  dataCard.appendChild(ankiBtn);
-
-  root.appendChild(dataCard);
+    wrap.appendChild(form);
+    return wrap;
+  }
 }

--- a/style.css
+++ b/style.css
@@ -741,11 +741,11 @@ input[type="checkbox"]:checked::after {
   border-radius: var(--radius-lg);
   border: 1px solid rgba(148, 163, 184, 0.32);
   background: linear-gradient(155deg, rgba(15, 23, 42, 0.85), rgba(8, 13, 23, 0.92));
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr);
   gap: var(--pad);
-  min-height: 220px;
-  max-height: clamp(280px, 46vh, 420px);
+  min-height: clamp(320px, 48vh, 420px);
+  max-height: clamp(420px, 64vh, 560px);
   overflow: hidden;
 }
 
@@ -758,7 +758,8 @@ input[type="checkbox"]:checked::after {
 .editor-chip-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  align-items: center;
+  gap: 10px;
 }
 
 .editor-block-panels {
@@ -766,8 +767,29 @@ input[type="checkbox"]:checked::after {
   flex-direction: column;
   gap: var(--pad-sm);
   overflow-y: auto;
-  padding-right: 6px;
+  padding-right: 10px;
+  margin-right: -6px;
   flex: 1;
+  min-height: 0;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(148, 163, 184, 0.4) transparent;
+}
+
+.editor-block-panels::-webkit-scrollbar,
+.editor-lecture-list::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+.editor-block-panels::-webkit-scrollbar-track,
+.editor-lecture-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.editor-block-panels::-webkit-scrollbar-thumb,
+.editor-lecture-list::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.35);
+  border-radius: 999px;
 }
 
 .editor-block-panel {
@@ -803,30 +825,39 @@ input[type="checkbox"]:checked::after {
 .editor-week-list {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
 }
 
 .editor-week-section {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 10px 12px;
+  gap: 10px;
+  padding: 12px 14px;
   border-radius: var(--radius);
-  border: 1px solid rgba(148, 163, 184, 0.22);
-  background: rgba(15, 23, 42, 0.45);
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  background: rgba(15, 23, 42, 0.55);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
 .editor-week-section.active {
   border-color: rgba(56, 189, 248, 0.45);
-  box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.2);
+  background: rgba(15, 23, 42, 0.68);
+  box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.25);
 }
 
 .editor-lecture-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  padding-left: 4px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 8px;
+  padding: 6px;
+  background: rgba(4, 10, 22, 0.6);
+  border-radius: var(--radius);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  max-height: clamp(160px, 32vh, 240px);
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(148, 163, 184, 0.4) transparent;
 }
 
 .editor-lecture-list.collapsed {
@@ -947,33 +978,38 @@ input[type="checkbox"]:checked::after {
 .rich-editor {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  background: rgba(15, 23, 42, 0.4);
-  border: 1px solid var(--border);
+  gap: calc(var(--pad-sm) * 0.75);
+  padding: calc(var(--pad-sm) * 0.9);
   border-radius: var(--radius);
-  padding: var(--pad-sm);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: rgba(8, 13, 23, 0.5);
 }
 
 .rich-editor-toolbar {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
-  align-items: center;
+  gap: 6px;
+  padding: 4px 6px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(2, 6, 23, 0.65);
+  position: sticky;
+  top: -6px;
+  z-index: 5;
 }
 
 .rich-editor-group {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 4px 6px;
-  border-radius: var(--radius-sm);
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  background: rgba(8, 13, 23, 0.6);
-  backdrop-filter: blur(6px);
+  gap: 3px;
+  padding: 3px 5px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(15, 23, 42, 0.7);
 }
 
 .rich-editor-label {
-  font-size: 0.75rem;
+  font-size: 0.68rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--text-muted);
@@ -983,15 +1019,16 @@ input[type="checkbox"]:checked::after {
   background: transparent;
   border: none;
   color: var(--text-muted);
-  padding: 6px 8px;
-  font-size: 0.9rem;
+  padding: 4px 6px;
+  font-size: 0.72rem;
   cursor: pointer;
-  border-radius: var(--radius-sm);
+  border-radius: 999px;
+  transition: background 0.2s ease, color 0.2s ease;
 }
 
 .rich-editor-btn:hover,
 .rich-editor-btn:focus {
-  background: var(--muted);
+  background: rgba(56, 189, 248, 0.18);
   color: var(--text);
   outline: none;
 }
@@ -1002,39 +1039,40 @@ input[type="checkbox"]:checked::after {
 }
 
 .rich-editor-color input {
-  width: 34px;
-  height: 30px;
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  border-radius: var(--radius-sm);
-  background: rgba(15, 23, 42, 0.4);
+  width: 26px;
+  height: 22px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(8, 13, 23, 0.6);
   padding: 0;
   cursor: pointer;
 }
 
 .rich-editor-highlight-group {
-  gap: 8px;
+  gap: 6px;
 }
 
 .rich-editor-swatch {
-  width: 26px;
-  height: 26px;
+  width: 22px;
+  height: 22px;
   border-radius: 50%;
-  border: 2px solid rgba(8, 13, 23, 0.7);
+  border: 2px solid rgba(8, 13, 23, 0.75);
   background: var(--swatch-color, transparent);
-  box-shadow: 0 0 0 2px rgba(148, 163, 184, 0.25);
+  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.3);
   cursor: pointer;
+  transition: box-shadow 0.2s ease;
 }
 
 .rich-editor-swatch:hover,
 .rich-editor-swatch:focus {
-  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.45);
+  box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.45);
   outline: none;
 }
 
 .rich-editor-swatch--clear {
-  background: rgba(15, 23, 42, 0.6);
+  background: rgba(15, 23, 42, 0.75);
   color: var(--text-muted);
-  font-size: 0.85rem;
+  font-size: 0.75rem;
   line-height: 1;
 }
 
@@ -1045,29 +1083,28 @@ input[type="checkbox"]:checked::after {
 
 .rich-editor-select,
 .rich-editor-size {
-  background: rgba(15, 23, 42, 0.6);
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  border-radius: var(--radius-sm);
+  background: rgba(8, 13, 23, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 999px;
   color: var(--text);
-  padding: 6px 10px;
+  padding: 4px 28px 4px 12px;
   cursor: pointer;
-  font-size: 0.9rem;
-  min-width: 120px;
+  font-size: 0.8rem;
+  min-width: 110px;
 }
 
 .rich-editor-area {
-  min-height: 150px;
-  padding: 12px;
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  min-height: 160px;
+  padding: var(--pad);
+  border: 1px solid rgba(148, 163, 184, 0.24);
   border-radius: var(--radius);
-  background: rgba(2, 6, 23, 0.55);
+  background: rgba(2, 6, 23, 0.6);
   overflow: auto;
   word-break: break-word;
-  backdrop-filter: blur(4px);
 }
 
 .rich-editor-area:focus {
-  outline: 2px solid var(--blue);
+  outline: 2px solid rgba(56, 189, 248, 0.6);
   outline-offset: 2px;
 }
 
@@ -1092,35 +1129,6 @@ input[type="checkbox"]:checked::after {
   margin-left: auto;
   font-size: 0.85rem;
   opacity: 0.8;
-}
-
-.editor-tags {
-  margin-top: var(--pad);
-  padding: var(--pad);
-  background: rgba(15, 23, 42, 0.45);
-  border-radius: var(--radius);
-  border: 1px solid var(--border);
-  max-height: min(420px, 50vh);
-  overflow: auto;
-  display: flex;
-  flex-direction: column;
-  gap: var(--pad-sm);
-}
-
-.editor-tags-title {
-  font-weight: 600;
-  margin: 0;
-  font-size: 1rem;
-}
-
-.editor-tag-block {
-  padding: 8px;
-  border-radius: var(--radius-sm);
-  background: rgba(8, 13, 23, 0.45);
-}
-
-.editor-tag-block:last-child {
-  margin-bottom: 0;
 }
 
 .window-dock {
@@ -1443,16 +1451,355 @@ input[type="checkbox"]:checked::after {
   gap: var(--pad-sm);
 }
 
-.settings-lecture-toggle {
-  margin-top: var(--pad-sm);
-  align-self: flex-start;
+.settings-page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-lg);
+  padding: var(--pad-lg);
+}
+
+.settings-hero {
+  border-radius: var(--radius-lg);
+  padding: calc(var(--pad-lg) * 1.2);
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.18), rgba(192, 132, 252, 0.14));
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  box-shadow: 0 24px 48px rgba(2, 6, 23, 0.5);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.settings-hero h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 3vw, 2.2rem);
+}
+
+.settings-hero p {
+  margin: 0;
+  max-width: 520px;
+  color: var(--text-muted);
+  font-size: 1rem;
+}
+
+.settings-overview {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: var(--pad-lg);
+}
+
+.settings-card {
+  background: rgba(15, 23, 42, 0.68);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: var(--radius-lg);
+  padding: var(--pad-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.settings-card-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.settings-card-title {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.settings-card-description {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.settings-card-helper {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.settings-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.95rem;
+}
+
+.settings-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad-sm);
+}
+
+.settings-hidden-file {
+  display: none;
+}
+
+.settings-section {
+  background: rgba(8, 13, 23, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: var(--radius-lg);
+  padding: var(--pad-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-lg);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.settings-section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.settings-section-header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.settings-section-description {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.settings-block-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+}
+
+.settings-block-card {
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: linear-gradient(155deg, rgba(15, 23, 42, 0.82), rgba(8, 13, 23, 0.9));
+  padding: var(--pad-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  position: relative;
+  overflow: hidden;
+}
+
+.settings-block-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  opacity: 0.25;
+  background: radial-gradient(circle at top right, var(--block-color, rgba(56, 189, 248, 0.35)), transparent 60%);
+  pointer-events: none;
+}
+
+.settings-block-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--pad);
+  position: relative;
+  z-index: 1;
+}
+
+.settings-block-identity {
+  display: flex;
+  align-items: center;
+  gap: var(--pad);
+  min-width: 0;
+}
+
+.settings-block-color {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.2);
+  flex-shrink: 0;
+}
+
+.settings-block-text {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.settings-block-title {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.settings-block-meta {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.settings-block-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--pad-sm);
+}
+
+.settings-collapse-btn {
+  background: rgba(148, 163, 184, 0.16);
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  border-radius: 999px;
+  padding: 6px 14px;
+  color: var(--text);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.settings-collapse-btn:hover {
+  background: rgba(56, 189, 248, 0.18);
+  border-color: rgba(56, 189, 248, 0.4);
+}
+
+.settings-icon-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.settings-inline-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad-sm);
+  align-items: center;
+  position: relative;
+  z-index: 1;
+}
+
+.settings-block-edit {
+  padding: var(--pad);
+  border-radius: var(--radius);
+  background: rgba(8, 13, 23, 0.7);
+  border: 1px dashed rgba(148, 163, 184, 0.35);
 }
 
 .settings-lecture-section {
   display: flex;
   flex-direction: column;
-  gap: var(--pad-sm);
+  gap: var(--pad);
   margin-top: var(--pad-sm);
+  position: relative;
+  z-index: 1;
+}
+
+.settings-lecture-section.collapsed {
+  display: none;
+}
+
+.settings-lecture-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+}
+
+.settings-empty {
+  padding: var(--pad);
+  border-radius: var(--radius);
+  background: rgba(15, 23, 42, 0.5);
+  border: 1px dashed rgba(148, 163, 184, 0.3);
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.settings-empty.subtle {
+  font-style: italic;
+  opacity: 0.8;
+}
+
+.settings-lecture-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--pad);
+  padding: var(--pad);
+  border-radius: var(--radius);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: rgba(8, 13, 23, 0.6);
+}
+
+.settings-lecture-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.settings-lecture-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.settings-lecture-meta {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.settings-lecture-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.settings-pill-btn {
+  background: rgba(56, 189, 248, 0.15);
+  border: 1px solid rgba(56, 189, 248, 0.32);
+  border-radius: 999px;
+  color: var(--text);
+  padding: 4px 12px;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.settings-pill-btn:hover {
+  background: rgba(56, 189, 248, 0.25);
+  border-color: rgba(56, 189, 248, 0.45);
+}
+
+.settings-pill-btn.danger {
+  background: rgba(248, 113, 113, 0.15);
+  border-color: rgba(248, 113, 113, 0.35);
+  color: #fca5a5;
+}
+
+.settings-pill-btn.danger:hover {
+  background: rgba(248, 113, 113, 0.3);
+  color: #fff;
+}
+
+.settings-link-btn {
+  background: none;
+  border: none;
+  color: var(--accent);
+  padding: 4px 8px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.settings-link-btn:hover {
+  background: rgba(56, 189, 248, 0.18);
+  color: var(--text);
+}
+
+.settings-add-block-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  padding: var(--pad);
+  border-radius: var(--radius);
+  border: 1px dashed rgba(148, 163, 184, 0.32);
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.settings-add-block-card h3 {
+  margin: 0;
 }
 
 .builder-controls {
@@ -2106,137 +2453,409 @@ input[type="checkbox"]:checked::after {
 }
 
 /* Decks */
-.deck-list {
-  display:flex;
-  flex-wrap:wrap;
-  gap:var(--pad);
-  padding:var(--pad);
-}
-.deck {
-  background:var(--panel);
-  border:1px solid var(--border);
-  border-radius:var(--radius);
-  padding:var(--pad-lg);
-  cursor:pointer;
-  box-shadow:0 2px 4px rgba(0,0,0,0.2);
-  position:relative;
-  width:200px;
-  display:flex;
-  flex-direction:column;
-  align-items:center;
-  text-align:center;
-  transition:transform 0.3s ease;
-}
-.deck-title { font-weight:600; margin-bottom:4px; }
-.deck-meta { font-size:0.85rem; color:var(--gray); }
-.deck.pop { transform:scale(1.05); z-index:2; }
-.deck-fan {
-  position:absolute;
-  top:50%;
-  left:50%;
-  transform:translate(-50%,-50%);
-  pointer-events:none;
-}
-.deck-fan .fan-card {
-  position:absolute;
-  width:70px;
-  height:90px;
-  background:var(--panel);
-  border:1px solid var(--border);
-  border-radius:var(--radius);
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  font-size:0.65rem;
-  color:var(--text);
-  opacity:0;
-  transform-origin:bottom center;
-  transition:opacity 0.3s ease, transform 0.3s ease;
-  white-space:nowrap;
-  overflow:hidden;
-  text-overflow:ellipsis;
-}
-.deck-viewer {
-  position: relative;
-  text-align: center;
-  padding: var(--pad);
+.cards-navigation {
   display: flex;
   flex-direction: column;
+  gap: var(--pad-lg);
+  padding: var(--pad-lg);
+  max-width: min(1100px, 100%);
+  margin: 0 auto;
+}
+
+.cards-block {
+  --block-accent: var(--block-color, rgba(56, 189, 248, 0.45));
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-left: 4px solid var(--block-accent);
+  background: rgba(11, 18, 32, 0.78);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  overflow: hidden;
+}
+
+.cards-block-header {
+  display: flex;
+  align-items: center;
+  gap: var(--pad);
+  width: 100%;
+  padding: var(--pad);
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.72), rgba(5, 10, 22, 0.82));
+  color: var(--text);
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  flex-wrap: wrap;
+}
+
+.cards-block.collapsed .cards-block-body {
+  display: none;
+}
+
+.cards-block-title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  flex: 1 1 auto;
+}
+
+.cards-block-meta {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  margin-left: auto;
+}
+
+.cards-chevron {
+  margin-left: auto;
+  width: 24px;
+  height: 24px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: rgba(15, 23, 42, 0.65);
+  display: grid;
+  place-items: center;
+  transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+}
+
+.cards-chevron::before {
+  content: '▾';
+  font-size: 0.85rem;
+  line-height: 1;
+}
+
+.cards-block.collapsed .cards-chevron {
+  transform: rotate(-90deg);
+  background: rgba(15, 23, 42, 0.5);
+}
+
+.cards-block-header:hover .cards-chevron {
+  border-color: rgba(56, 189, 248, 0.45);
+  background: rgba(12, 20, 34, 0.85);
+}
+
+.cards-block-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  padding: 0 var(--pad) var(--pad);
+  border-top: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.cards-overview {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+}
+
+.cards-overview-title {
+  font-size: 0.88rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.cards-week {
+  border-radius: var(--radius);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(6, 12, 22, 0.6);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.cards-week-header {
+  display: flex;
+  align-items: center;
+  gap: var(--pad-sm);
+  width: 100%;
+  padding: 12px var(--pad);
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  flex-wrap: wrap;
+}
+
+.cards-week.collapsed .cards-week-body {
+  display: none;
+}
+
+.cards-week-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  flex: 1 1 auto;
+}
+
+.cards-week-meta {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  margin-left: auto;
+}
+
+.cards-week-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  padding: 0 var(--pad) var(--pad);
+  border-top: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.cards-deck-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--pad);
+}
+
+.cards-deck {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: var(--pad);
+  border-radius: var(--radius);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(10, 16, 28, 0.78);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.cards-deck:hover {
+  transform: translateY(-4px);
+  border-color: rgba(56, 189, 248, 0.45);
+  background: rgba(12, 20, 34, 0.9);
+  box-shadow: 0 16px 36px rgba(2, 6, 23, 0.38);
+}
+
+.cards-deck[data-kind='block'] {
+  background: rgba(56, 189, 248, 0.1);
+  border-color: rgba(56, 189, 248, 0.25);
+}
+
+.cards-deck[data-kind='week-general'] {
+  background: rgba(192, 132, 252, 0.12);
+  border-color: rgba(192, 132, 252, 0.28);
+}
+
+.cards-deck-title {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.cards-deck-subtitle {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.cards-deck-meta {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+.cards-empty {
+  padding: var(--pad);
+  border-radius: var(--radius);
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.cards-empty.subtle {
+  background: none;
+  color: rgba(248, 250, 252, 0.6);
+  font-style: italic;
+}
+
+.cards-viewer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-lg);
+  padding: var(--pad-lg);
+  background: rgba(8, 13, 23, 0.86);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 32px 60px rgba(2, 6, 23, 0.55);
+  max-width: min(1100px, 100%);
+  margin: 0 auto;
+}
+
+.cards-viewer-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--pad-sm);
+  align-items: start;
+}
+
+.cards-viewer-header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.cards-viewer-meta {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  grid-column: 1 / -1;
+}
+
+.cards-viewer-close {
+  justify-self: end;
+}
+
+.cards-viewer-body {
+  position: relative;
+  display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 70vh;
+  gap: var(--pad);
+  padding: var(--pad-lg);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(4, 10, 22, 0.6);
+  min-height: clamp(320px, 52vh, 540px);
+  overflow: hidden;
 }
+
 .deck-card {
-  margin:0 auto;
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  min-width: 0;
 }
 
 .deck-card .item-card {
-  width:40vw;
-  height:20vh;
-  overflow:hidden;
-  display:flex;
-  flex-direction:column;
+  width: min(720px, 80vw);
+  max-height: clamp(320px, 60vh, 620px);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 .deck-card .item-card.expanded {
-  height:70vh;
+  max-height: none;
 }
 
 .deck-card .item-card .card-body {
-  display:none;
-  flex:1;
-  overflow:auto;
+  flex: 1;
+  overflow: auto;
 }
 
-.deck-card .item-card.expanded .card-body {
-  display:block;
+.deck-prev,
+.deck-next {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(8, 13, 23, 0.8);
+  color: var(--text);
+  display: grid;
+  place-items: center;
+  font-size: 1.1rem;
+  line-height: 1;
+  box-shadow: 0 16px 30px rgba(2, 6, 23, 0.4);
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
 }
 
-.deck-card .item-card.expanded .section-content {
-  overflow-y:auto;
+.deck-prev {
+  left: 18px;
 }
-.deck-prev, .deck-next {
-  position:absolute;
-  top:50%;
-  transform:translateY(-50%);
-  background:var(--muted);
-  color:var(--text);
-  padding:8px;
-  border-radius:var(--radius);
-  cursor:pointer;
-  border:1px solid var(--border);
+
+.deck-next {
+  right: 18px;
 }
-.deck-prev { left:var(--pad); }
-.deck-next { right:var(--pad); }
-.deck-prev:hover, .deck-next:hover {
-  transform:translateY(calc(-50% - 2px));
+
+.deck-prev:hover,
+.deck-next:hover {
+  transform: translateY(-50%) scale(1.05);
+  border-color: rgba(56, 189, 248, 0.45);
+  background: rgba(12, 20, 34, 0.92);
+  box-shadow: 0 20px 40px rgba(2, 6, 23, 0.45);
 }
+
+.deck-related-toggle {
+  align-self: flex-start;
+}
+
 .deck-related {
-  display:flex;
-  flex-wrap:wrap;
-  gap:var(--pad);
-  justify-content:center;
-  margin-top:var(--pad);
-  opacity:0;
-  transform:translateY(-10px);
-  transition:opacity 0.3s ease, transform 0.3s ease;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--pad);
+  padding: var(--pad);
+  border-radius: var(--radius);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(5, 12, 24, 0.72);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  animation: cards-related-in 0.25s ease forwards;
 }
-.deck-related:not(.hidden) {
-  opacity:1;
-  transform:translateY(0);
+
+.deck-related.hidden {
+  display: none;
 }
-.deck-related .related-card {
-  opacity:0;
-  transform:scale(0.95);
-  transition:opacity 0.3s ease, transform 0.3s ease;
+
+.related-card {
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 0.25s ease, transform 0.25s ease;
 }
-.deck-related .related-card.visible {
-  opacity:1;
-  transform:scale(1);
+
+.related-card.visible {
+  opacity: 1;
+  transform: translateY(0);
 }
-.deck-close {
-  margin-top:var(--pad);
+
+@keyframes cards-related-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
+
+@media (max-width: 768px) {
+  .cards-navigation,
+  .cards-viewer {
+    padding: var(--pad);
+  }
+
+  .cards-block-header,
+  .cards-week-header {
+    flex-wrap: wrap;
+  }
+
+  .cards-viewer-body {
+    padding: var(--pad);
+  }
+
+  .deck-prev,
+  .deck-next {
+    top: auto;
+    bottom: 16px;
+    width: 40px;
+    height: 40px;
+    transform: none;
+  }
+
+  .deck-prev {
+    left: calc(50% - 48px);
+  }
+
+  .deck-next {
+    left: calc(50% + 8px);
+  }
+}
+
+@media (max-width: 520px) {
+  .deck-prev,
+  .deck-next {
+    display: none;
+  }
+}
+
 .hidden { display:none !important; }
 
 .title-cell{


### PR DESCRIPTION
## Summary
- modernize the settings page layout with hero, overview cards, and refreshed block/lecture controls
- rebuild the cards view navigation and viewer styling to match the new block/week deck grouping
- tighten the editor rich text toolbar and tagging panes for better usability

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc321904748322a034cacdc6b84d28