### PR TITLE
Refresh cards layout styling

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -145,7 +145,7 @@ async function render() {
     main.appendChild(content);
     const filter = { ...state.filters, query: state.query };
     const items = await findItemsByFilter(filter);
-    renderCards(content, items, render);
+    await renderCards(content, items, render);
   } else if (state.tab === 'Study') {
     main.appendChild(createEntryAddControl(render, 'disease'));
     const content = document.createElement('div');

--- a/js/ui/components/cards.js
+++ b/js/ui/components/cards.js
@@ -1,144 +1,368 @@
 import { createItemCard } from './cardlist.js';
+import { listBlocks } from '../../storage/storage.js';
 
-/**
- * Render lecture-based decks combining all item types.
- * @param {HTMLElement} container
- * @param {import('../../types.js').Item[]} items
- * @param {Function} onChange
- */
-export function renderCards(container, items, onChange){
-  container.innerHTML = '';
-  const decks = new Map();
-  items.forEach(it => {
-    if (it.lectures && it.lectures.length){
-      it.lectures.forEach(l => {
-        const key = l.name || `Lecture ${l.id}`;
-        if (!decks.has(key)) decks.set(key, []);
-        decks.get(key).push(it);
-      });
-    } else {
-      if (!decks.has('Unassigned')) decks.set('Unassigned', []);
-      decks.get('Unassigned').push(it);
-    }
+const collapsedBlocks = new Set();
+const collapsedWeeks = new Set();
+
+function blockKey(blockId) {
+  return blockId || '__unassigned';
+}
+
+function weekKey(blockId, weekId) {
+  return `${blockKey(blockId)}|${weekId}`;
+}
+
+function normalizeWeek(value) {
+  if (value == null || value === '' || Number.isNaN(value)) {
+    return { key: '__general', label: 'General', order: Number.POSITIVE_INFINITY - 1 };
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return { key: String(value), label: `Week ${value}`, order: value };
+  }
+  const numeric = Number(value);
+  if (!Number.isNaN(numeric)) {
+    return { key: String(numeric), label: `Week ${numeric}`, order: numeric };
+  }
+  const label = String(value);
+  return { key: label.toLowerCase(), label, order: Number.POSITIVE_INFINITY }; // custom label sorts last
+}
+
+function formatPlural(count, singular) {
+  return `${count} ${singular}${count === 1 ? '' : 's'}`;
+}
+
+function summarizeTypes(items) {
+  const counts = new Map();
+  items.forEach(item => {
+    const kind = item.kind || 'card';
+    counts.set(kind, (counts.get(kind) || 0) + 1);
   });
+  const labels = { disease: 'Disease', drug: 'Drug', concept: 'Concept' };
+  return Array.from(counts.entries())
+    .map(([kind, count]) => `${count} ${labels[kind] || 'Card'}${count === 1 ? '' : 's'}`)
+    .join(' • ');
+}
+
+function createFallbackBlock(blockId) {
+  return {
+    blockId,
+    title: blockId === '__unassigned' ? 'Unassigned' : blockId,
+    color: '#475569',
+    order: Number.MAX_SAFE_INTEGER,
+    weeks: 0
+  };
+}
+
+function createWeekDecks(weekGroup) {
+  const decks = Array.from(weekGroup.lectures.values())
+    .sort((a, b) => a.title.localeCompare(b.title));
+  if (weekGroup.general.length) {
+    decks.push({
+      key: `${weekGroup.key}|general`,
+      title: 'General content',
+      items: weekGroup.general.slice(),
+      isGeneral: true
+    });
+  }
+  return decks;
+}
+
+export async function renderCards(container, items, onChange) {
+  container.innerHTML = '';
+
+  const blockDefs = await listBlocks();
+  blockDefs.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+  const blockMeta = new Map();
+  blockDefs.forEach((block, index) => {
+    blockMeta.set(block.blockId, { ...block, order: block.order ?? index });
+  });
+  if (!blockMeta.has('__unassigned')) {
+    blockMeta.set('__unassigned', { ...createFallbackBlock('__unassigned'), order: Number.MAX_SAFE_INTEGER });
+  }
+
+  const grouped = new Map();
+
+  function getBlockGroup(blockId) {
+    const key = blockKey(blockId);
+    if (!grouped.has(key)) {
+      if (!blockMeta.has(key)) {
+        blockMeta.set(key, createFallbackBlock(key));
+      }
+      grouped.set(key, { key, meta: blockMeta.get(key), weeks: new Map(), stats: { deckCount: 0, cardCount: 0 } });
+    }
+    return grouped.get(key);
+  }
+
+  function getWeekGroup(blockGroup, rawWeek) {
+    const descriptor = normalizeWeek(rawWeek);
+    if (!blockGroup.weeks.has(descriptor.key)) {
+      blockGroup.weeks.set(descriptor.key, { ...descriptor, lectures: new Map(), general: [] });
+    }
+    return blockGroup.weeks.get(descriptor.key);
+  }
+
+  items.forEach(item => {
+    const lectureRefs = Array.isArray(item.lectures) ? item.lectures.filter(Boolean) : [];
+    if (lectureRefs.length) {
+      lectureRefs.forEach(lecture => {
+        const blockGroup = getBlockGroup(lecture.blockId || (item.blocks?.[0] ?? '__unassigned'));
+        const weekGroup = getWeekGroup(blockGroup, lecture.week);
+        const lectureKey = `${blockGroup.key}|${lecture.id}`;
+        if (!weekGroup.lectures.has(lectureKey)) {
+          weekGroup.lectures.set(lectureKey, {
+            key: lectureKey,
+            lecture,
+            title: lecture.name || `Lecture ${lecture.id}`,
+            items: []
+          });
+        }
+        weekGroup.lectures.get(lectureKey).items.push(item);
+      });
+      return;
+    }
+
+    const blocks = item.blocks?.length ? item.blocks : ['__unassigned'];
+    const weeks = item.weeks?.length ? item.weeks : [null];
+    blocks.forEach(blockId => {
+      const blockGroup = getBlockGroup(blockId);
+      weeks.forEach(weekValue => {
+        const weekGroup = getWeekGroup(blockGroup, weekValue);
+        if (!weekGroup.general.includes(item)) weekGroup.general.push(item);
+      });
+    });
+  });
+
+  const layout = document.createElement('div');
+  layout.className = 'cards-layout';
+  container.appendChild(layout);
 
   const list = document.createElement('div');
-  list.className = 'deck-list';
-  container.appendChild(list);
+  list.className = 'cards-block-list';
+  layout.appendChild(list);
 
   const viewer = document.createElement('div');
-  viewer.className = 'deck-viewer hidden';
-  container.appendChild(viewer);
+  viewer.className = 'cards-viewer hidden';
+  layout.appendChild(viewer);
 
-  decks.forEach((cards, lecture) => {
-    const deck = document.createElement('div');
-    deck.className = 'deck';
-    const title = document.createElement('div');
-    title.className = 'deck-title';
-    title.textContent = lecture;
-    const meta = document.createElement('div');
-    meta.className = 'deck-meta';
-    const blocks = Array.from(new Set(cards.flatMap(c => c.blocks || []))).join(', ');
-    const weeks = Array.from(new Set(cards.flatMap(c => c.weeks || []))).join(', ');
-    meta.textContent = `${blocks}${blocks && weeks ? ' • ' : ''}${weeks ? 'Week ' + weeks : ''}`;
-    deck.appendChild(title);
-    deck.appendChild(meta);
-    deck.addEventListener('click', () => { stopPreview(deck); openDeck(lecture, cards); });
-    let hoverTimer;
-    deck.addEventListener('mouseenter', () => {
-      hoverTimer = setTimeout(() => startPreview(deck, cards), 3000);
+  const blockEntries = Array.from(grouped.values())
+    .sort((a, b) => (a.meta.order ?? Number.MAX_SAFE_INTEGER) - (b.meta.order ?? Number.MAX_SAFE_INTEGER)
+      || (a.meta.title || '').localeCompare(b.meta.title || ''));
+
+  if (!blockEntries.length) {
+    const empty = document.createElement('div');
+    empty.className = 'cards-empty';
+    empty.textContent = 'No cards match your current filters yet.';
+    list.appendChild(empty);
+    return;
+  }
+
+  blockEntries.forEach(blockGroup => {
+    const weeks = Array.from(blockGroup.weeks.values())
+      .sort((a, b) => a.order - b.order || a.label.localeCompare(b.label));
+
+    const blockSection = document.createElement('section');
+    blockSection.className = 'cards-block';
+    const blockCollapsed = collapsedBlocks.has(blockGroup.key);
+    if (blockCollapsed) blockSection.classList.add('is-collapsed');
+
+    weeks.forEach(weekGroup => {
+      weekGroup.decks = createWeekDecks(weekGroup);
+      weekGroup.cardCount = weekGroup.decks.reduce((sum, deck) => sum + deck.items.length, 0);
+      blockGroup.stats.deckCount += weekGroup.decks.length;
+      blockGroup.stats.cardCount += weekGroup.cardCount;
     });
-    deck.addEventListener('mouseleave', () => {
-      clearTimeout(hoverTimer);
-      stopPreview(deck);
+
+    const header = document.createElement('header');
+    header.className = 'cards-block-header';
+    const info = document.createElement('div');
+    info.className = 'cards-block-info';
+    const swatch = document.createElement('span');
+    swatch.className = 'cards-block-swatch';
+    swatch.style.setProperty('--block-color', blockGroup.meta.color || '#38bdf8');
+    info.appendChild(swatch);
+    const title = document.createElement('h3');
+    title.className = 'cards-block-title';
+    title.textContent = blockGroup.meta.title || blockGroup.meta.blockId;
+    info.appendChild(title);
+    const meta = document.createElement('span');
+    meta.className = 'cards-block-meta';
+    const weekCount = weeks.length;
+    meta.textContent = `${formatPlural(weekCount, 'week')} • ${formatPlural(blockGroup.stats.deckCount, 'deck')} • ${formatPlural(blockGroup.stats.cardCount, 'card')}`;
+    info.appendChild(meta);
+    header.appendChild(info);
+
+    const toggle = document.createElement('button');
+    toggle.type = 'button';
+    toggle.className = 'cards-block-toggle';
+    toggle.textContent = blockCollapsed ? 'Expand' : 'Collapse';
+    toggle.setAttribute('aria-expanded', String(!blockCollapsed));
+    toggle.addEventListener('click', () => {
+      const collapsed = blockSection.classList.toggle('is-collapsed');
+      toggle.textContent = collapsed ? 'Expand' : 'Collapse';
+      toggle.setAttribute('aria-expanded', String(!collapsed));
+      if (collapsed) collapsedBlocks.add(blockGroup.key);
+      else collapsedBlocks.delete(blockGroup.key);
     });
-    list.appendChild(deck);
+    header.appendChild(toggle);
+    blockSection.appendChild(header);
+
+    const weekList = document.createElement('div');
+    weekList.className = 'cards-week-list';
+    blockSection.appendChild(weekList);
+
+    if (!weeks.length) {
+      const empty = document.createElement('div');
+      empty.className = 'cards-empty';
+      empty.textContent = 'No decks created for this block yet.';
+      weekList.appendChild(empty);
+    } else {
+      weeks.forEach(weekGroup => {
+        const decks = weekGroup.decks;
+        const weekSection = document.createElement('section');
+        weekSection.className = 'cards-week';
+        const weekKeyValue = weekKey(blockGroup.key, weekGroup.key);
+        const weekCollapsed = collapsedWeeks.has(weekKeyValue);
+        if (weekCollapsed) weekSection.classList.add('is-collapsed');
+
+        const weekHeader = document.createElement('div');
+        weekHeader.className = 'cards-week-header';
+        const label = document.createElement('h4');
+        label.className = 'cards-week-title';
+        label.textContent = weekGroup.label;
+        weekHeader.appendChild(label);
+        const weekMeta = document.createElement('span');
+        weekMeta.className = 'cards-week-meta';
+        weekMeta.textContent = `${formatPlural(decks.length, 'deck')} • ${formatPlural(weekGroup.cardCount, 'card')}`;
+        weekHeader.appendChild(weekMeta);
+        const weekToggle = document.createElement('button');
+        weekToggle.type = 'button';
+        weekToggle.className = 'cards-week-toggle';
+        weekToggle.textContent = weekCollapsed ? 'Show' : 'Hide';
+        weekToggle.setAttribute('aria-expanded', String(!weekCollapsed));
+        weekToggle.addEventListener('click', () => {
+          const collapsed = weekSection.classList.toggle('is-collapsed');
+          weekToggle.textContent = collapsed ? 'Show' : 'Hide';
+          weekToggle.setAttribute('aria-expanded', String(!collapsed));
+          if (collapsed) collapsedWeeks.add(weekKeyValue);
+          else collapsedWeeks.delete(weekKeyValue);
+        });
+        weekHeader.appendChild(weekToggle);
+        weekSection.appendChild(weekHeader);
+
+        const deckGrid = document.createElement('div');
+        deckGrid.className = 'cards-lecture-grid';
+        weekSection.appendChild(deckGrid);
+
+        if (!decks.length) {
+          const empty = document.createElement('div');
+          empty.className = 'cards-empty';
+          empty.textContent = 'No cards linked yet.';
+          deckGrid.appendChild(empty);
+        } else {
+          decks.forEach(deck => {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = 'cards-deck';
+            const heading = document.createElement('h5');
+            heading.className = 'cards-deck-title';
+            heading.textContent = deck.title;
+            button.appendChild(heading);
+            const count = document.createElement('span');
+            count.className = 'cards-deck-count';
+            count.textContent = formatPlural(deck.items.length, 'card');
+            button.appendChild(count);
+            const summary = document.createElement('span');
+            summary.className = 'cards-deck-summary';
+            summary.textContent = summarizeTypes(deck.items);
+            button.appendChild(summary);
+            button.addEventListener('click', () => {
+              openDeck({ block: blockGroup.meta, week: weekGroup, deck }, deck.items);
+            });
+            deckGrid.appendChild(button);
+          });
+        }
+
+        weekList.appendChild(weekSection);
+      });
+    }
+
+    list.appendChild(blockSection);
   });
 
-  function startPreview(deckEl, cards){
-    if (deckEl._preview) return;
-    deckEl.classList.add('pop');
-    const fan = document.createElement('div');
-    fan.className = 'deck-fan';
-    deckEl.appendChild(fan);
-    const show = cards.slice(0,5);
-    const spread = 20;
-    const offset = (show.length - 1) * spread / 2;
-    show.forEach((c,i) => {
-      const mini = document.createElement('div');
-      mini.className = 'fan-card';
-      mini.textContent = c.name || c.concept || '';
-      fan.appendChild(mini);
-      const angle = -offset + i * spread;
-      mini.style.transform = `rotate(${angle}deg) translateY(-80px)`;
-      setTimeout(() => { mini.style.opacity = 1; }, i * 100);
-    });
-    deckEl._preview = { fan };
-  }
-
-  function stopPreview(deckEl){
-    const prev = deckEl._preview;
-    if (prev){
-      prev.fan.remove();
-      deckEl.classList.remove('pop');
-      deckEl._preview = null;
-    }
-  }
-
-  function openDeck(title, cards){
-    list.classList.add('hidden');
+  function openDeck(context, cards) {
+    list.classList.add('is-hidden');
     viewer.classList.remove('hidden');
     viewer.innerHTML = '';
 
-    const header = document.createElement('h2');
-    header.textContent = title;
+    const header = document.createElement('header');
+    header.className = 'cards-viewer-header';
+    const title = document.createElement('h2');
+    title.textContent = context.deck.title;
+    header.appendChild(title);
+    const meta = document.createElement('p');
+    meta.className = 'cards-viewer-meta';
+    meta.textContent = `${context.block.title || context.block.blockId} • ${context.week.label} • ${formatPlural(cards.length, 'card')}`;
+    header.appendChild(meta);
+    const close = document.createElement('button');
+    close.type = 'button';
+    close.className = 'icon-btn ghost cards-viewer-close';
+    close.textContent = '✕';
+    header.appendChild(close);
     viewer.appendChild(header);
 
-    const cardHolder = document.createElement('div');
-    cardHolder.className = 'deck-card';
-    viewer.appendChild(cardHolder);
+    const stage = document.createElement('div');
+    stage.className = 'cards-viewer-stage';
+    viewer.appendChild(stage);
 
     const prev = document.createElement('button');
-    prev.className = 'deck-prev';
-    prev.textContent = '◀';
-    const next = document.createElement('button');
-    next.className = 'deck-next';
-    next.textContent = '▶';
-    viewer.appendChild(prev);
-    viewer.appendChild(next);
+    prev.type = 'button';
+    prev.className = 'cards-nav-btn prev';
+    prev.setAttribute('aria-label', 'Previous card');
+    prev.textContent = '‹';
+    stage.appendChild(prev);
 
-    const toggle = document.createElement('button');
-    toggle.className = 'deck-related-toggle btn';
-    toggle.textContent = 'Show Related';
-    viewer.appendChild(toggle);
+    const cardHolder = document.createElement('div');
+    cardHolder.className = 'cards-viewer-card';
+    stage.appendChild(cardHolder);
+
+    const next = document.createElement('button');
+    next.type = 'button';
+    next.className = 'cards-nav-btn next';
+    next.setAttribute('aria-label', 'Next card');
+    next.textContent = '›';
+    stage.appendChild(next);
+
+    const controls = document.createElement('div');
+    controls.className = 'cards-viewer-controls';
+    const toggleRelated = document.createElement('button');
+    toggleRelated.type = 'button';
+    toggleRelated.className = 'btn subtle cards-related-toggle';
+    toggleRelated.textContent = 'Show related';
+    controls.appendChild(toggleRelated);
+    viewer.appendChild(controls);
 
     const relatedWrap = document.createElement('div');
-    relatedWrap.className = 'deck-related hidden';
+    relatedWrap.className = 'cards-related hidden';
     viewer.appendChild(relatedWrap);
-
-    const close = document.createElement('button');
-    close.className = 'deck-close btn';
-    close.textContent = 'Close';
-    viewer.appendChild(close);
 
     let idx = 0;
     let showRelated = false;
 
-    function renderCard(){
+    function renderCard() {
       cardHolder.innerHTML = '';
       cardHolder.appendChild(createItemCard(cards[idx], onChange));
       renderRelated();
     }
 
-    function renderRelated(){
+    function renderRelated() {
       relatedWrap.innerHTML = '';
       if (!showRelated) return;
       const current = cards[idx];
-      (current.links || []).forEach(l => {
-        const item = items.find(it => it.id === l.id);
+      (current.links || []).forEach(link => {
+        const item = items.find(it => it.id === link.id);
         if (item) {
           const el = createItemCard(item, onChange);
-          el.classList.add('related-card');
+          el.classList.add('cards-related-card');
           relatedWrap.appendChild(el);
           requestAnimationFrame(() => el.classList.add('visible'));
         }
@@ -149,32 +373,35 @@ export function renderCards(container, items, onChange){
       idx = (idx - 1 + cards.length) % cards.length;
       renderCard();
     });
+
     next.addEventListener('click', () => {
       idx = (idx + 1) % cards.length;
       renderCard();
     });
 
-    toggle.addEventListener('click', () => {
+    toggleRelated.addEventListener('click', () => {
       showRelated = !showRelated;
-      toggle.textContent = showRelated ? 'Hide Related' : 'Show Related';
+      toggleRelated.textContent = showRelated ? 'Hide related' : 'Show related';
       relatedWrap.classList.toggle('hidden', !showRelated);
       renderRelated();
     });
 
-    close.addEventListener('click', () => {
+    function closeViewer() {
       document.removeEventListener('keydown', keyHandler);
       viewer.classList.add('hidden');
       viewer.innerHTML = '';
-      list.classList.remove('hidden');
-    });
-
-    function keyHandler(e){
-      if (e.key === 'ArrowLeft') prev.click();
-      if (e.key === 'ArrowRight') next.click();
-      if (e.key === 'Escape') close.click();
+      list.classList.remove('is-hidden');
     }
-    document.addEventListener('keydown', keyHandler);
 
+    close.addEventListener('click', closeViewer);
+
+    function keyHandler(event) {
+      if (event.key === 'ArrowLeft') prev.click();
+      if (event.key === 'ArrowRight') next.click();
+      if (event.key === 'Escape') closeViewer();
+    }
+
+    document.addEventListener('keydown', keyHandler);
     renderCard();
   }
 }

--- a/js/ui/components/editor.js
+++ b/js/ui/components/editor.js
@@ -171,11 +171,20 @@ export async function openEditor(kind, onSave, existing = null) {
 
   const blockChipRow = document.createElement('div');
   blockChipRow.className = 'editor-chip-row';
-  blockWrap.appendChild(blockChipRow);
 
   const blockPanels = document.createElement('div');
   blockPanels.className = 'editor-block-panels';
-  blockWrap.appendChild(blockPanels);
+
+  const layout = document.createElement('div');
+  layout.className = 'editor-tag-layout';
+  const chipColumn = document.createElement('div');
+  chipColumn.className = 'editor-chip-column';
+  chipColumn.appendChild(blockChipRow);
+  const panelColumn = document.createElement('div');
+  panelColumn.className = 'editor-panel-column';
+  panelColumn.appendChild(blockPanels);
+  layout.append(chipColumn, panelColumn);
+  blockWrap.appendChild(layout);
 
   function createTagChip(label, variant, active = false) {
     const chip = document.createElement('button');

--- a/style.css
+++ b/style.css
@@ -735,18 +735,16 @@ input[type="checkbox"]:checked::after {
   font-size: 0.95rem;
 }
 
+
 .editor-tags {
   margin-top: var(--pad);
-  padding: var(--pad);
+  padding: var(--pad-lg);
   border-radius: var(--radius-lg);
   border: 1px solid rgba(148, 163, 184, 0.32);
-  background: linear-gradient(155deg, rgba(15, 23, 42, 0.85), rgba(8, 13, 23, 0.92));
+  background: linear-gradient(155deg, rgba(15, 23, 42, 0.9), rgba(8, 13, 23, 0.95));
   display: flex;
   flex-direction: column;
   gap: var(--pad);
-  min-height: 220px;
-  max-height: clamp(280px, 46vh, 420px);
-  overflow: hidden;
 }
 
 .editor-tags-title {
@@ -755,18 +753,59 @@ input[type="checkbox"]:checked::after {
   color: var(--text);
 }
 
+.editor-tag-layout {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.75fr) minmax(0, 1fr);
+  gap: var(--pad);
+  align-items: stretch;
+  min-height: 320px;
+}
+
+@media (max-width: 1024px) {
+  .editor-tag-layout {
+    grid-template-columns: 1fr;
+    min-height: 0;
+  }
+  .editor-chip-column {
+    order: 2;
+    border-right: none;
+    border-top: 1px solid rgba(148, 163, 184, 0.18);
+    padding-right: 0;
+    padding-top: var(--pad);
+  }
+  .editor-panel-column {
+    order: 1;
+  }
+}
+
+.editor-chip-column {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+  padding-right: 8px;
+  border-right: 1px solid rgba(148, 163, 184, 0.12);
+  max-height: 360px;
+  overflow-y: auto;
+}
+
 .editor-chip-row {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
 }
 
+.editor-panel-column {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+  overflow: auto;
+  padding-right: 6px;
+}
+
 .editor-block-panels {
   display: flex;
   flex-direction: column;
   gap: var(--pad-sm);
-  overflow-y: auto;
-  padding-right: 6px;
   flex: 1;
 }
 
@@ -947,112 +986,145 @@ input[type="checkbox"]:checked::after {
 .rich-editor {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  background: rgba(15, 23, 42, 0.4);
-  border: 1px solid var(--border);
+  gap: var(--pad-sm);
+  background: rgba(10, 16, 30, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.22);
   border-radius: var(--radius);
   padding: var(--pad-sm);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 18px 36px rgba(2, 6, 23, 0.35);
 }
 
 .rich-editor-toolbar {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
   align-items: center;
+  gap: 8px;
 }
 
 .rich-editor-group {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
   padding: 4px 6px;
   border-radius: var(--radius-sm);
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  background: rgba(8, 13, 23, 0.6);
-  backdrop-filter: blur(6px);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  background: rgba(6, 12, 26, 0.55);
+  backdrop-filter: blur(8px);
 }
 
-.rich-editor-label {
-  font-size: 0.75rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--text-muted);
+.rich-editor-group--compact {
+  gap: 2px;
+  padding: 4px;
+}
+
+.rich-editor-group--popover {
+  position: relative;
+}
+
+.rich-editor-group--popover.open {
+  border-color: rgba(56, 189, 248, 0.6);
+  box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.35);
 }
 
 .rich-editor-btn {
   background: transparent;
   border: none;
   color: var(--text-muted);
-  padding: 6px 8px;
+  padding: 6px 7px;
   font-size: 0.9rem;
   cursor: pointer;
   border-radius: var(--radius-sm);
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.rich-editor-group--compact .rich-editor-btn {
+  padding: 5px 6px;
 }
 
 .rich-editor-btn:hover,
-.rich-editor-btn:focus {
-  background: var(--muted);
+.rich-editor-btn:focus-visible {
+  background: rgba(56, 189, 248, 0.16);
   color: var(--text);
   outline: none;
 }
 
-.rich-editor-color {
-  display: inline-flex;
-  align-items: center;
+.rich-editor-color-btn {
+  position: relative;
+  padding-left: 18px;
 }
 
-.rich-editor-color input {
-  width: 34px;
-  height: 30px;
+.rich-editor-color-btn::before {
+  content: '';
+  position: absolute;
+  left: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--current-color, #ffffff);
+  box-shadow: 0 0 0 1px rgba(8, 13, 23, 0.6);
+}
+
+.rich-editor-color-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.rich-editor-popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px;
+  border-radius: var(--radius);
   border: 1px solid rgba(148, 163, 184, 0.25);
-  border-radius: var(--radius-sm);
-  background: rgba(15, 23, 42, 0.4);
-  padding: 0;
-  cursor: pointer;
-}
-
-.rich-editor-highlight-group {
-  gap: 8px;
+  background: rgba(6, 12, 26, 0.95);
+  box-shadow: 0 18px 32px rgba(2, 6, 23, 0.45);
+  min-width: 160px;
+  z-index: 40;
 }
 
 .rich-editor-swatch {
-  width: 26px;
-  height: 26px;
+  width: 24px;
+  height: 24px;
   border-radius: 50%;
-  border: 2px solid rgba(8, 13, 23, 0.7);
+  border: 2px solid rgba(6, 12, 26, 0.7);
   background: var(--swatch-color, transparent);
-  box-shadow: 0 0 0 2px rgba(148, 163, 184, 0.25);
+  box-shadow: 0 0 0 2px rgba(148, 163, 184, 0.2);
   cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
 .rich-editor-swatch:hover,
-.rich-editor-swatch:focus {
+.rich-editor-swatch:focus-visible {
+  transform: translateY(-1px);
   box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.45);
   outline: none;
 }
 
-.rich-editor-swatch--clear {
-  background: rgba(15, 23, 42, 0.6);
-  color: var(--text-muted);
+.rich-editor-popover-action {
+  background: none;
+  border: none;
+  color: var(--text);
+  padding: 6px 8px;
+  text-align: left;
   font-size: 0.85rem;
-  line-height: 1;
-}
-
-.rich-editor-swatch--clear:hover,
-.rich-editor-swatch--clear:focus {
-  color: var(--text);
-}
-
-.rich-editor-select,
-.rich-editor-size {
-  background: rgba(15, 23, 42, 0.6);
-  border: 1px solid rgba(148, 163, 184, 0.2);
   border-radius: var(--radius-sm);
-  color: var(--text);
-  padding: 6px 10px;
   cursor: pointer;
-  font-size: 0.9rem;
-  min-width: 120px;
+  transition: background-color 0.15s ease;
+}
+
+.rich-editor-popover-action:hover,
+.rich-editor-popover-action:focus-visible {
+  background: rgba(56, 189, 248, 0.14);
+  outline: none;
 }
 
 .rich-editor-area {
@@ -1092,35 +1164,6 @@ input[type="checkbox"]:checked::after {
   margin-left: auto;
   font-size: 0.85rem;
   opacity: 0.8;
-}
-
-.editor-tags {
-  margin-top: var(--pad);
-  padding: var(--pad);
-  background: rgba(15, 23, 42, 0.45);
-  border-radius: var(--radius);
-  border: 1px solid var(--border);
-  max-height: min(420px, 50vh);
-  overflow: auto;
-  display: flex;
-  flex-direction: column;
-  gap: var(--pad-sm);
-}
-
-.editor-tags-title {
-  font-weight: 600;
-  margin: 0;
-  font-size: 1rem;
-}
-
-.editor-tag-block {
-  padding: 8px;
-  border-radius: var(--radius-sm);
-  background: rgba(8, 13, 23, 0.45);
-}
-
-.editor-tag-block:last-child {
-  margin-bottom: 0;
 }
 
 .window-dock {
@@ -1443,16 +1486,253 @@ input[type="checkbox"]:checked::after {
   gap: var(--pad-sm);
 }
 
-.settings-lecture-toggle {
-  margin-top: var(--pad-sm);
-  align-self: flex-start;
+.settings-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(240px, 1fr);
+  gap: var(--pad-lg);
+  align-items: flex-start;
 }
 
-.settings-lecture-section {
+@media (max-width: 1080px) {
+  .settings-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.settings-column {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-lg);
+}
+
+.settings-card {
+  background: rgba(11, 17, 32, 0.72);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  padding: var(--pad-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-lg);
+  box-shadow: 0 20px 45px rgba(8, 13, 23, 0.35);
+}
+
+.settings-card-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.settings-card-header h2 {
+  margin: 0;
+  font-size: 1.2rem;
+  letter-spacing: 0.02em;
+}
+
+.settings-card-description {
+  margin: 0;
+  color: var(--gray);
+  font-size: 0.95rem;
+}
+
+.settings-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.settings-field .input {
+  width: 160px;
+}
+
+.settings-block-grid {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+}
+
+.settings-block-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  border-radius: var(--radius);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(6, 12, 26, 0.65);
+  padding: var(--pad);
+  backdrop-filter: blur(10px);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.settings-block-card.editing {
+  border-color: var(--blue);
+  box-shadow: 0 12px 30px rgba(2, 132, 199, 0.2);
+}
+
+.settings-block-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: var(--pad);
+  align-items: flex-start;
+}
+
+.settings-block-info {
+  display: flex;
+  align-items: center;
+  gap: var(--pad-sm);
+}
+
+.settings-block-swatch {
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  background: var(--swatch-color, #64748b);
+  box-shadow: 0 0 0 2px rgba(8, 13, 23, 0.75);
+}
+
+.settings-block-titles {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.settings-block-titles h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: 0.01em;
+}
+
+.settings-block-meta {
+  margin: 0;
+  color: var(--gray);
+  font-size: 0.85rem;
+}
+
+.settings-block-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.settings-collapse-toggle {
+  border: none;
+  background: none;
+  color: var(--gray);
+  cursor: pointer;
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  transition: color 0.2s ease;
+}
+
+.settings-collapse-toggle:hover,
+.settings-collapse-toggle:focus-visible {
+  color: var(--text);
+  outline: none;
+}
+
+.settings-block-card.is-collapsed .settings-lecture-panel {
+  display: none;
+}
+
+.settings-block-edit {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad-sm);
+  padding: var(--pad-sm);
+  border-radius: var(--radius);
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.settings-block-edit .btn {
+  min-width: 140px;
+}
+
+.settings-lecture-panel {
   display: flex;
   flex-direction: column;
   gap: var(--pad-sm);
+}
+
+.settings-lecture-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.settings-empty {
+  margin: 0;
+  color: var(--gray);
+  font-style: italic;
+}
+
+.settings-lecture-row {
+  display: flex;
+  align-items: center;
+  gap: var(--pad);
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-radius: var(--radius);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(10, 16, 30, 0.75);
+}
+
+.settings-lecture-label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.settings-lecture-label strong {
+  font-size: 0.95rem;
+}
+
+.settings-lecture-label span {
+  color: var(--gray);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.settings-lecture-actions {
+  display: inline-flex;
+  gap: 6px;
+}
+
+.settings-lecture-edit {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad-sm);
+  width: 100%;
+}
+
+.settings-lecture-edit .btn {
+  min-width: 96px;
+}
+
+.settings-lecture-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad-sm);
+  border-top: 1px solid rgba(148, 163, 184, 0.1);
+  padding-top: var(--pad);
   margin-top: var(--pad-sm);
+}
+
+.settings-add-block {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad-sm);
+  border-top: 1px solid rgba(148, 163, 184, 0.1);
+  padding-top: var(--pad);
+  margin-top: var(--pad);
+}
+
+.settings-add-block .btn {
+  min-width: 140px;
+}
+
+.settings-wide-btn {
+  width: 100%;
+  justify-content: center;
 }
 
 .builder-controls {
@@ -2105,137 +2385,370 @@ input[type="checkbox"]:checked::after {
   display: block;
 }
 
-/* Decks */
-.deck-list {
-  display:flex;
-  flex-wrap:wrap;
-  gap:var(--pad);
-  padding:var(--pad);
+/* Cards */
+.cards-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 420px) minmax(0, 1fr);
+  gap: clamp(20px, 4vw, 36px);
+  align-items: stretch;
+  height: 100%;
 }
-.deck {
-  background:var(--panel);
-  border:1px solid var(--border);
-  border-radius:var(--radius);
-  padding:var(--pad-lg);
-  cursor:pointer;
-  box-shadow:0 2px 4px rgba(0,0,0,0.2);
-  position:relative;
-  width:200px;
-  display:flex;
-  flex-direction:column;
-  align-items:center;
-  text-align:center;
-  transition:transform 0.3s ease;
-}
-.deck-title { font-weight:600; margin-bottom:4px; }
-.deck-meta { font-size:0.85rem; color:var(--gray); }
-.deck.pop { transform:scale(1.05); z-index:2; }
-.deck-fan {
-  position:absolute;
-  top:50%;
-  left:50%;
-  transform:translate(-50%,-50%);
-  pointer-events:none;
-}
-.deck-fan .fan-card {
-  position:absolute;
-  width:70px;
-  height:90px;
-  background:var(--panel);
-  border:1px solid var(--border);
-  border-radius:var(--radius);
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  font-size:0.65rem;
-  color:var(--text);
-  opacity:0;
-  transform-origin:bottom center;
-  transition:opacity 0.3s ease, transform 0.3s ease;
-  white-space:nowrap;
-  overflow:hidden;
-  text-overflow:ellipsis;
-}
-.deck-viewer {
-  position: relative;
-  text-align: center;
-  padding: var(--pad);
+
+.cards-block-list {
   display: flex;
   flex-direction: column;
+  gap: clamp(16px, 3vw, 26px);
+  padding: var(--pad-lg);
+  padding-right: clamp(12px, 2vw, 22px);
+  overflow-y: auto;
+  border-radius: var(--radius-lg);
+  background: rgba(15, 23, 42, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 24px 40px rgba(8, 15, 28, 0.38);
+}
+
+.cards-block-list.is-hidden {
+  display: none;
+}
+
+.cards-block {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(12px, 2.2vw, 20px);
+  padding: clamp(16px, 3vw, 26px);
+  border-radius: calc(var(--radius-lg) - 4px);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.6), rgba(30, 41, 59, 0.52));
+  box-shadow: 0 18px 32px rgba(8, 15, 28, 0.35);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.cards-block:hover {
+  border-color: rgba(56, 189, 248, 0.45);
+  box-shadow: 0 24px 42px rgba(8, 15, 28, 0.45);
+}
+
+.cards-block.is-collapsed .cards-week-list {
+  display: none;
+}
+
+.cards-block-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--pad);
+}
+
+.cards-block-info {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0 var(--pad-sm);
   align-items: center;
+}
+
+.cards-block-swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 4px;
+  background: var(--block-color, var(--accent));
+  box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.14);
+  align-self: flex-start;
+}
+
+.cards-block-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.cards-block-meta {
+  grid-column: 1 / -1;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.cards-block-toggle {
+  align-self: flex-start;
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.45);
+  color: var(--text);
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.cards-block-toggle:hover {
+  border-color: rgba(56, 189, 248, 0.55);
+  background: rgba(56, 189, 248, 0.18);
+  color: #e0f2fe;
+}
+
+.cards-week-list {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(10px, 2vw, 18px);
+}
+
+.cards-week {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(10px, 2vw, 16px);
+  padding: clamp(12px, 2.5vw, 20px);
+  border-radius: var(--radius);
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.cards-week.is-collapsed .cards-lecture-grid {
+  display: none;
+}
+
+.cards-week-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--pad);
+}
+
+.cards-week-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.cards-week-meta {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+.cards-week-toggle {
+  padding: 4px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.45);
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.cards-week-toggle:hover {
+  border-color: rgba(56, 189, 248, 0.45);
+  background: rgba(56, 189, 248, 0.16);
+  color: #e0f2fe;
+}
+
+.cards-lecture-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: clamp(12px, 2.4vw, 20px);
+}
+
+.cards-deck {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: flex-start;
+  padding: clamp(14px, 2.6vw, 20px);
+  border-radius: calc(var(--radius) + 4px);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: linear-gradient(150deg, rgba(30, 41, 59, 0.72), rgba(15, 23, 42, 0.68));
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.cards-deck:hover {
+  transform: translateY(-3px);
+  border-color: rgba(56, 189, 248, 0.45);
+  box-shadow: 0 16px 28px rgba(8, 15, 28, 0.42);
+}
+
+.cards-deck-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.cards-deck-count {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.cards-deck-summary {
+  font-size: 0.78rem;
+  color: rgba(226, 232, 240, 0.68);
+}
+
+.cards-empty {
+  padding: clamp(16px, 3vw, 24px);
+  border-radius: var(--radius);
+  border: 1px dashed rgba(148, 163, 184, 0.28);
+  color: var(--text-muted);
+  background: rgba(15, 23, 42, 0.3);
+  text-align: center;
+}
+
+.cards-viewer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  padding: var(--pad-lg);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.7), rgba(30, 41, 59, 0.65));
+  box-shadow: 0 28px 48px rgba(8, 15, 28, 0.5);
+}
+
+.cards-viewer.hidden {
+  display: none;
+}
+
+.cards-viewer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--pad);
+}
+
+.cards-viewer-header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+  letter-spacing: 0.01em;
+}
+
+.cards-viewer-meta {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.cards-viewer-close {
+  flex-shrink: 0;
+}
+
+.cards-viewer-stage {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: var(--pad);
+  align-items: stretch;
+  min-height: 420px;
+}
+
+.cards-nav-btn {
+  width: 42px;
+  height: 42px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.48);
+  color: var(--text);
+  font-size: 1.5rem;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.cards-nav-btn:hover {
+  border-color: rgba(56, 189, 248, 0.45);
+  background: rgba(56, 189, 248, 0.16);
+  transform: translateY(-2px);
+}
+
+.cards-viewer-card {
+  display: flex;
   justify-content: center;
-  min-height: 70vh;
-}
-.deck-card {
-  margin:0 auto;
+  align-items: stretch;
+  overflow: hidden;
 }
 
-.deck-card .item-card {
-  width:40vw;
-  height:20vh;
-  overflow:hidden;
-  display:flex;
-  flex-direction:column;
+.cards-viewer-card .item-card {
+  width: 100%;
+  max-width: 540px;
+  box-shadow: 0 18px 32px rgba(8, 15, 28, 0.45);
 }
 
-.deck-card .item-card.expanded {
-  height:70vh;
+.cards-viewer-controls {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
 }
 
-.deck-card .item-card .card-body {
-  display:none;
-  flex:1;
-  overflow:auto;
+.cards-related {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: var(--pad);
+  padding: var(--pad);
+  border-radius: var(--radius);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.55);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.08);
 }
 
-.deck-card .item-card.expanded .card-body {
-  display:block;
+.cards-related.hidden {
+  display: none;
 }
 
-.deck-card .item-card.expanded .section-content {
-  overflow-y:auto;
+.cards-related-card {
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 0.25s ease, transform 0.25s ease;
 }
-.deck-prev, .deck-next {
-  position:absolute;
-  top:50%;
-  transform:translateY(-50%);
-  background:var(--muted);
-  color:var(--text);
-  padding:8px;
-  border-radius:var(--radius);
-  cursor:pointer;
-  border:1px solid var(--border);
+
+.cards-related-card.visible {
+  opacity: 1;
+  transform: none;
 }
-.deck-prev { left:var(--pad); }
-.deck-next { right:var(--pad); }
-.deck-prev:hover, .deck-next:hover {
-  transform:translateY(calc(-50% - 2px));
+
+@media (max-width: 1200px) {
+  .cards-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .cards-block-list {
+    max-height: none;
+  }
+
+  .cards-viewer {
+    order: -1;
+  }
 }
-.deck-related {
-  display:flex;
-  flex-wrap:wrap;
-  gap:var(--pad);
-  justify-content:center;
-  margin-top:var(--pad);
-  opacity:0;
-  transform:translateY(-10px);
-  transition:opacity 0.3s ease, transform 0.3s ease;
-}
-.deck-related:not(.hidden) {
-  opacity:1;
-  transform:translateY(0);
-}
-.deck-related .related-card {
-  opacity:0;
-  transform:scale(0.95);
-  transition:opacity 0.3s ease, transform 0.3s ease;
-}
-.deck-related .related-card.visible {
-  opacity:1;
-  transform:scale(1);
-}
-.deck-close {
-  margin-top:var(--pad);
+
+@media (max-width: 720px) {
+  .cards-block-list {
+    padding: var(--pad);
+  }
+
+  .cards-block-header,
+  .cards-week-header,
+  .cards-viewer-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .cards-viewer-stage {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .cards-nav-btn {
+    width: 100%;
+    height: 38px;
+  }
+
+  .cards-viewer-stage {
+    gap: 12px;
+  }
 }
 .hidden { display:none !important; }
 


### PR DESCRIPTION
## Summary
- redesign the settings surface with card-based sections, collapsible lecture lists, and inline block editing controls
- streamline the rich-text editor with a compact toolbar, contextual popovers, and refreshed tagging layout inside the entry editor
- rebuild the cards tab to group decks by block and week with collapsible sections and a refreshed viewer, and align the CSS with the new structure

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc321904748322a034cacdc6b84d28