### PR TITLE
Redesign settings and cards layout

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -145,7 +145,7 @@ async function render() {
     main.appendChild(content);
     const filter = { ...state.filters, query: state.query };
     const items = await findItemsByFilter(filter);
-    renderCards(content, items, render);
+    await renderCards(content, items, render);
   } else if (state.tab === 'Study') {
     main.appendChild(createEntryAddControl(render, 'disease'));
     const content = document.createElement('div');

--- a/js/ui/components/cards.js
+++ b/js/ui/components/cards.js
@@ -1,97 +1,270 @@
 import { createItemCard } from './cardlist.js';
+import { listBlocks } from '../../storage/storage.js';
 
-/**
- * Render lecture-based decks combining all item types.
- * @param {HTMLElement} container
- * @param {import('../../types.js').Item[]} items
- * @param {Function} onChange
- */
-export function renderCards(container, items, onChange){
+const collapsedBlockSections = new Set();
+const collapsedWeekSections = new Set();
+
+function blockKey(blockId = 'unassigned') {
+  return blockId || 'unassigned';
+}
+
+function weekKey(blockId, week) {
+  return `${blockKey(blockId)}::${week ?? 'general'}`;
+}
+
+function ensureGroup(groups, blockId, meta) {
+  const key = blockKey(blockId);
+  if (!groups.has(key)) {
+    const fallbackName = blockId ? blockId : 'Unassigned';
+    groups.set(key, {
+      id: key,
+      blockId,
+      label: meta ? `${meta.blockId} • ${meta.title}` : fallbackName,
+      title: meta?.title || (blockId ? meta?.title || blockId : 'Unassigned'),
+      color: meta?.color || null,
+      order: typeof meta?.order === 'number' ? meta.order : Number.MAX_SAFE_INTEGER,
+      weeks: new Map(),
+    });
+  }
+  return groups.get(key);
+}
+
+function ensureWeek(group, rawWeek) {
+  const key = weekKey(group.blockId, rawWeek);
+  if (!group.weeks.has(key)) {
+    const hasWeekNumber = typeof rawWeek === 'number' && !Number.isNaN(rawWeek);
+    group.weeks.set(key, {
+      key,
+      raw: hasWeekNumber ? rawWeek : null,
+      label: hasWeekNumber ? `Week ${rawWeek}` : 'General',
+      order: hasWeekNumber ? rawWeek : Number.MAX_SAFE_INTEGER - 1,
+      decks: new Map(),
+    });
+  }
+  return group.weeks.get(key);
+}
+
+function ensureDeck(week, key, title, meta = {}) {
+  if (!week.decks.has(key)) {
+    week.decks.set(key, {
+      key,
+      title,
+      meta,
+      cards: [],
+    });
+  }
+  return week.decks.get(key);
+}
+
+export async function renderCards(container, items, onChange) {
   container.innerHTML = '';
-  const decks = new Map();
-  items.forEach(it => {
-    if (it.lectures && it.lectures.length){
-      it.lectures.forEach(l => {
-        const key = l.name || `Lecture ${l.id}`;
-        if (!decks.has(key)) decks.set(key, []);
-        decks.get(key).push(it);
+  container.classList.add('cards-workspace');
+
+  const blockMeta = await listBlocks();
+  const blockMap = new Map(blockMeta.map((block, idx) => [block.blockId, { ...block, index: idx }]));
+
+  const groups = new Map();
+
+  items.forEach((item) => {
+    const lectures = Array.isArray(item.lectures) ? item.lectures : [];
+    if (lectures.length) {
+      lectures.forEach((lecture) => {
+        const block = ensureGroup(groups, lecture.blockId, blockMap.get(lecture.blockId));
+        const week = ensureWeek(block, lecture.week);
+        const deckTitle = lecture.name || (lecture.id ? `Lecture ${lecture.id}` : 'Lecture');
+        const deck = ensureDeck(week, `lecture-${lecture.id ?? deckTitle}`, deckTitle, {
+          lectureId: lecture.id,
+          week: lecture.week,
+          blockId: lecture.blockId,
+        });
+        if (!deck.cards.some(card => card.id === item.id)) deck.cards.push(item);
       });
-    } else {
-      if (!decks.has('Unassigned')) decks.set('Unassigned', []);
-      decks.get('Unassigned').push(it);
+      return;
     }
+
+    const blocks = Array.isArray(item.blocks) ? item.blocks : [];
+    if (blocks.length) {
+      blocks.forEach((blockId) => {
+        const block = ensureGroup(groups, blockId, blockMap.get(blockId));
+        const derivedWeek = Array.isArray(item.weeks) && item.weeks.length ? Number(item.weeks[0]) : null;
+        const week = ensureWeek(block, Number.isFinite(derivedWeek) ? derivedWeek : null);
+        const deck = ensureDeck(week, 'block-items', 'Block entries', { blockId });
+        if (!deck.cards.some(card => card.id === item.id)) deck.cards.push(item);
+      });
+      return;
+    }
+
+    const block = ensureGroup(groups, null, null);
+    const week = ensureWeek(block, null);
+    const deck = ensureDeck(week, 'unassigned', 'Unsorted entries');
+    if (!deck.cards.some(card => card.id === item.id)) deck.cards.push(item);
   });
 
-  const list = document.createElement('div');
-  list.className = 'deck-list';
-  container.appendChild(list);
+  const browser = document.createElement('div');
+  browser.className = 'cards-browser';
+  container.appendChild(browser);
 
   const viewer = document.createElement('div');
-  viewer.className = 'deck-viewer hidden';
+  viewer.className = 'deck-viewer cards-viewer hidden';
   container.appendChild(viewer);
 
-  decks.forEach((cards, lecture) => {
-    const deck = document.createElement('div');
-    deck.className = 'deck';
-    const title = document.createElement('div');
-    title.className = 'deck-title';
-    title.textContent = lecture;
-    const meta = document.createElement('div');
-    meta.className = 'deck-meta';
-    const blocks = Array.from(new Set(cards.flatMap(c => c.blocks || []))).join(', ');
-    const weeks = Array.from(new Set(cards.flatMap(c => c.weeks || []))).join(', ');
-    meta.textContent = `${blocks}${blocks && weeks ? ' • ' : ''}${weeks ? 'Week ' + weeks : ''}`;
-    deck.appendChild(title);
-    deck.appendChild(meta);
-    deck.addEventListener('click', () => { stopPreview(deck); openDeck(lecture, cards); });
-    let hoverTimer;
-    deck.addEventListener('mouseenter', () => {
-      hoverTimer = setTimeout(() => startPreview(deck, cards), 3000);
-    });
-    deck.addEventListener('mouseleave', () => {
-      clearTimeout(hoverTimer);
-      stopPreview(deck);
-    });
-    list.appendChild(deck);
+  const sortedBlocks = Array.from(groups.values()).sort((a, b) => {
+    if (a.order !== b.order) return a.order - b.order;
+    const aIndex = blockMap.get(a.blockId)?.index ?? Number.MAX_SAFE_INTEGER;
+    const bIndex = blockMap.get(b.blockId)?.index ?? Number.MAX_SAFE_INTEGER;
+    if (aIndex !== bIndex) return aIndex - bIndex;
+    return a.label.localeCompare(b.label);
   });
 
-  function startPreview(deckEl, cards){
-    if (deckEl._preview) return;
-    deckEl.classList.add('pop');
-    const fan = document.createElement('div');
-    fan.className = 'deck-fan';
-    deckEl.appendChild(fan);
-    const show = cards.slice(0,5);
-    const spread = 20;
-    const offset = (show.length - 1) * spread / 2;
-    show.forEach((c,i) => {
-      const mini = document.createElement('div');
-      mini.className = 'fan-card';
-      mini.textContent = c.name || c.concept || '';
-      fan.appendChild(mini);
-      const angle = -offset + i * spread;
-      mini.style.transform = `rotate(${angle}deg) translateY(-80px)`;
-      setTimeout(() => { mini.style.opacity = 1; }, i * 100);
+  if (!sortedBlocks.length) {
+    const empty = document.createElement('p');
+    empty.className = 'cards-empty';
+    empty.textContent = 'No cards yet. Add entries to start building decks.';
+    browser.appendChild(empty);
+    return;
+  }
+
+  sortedBlocks.forEach((blockGroup) => {
+    const blockSection = document.createElement('section');
+    blockSection.className = 'cards-block';
+    if (blockGroup.color) blockSection.style.setProperty('--block-accent', blockGroup.color);
+    const blockCollapsed = collapsedBlockSections.has(blockGroup.id);
+    if (blockCollapsed) blockSection.classList.add('collapsed');
+
+    const header = document.createElement('header');
+    header.className = 'cards-block-header';
+    blockSection.appendChild(header);
+
+    const info = document.createElement('div');
+    info.className = 'cards-block-info';
+    const title = document.createElement('h2');
+    title.textContent = blockGroup.blockId ? `${blockGroup.blockId} • ${blockGroup.title}` : 'Unassigned';
+    info.appendChild(title);
+    const meta = document.createElement('p');
+    meta.className = 'cards-block-meta';
+    const totalCards = Array.from(blockGroup.weeks.values()).reduce((sum, wk) => sum + Array.from(wk.decks.values()).reduce((inner, deck) => inner + deck.cards.length, 0), 0);
+    meta.textContent = `${blockGroup.weeks.size} ${blockGroup.weeks.size === 1 ? 'section' : 'sections'} • ${totalCards} ${totalCards === 1 ? 'card' : 'cards'}`;
+    info.appendChild(meta);
+    header.appendChild(info);
+
+    const toggleBtn = document.createElement('button');
+    toggleBtn.className = 'icon-btn ghost cards-collapse-btn';
+    toggleBtn.textContent = blockCollapsed ? '▸' : '▾';
+    toggleBtn.title = blockCollapsed ? 'Expand block' : 'Collapse block';
+    toggleBtn.setAttribute('aria-expanded', blockCollapsed ? 'false' : 'true');
+    toggleBtn.addEventListener('click', () => {
+      blockSection.classList.toggle('collapsed');
+      const collapsed = blockSection.classList.contains('collapsed');
+      toggleBtn.textContent = collapsed ? '▸' : '▾';
+      toggleBtn.title = collapsed ? 'Expand block' : 'Collapse block';
+      toggleBtn.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+      content.hidden = collapsed;
+      if (collapsed) collapsedBlockSections.add(blockGroup.id);
+      else collapsedBlockSections.delete(blockGroup.id);
     });
-    deckEl._preview = { fan };
-  }
+    header.appendChild(toggleBtn);
 
-  function stopPreview(deckEl){
-    const prev = deckEl._preview;
-    if (prev){
-      prev.fan.remove();
-      deckEl.classList.remove('pop');
-      deckEl._preview = null;
-    }
-  }
+    const content = document.createElement('div');
+    content.className = 'cards-block-content';
+    if (blockCollapsed) content.hidden = true;
+    blockSection.appendChild(content);
 
-  function openDeck(title, cards){
-    list.classList.add('hidden');
+    const sortedWeeks = Array.from(blockGroup.weeks.values()).sort((a, b) => {
+      if (a.order !== b.order) return a.order - b.order;
+      return a.label.localeCompare(b.label);
+    });
+
+    sortedWeeks.forEach((week) => {
+      const weekSection = document.createElement('section');
+      weekSection.className = 'cards-week';
+      const wkCollapsed = collapsedWeekSections.has(week.key);
+      if (wkCollapsed) weekSection.classList.add('collapsed');
+
+      const weekHeader = document.createElement('div');
+      weekHeader.className = 'cards-week-header';
+      const weekTitle = document.createElement('h3');
+      weekTitle.textContent = week.label;
+      weekHeader.appendChild(weekTitle);
+      const weekMeta = document.createElement('span');
+      const weekCardCount = Array.from(week.decks.values()).reduce((sum, deck) => sum + deck.cards.length, 0);
+      weekMeta.className = 'cards-week-meta';
+      weekMeta.textContent = `${week.decks.size} ${week.decks.size === 1 ? 'deck' : 'decks'} • ${weekCardCount} cards`;
+      weekHeader.appendChild(weekMeta);
+      const weekToggle = document.createElement('button');
+      weekToggle.className = 'icon-btn ghost cards-collapse-btn';
+      weekToggle.textContent = wkCollapsed ? '▸' : '▾';
+      weekToggle.title = wkCollapsed ? 'Expand week' : 'Collapse week';
+      weekToggle.setAttribute('aria-expanded', wkCollapsed ? 'false' : 'true');
+      weekToggle.addEventListener('click', () => {
+        weekSection.classList.toggle('collapsed');
+        const collapsed = weekSection.classList.contains('collapsed');
+        weekToggle.textContent = collapsed ? '▸' : '▾';
+        weekToggle.title = collapsed ? 'Expand week' : 'Collapse week';
+        weekToggle.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+        if (collapsed) collapsedWeekSections.add(week.key);
+        else collapsedWeekSections.delete(week.key);
+        weekContent.hidden = collapsed;
+      });
+      weekHeader.appendChild(weekToggle);
+      weekSection.appendChild(weekHeader);
+
+      const weekContent = document.createElement('div');
+      weekContent.className = 'cards-week-content';
+      weekContent.hidden = wkCollapsed;
+      weekSection.appendChild(weekContent);
+
+      const decks = Array.from(week.decks.values()).sort((a, b) => a.title.localeCompare(b.title));
+      decks.forEach((deck) => {
+        if (!deck.cards.length) return;
+        const deckCard = document.createElement('button');
+        deckCard.type = 'button';
+        deckCard.className = 'cards-deck';
+        const deckTitleEl = document.createElement('span');
+        deckTitleEl.className = 'cards-deck-title';
+        deckTitleEl.textContent = deck.title;
+        const deckCount = document.createElement('span');
+        deckCount.className = 'cards-deck-count';
+        deckCount.textContent = `${deck.cards.length}`;
+        deckCard.append(deckTitleEl, deckCount);
+        deckCard.addEventListener('click', () => {
+          openDeck(blockGroup, week, deck);
+        });
+        weekContent.appendChild(deckCard);
+      });
+
+      content.appendChild(weekSection);
+    });
+
+    browser.appendChild(blockSection);
+  });
+
+  function openDeck(blockGroup, week, deck) {
+    browser.classList.add('hidden');
     viewer.classList.remove('hidden');
     viewer.innerHTML = '';
 
-    const header = document.createElement('h2');
-    header.textContent = title;
+    const header = document.createElement('div');
+    header.className = 'cards-viewer-header';
+    const back = document.createElement('button');
+    back.type = 'button';
+    back.className = 'btn secondary cards-viewer-back';
+    back.textContent = 'Back to collection';
+    back.addEventListener('click', closeDeck);
+    header.appendChild(back);
+
+    const title = document.createElement('h2');
+    title.textContent = deck.title;
+    header.appendChild(title);
+
+    const subtitle = document.createElement('p');
+    subtitle.className = 'cards-viewer-meta';
+    const parts = [];
+    if (blockGroup.blockId) parts.push(`${blockGroup.blockId} • ${blockGroup.title}`);
+    else parts.push('Unassigned');
+    if (week.raw != null) parts.push(`Week ${week.raw}`);
+    subtitle.textContent = parts.join(' • ');
+    header.appendChild(subtitle);
+
     viewer.appendChild(header);
 
     const cardHolder = document.createElement('div');
@@ -99,43 +272,44 @@ export function renderCards(container, items, onChange){
     viewer.appendChild(cardHolder);
 
     const prev = document.createElement('button');
-    prev.className = 'deck-prev';
+    prev.className = 'deck-nav deck-prev';
     prev.textContent = '◀';
     const next = document.createElement('button');
-    next.className = 'deck-next';
+    next.className = 'deck-nav deck-next';
     next.textContent = '▶';
     viewer.appendChild(prev);
     viewer.appendChild(next);
 
-    const toggle = document.createElement('button');
-    toggle.className = 'deck-related-toggle btn';
-    toggle.textContent = 'Show Related';
-    viewer.appendChild(toggle);
+    const toggleRelated = document.createElement('button');
+    toggleRelated.className = 'btn subtle deck-related-toggle';
+    toggleRelated.textContent = 'Show related';
+    viewer.appendChild(toggleRelated);
 
     const relatedWrap = document.createElement('div');
     relatedWrap.className = 'deck-related hidden';
     viewer.appendChild(relatedWrap);
 
-    const close = document.createElement('button');
-    close.className = 'deck-close btn';
-    close.textContent = 'Close';
-    viewer.appendChild(close);
+    const closeBtn = document.createElement('button');
+    closeBtn.className = 'btn secondary deck-close';
+    closeBtn.textContent = 'Close deck';
+    closeBtn.addEventListener('click', closeDeck);
+    viewer.appendChild(closeBtn);
 
-    let idx = 0;
+    let index = 0;
     let showRelated = false;
 
-    function renderCard(){
+    function renderCard() {
       cardHolder.innerHTML = '';
-      cardHolder.appendChild(createItemCard(cards[idx], onChange));
+      cardHolder.appendChild(createItemCard(deck.cards[index], onChange));
       renderRelated();
     }
 
-    function renderRelated(){
+    function renderRelated() {
       relatedWrap.innerHTML = '';
       if (!showRelated) return;
-      const current = cards[idx];
-      (current.links || []).forEach(l => {
-        const item = items.find(it => it.id === l.id);
+      const current = deck.cards[index];
+      (current.links || []).forEach((link) => {
+        const item = items.find((it) => it.id === link.id);
         if (item) {
           const el = createItemCard(item, onChange);
           el.classList.add('related-card');
@@ -145,35 +319,35 @@ export function renderCards(container, items, onChange){
       });
     }
 
-    prev.addEventListener('click', () => {
-      idx = (idx - 1 + cards.length) % cards.length;
+    function step(offset) {
+      index = (index + offset + deck.cards.length) % deck.cards.length;
       renderCard();
-    });
-    next.addEventListener('click', () => {
-      idx = (idx + 1) % cards.length;
-      renderCard();
-    });
+    }
 
-    toggle.addEventListener('click', () => {
+    prev.addEventListener('click', () => step(-1));
+    next.addEventListener('click', () => step(1));
+
+    toggleRelated.addEventListener('click', () => {
       showRelated = !showRelated;
-      toggle.textContent = showRelated ? 'Hide Related' : 'Show Related';
+      toggleRelated.textContent = showRelated ? 'Hide related' : 'Show related';
       relatedWrap.classList.toggle('hidden', !showRelated);
       renderRelated();
     });
 
-    close.addEventListener('click', () => {
-      document.removeEventListener('keydown', keyHandler);
+    function closeDeck() {
+      document.removeEventListener('keydown', handleKeys);
       viewer.classList.add('hidden');
       viewer.innerHTML = '';
-      list.classList.remove('hidden');
-    });
-
-    function keyHandler(e){
-      if (e.key === 'ArrowLeft') prev.click();
-      if (e.key === 'ArrowRight') next.click();
-      if (e.key === 'Escape') close.click();
+      browser.classList.remove('hidden');
     }
-    document.addEventListener('keydown', keyHandler);
+
+    function handleKeys(event) {
+      if (event.key === 'ArrowLeft') step(-1);
+      if (event.key === 'ArrowRight') step(1);
+      if (event.key === 'Escape') closeDeck();
+    }
+
+    document.addEventListener('keydown', handleKeys);
 
     renderCard();
   }

--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -3,296 +3,96 @@ import { confirmModal } from './components/confirm.js';
 
 const collapsedLectureBlocks = new Set();
 
-function isLectureListCollapsed(blockId) {
-  return collapsedLectureBlocks.has(blockId);
+function sectionKey(blockId) {
+  return blockId || '__unassigned__';
 }
 
-function toggleLectureListCollapse(blockId) {
-  if (collapsedLectureBlocks.has(blockId)) {
-    collapsedLectureBlocks.delete(blockId);
-  } else {
-    collapsedLectureBlocks.add(blockId);
+function isBlockCollapsed(blockId) {
+  return collapsedLectureBlocks.has(sectionKey(blockId));
+}
+
+function setBlockCollapsed(blockId, collapsed) {
+  const key = sectionKey(blockId);
+  if (collapsed) collapsedLectureBlocks.add(key);
+  else collapsedLectureBlocks.delete(key);
+}
+
+function createPanel(title, description) {
+  const panel = document.createElement('section');
+  panel.className = 'settings-panel';
+
+  const header = document.createElement('div');
+  header.className = 'settings-panel-header';
+  const heading = document.createElement('h3');
+  heading.textContent = title;
+  header.appendChild(heading);
+  if (description) {
+    const subtitle = document.createElement('p');
+    subtitle.className = 'settings-panel-description';
+    subtitle.textContent = description;
+    header.appendChild(subtitle);
   }
+  panel.appendChild(header);
+
+  const body = document.createElement('div');
+  body.className = 'settings-panel-body';
+  panel.appendChild(body);
+
+  return { panel, body };
 }
 
 export async function renderSettings(root) {
   root.innerHTML = '';
+  root.className = 'settings-root';
 
   const settings = await getSettings();
-
-  const settingsCard = document.createElement('section');
-  settingsCard.className = 'card';
-  const heading = document.createElement('h2');
-  heading.textContent = 'Settings';
-  settingsCard.appendChild(heading);
-
-  const dailyLabel = document.createElement('label');
-  dailyLabel.textContent = 'Daily review target:';
-  const dailyInput = document.createElement('input');
-  dailyInput.type = 'number';
-  dailyInput.className = 'input';
-  dailyInput.min = '1';
-  dailyInput.value = settings.dailyCount;
-  dailyInput.addEventListener('change', () => {
-    saveSettings({ dailyCount: Number(dailyInput.value) });
-  });
-  dailyLabel.appendChild(dailyInput);
-  settingsCard.appendChild(dailyLabel);
-
-  root.appendChild(settingsCard);
-
-  const blocksCard = document.createElement('section');
-  blocksCard.className = 'card';
-  const bHeading = document.createElement('h2');
-  bHeading.textContent = 'Blocks';
-  blocksCard.appendChild(bHeading);
-
-  const list = document.createElement('div');
-  list.className = 'block-list';
-  blocksCard.appendChild(list);
-
   const blocks = await listBlocks();
-  blocks.forEach((b,i) => {
-    const wrap = document.createElement('div');
-    wrap.className = 'block';
-    const lectures = (b.lectures || []).slice().sort((a,b)=> b.week - a.week || b.id - a.id);
-    const lecturesCollapsed = isLectureListCollapsed(b.blockId);
-    const title = document.createElement('h3');
-    title.textContent = `${b.blockId} – ${b.title}`;
-    wrap.appendChild(title);
+  blocks.sort((a, b) => a.order - b.order || a.blockId.localeCompare(b.blockId));
 
-    const wkInfo = document.createElement('div');
-    wkInfo.textContent = `Weeks: ${b.weeks}`;
-    wrap.appendChild(wkInfo);
+  const page = document.createElement('div');
+  page.className = 'settings-page';
+  root.appendChild(page);
 
-    if (lectures.length || lecturesCollapsed) {
-      const toggleLecturesBtn = document.createElement('button');
-      toggleLecturesBtn.type = 'button';
-      toggleLecturesBtn.className = 'btn secondary settings-lecture-toggle';
-      toggleLecturesBtn.textContent = lecturesCollapsed ? 'Show lectures' : 'Hide lectures';
-      toggleLecturesBtn.addEventListener('click', async () => {
-        toggleLectureListCollapse(b.blockId);
-        await renderSettings(root);
-      });
-      wrap.appendChild(toggleLecturesBtn);
-    }
+  const hero = document.createElement('header');
+  hero.className = 'settings-hero';
+  const title = document.createElement('h1');
+  title.textContent = 'Settings';
+  const intro = document.createElement('p');
+  intro.textContent = 'Tune your study experience, manage curriculum structure, and keep your data in sync with the rest of Sevenn.';
+  hero.append(title, intro);
+  page.appendChild(hero);
 
-    const controls = document.createElement('div');
-    controls.className = 'row';
+  const panels = document.createElement('div');
+  panels.className = 'settings-panels';
+  page.appendChild(panels);
 
-    const upBtn = document.createElement('button');
-    upBtn.className = 'btn';
-    upBtn.textContent = '↑';
-    upBtn.disabled = i === 0;
-    upBtn.addEventListener('click', async () => {
-      const other = blocks[i-1];
-      const tmp = b.order; b.order = other.order; other.order = tmp;
-      await upsertBlock(b); await upsertBlock(other);
-      await renderSettings(root);
-    });
-    controls.appendChild(upBtn);
-
-    const downBtn = document.createElement('button');
-    downBtn.className = 'btn';
-    downBtn.textContent = '↓';
-    downBtn.disabled = i === blocks.length - 1;
-    downBtn.addEventListener('click', async () => {
-      const other = blocks[i+1];
-      const tmp = b.order; b.order = other.order; other.order = tmp;
-      await upsertBlock(b); await upsertBlock(other);
-      await renderSettings(root);
-    });
-    controls.appendChild(downBtn);
-
-    const edit = document.createElement('button');
-    edit.className = 'btn';
-    edit.textContent = 'Edit';
-    controls.appendChild(edit);
-
-    const del = document.createElement('button');
-    del.className = 'btn';
-    del.textContent = 'Delete';
-    del.addEventListener('click', async () => {
-      if (await confirmModal('Delete block?')) {
-        await deleteBlock(b.blockId);
-        await renderSettings(root);
-      }
-    });
-    controls.appendChild(del);
-    wrap.appendChild(controls);
-
-    const editForm = document.createElement('form');
-    editForm.className = 'row';
-    editForm.style.display = 'none';
-    const titleInput = document.createElement('input');
-    titleInput.className = 'input';
-    titleInput.value = b.title;
-    const weeksInput = document.createElement('input');
-    weeksInput.className = 'input';
-    weeksInput.type = 'number';
-    weeksInput.value = b.weeks;
-    const colorInput = document.createElement('input');
-    colorInput.className = 'input';
-    colorInput.type = 'color';
-    colorInput.value = b.color || '#ffffff';
-    const saveBtn = document.createElement('button');
-    saveBtn.className = 'btn';
-    saveBtn.type = 'submit';
-    saveBtn.textContent = 'Save';
-    editForm.append(titleInput, weeksInput, colorInput, saveBtn);
-    editForm.addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const updated = { ...b, title: titleInput.value.trim(), weeks: Number(weeksInput.value), color: colorInput.value };
-      await upsertBlock(updated);
-      await renderSettings(root);
-    });
-    wrap.appendChild(editForm);
-
-    edit.addEventListener('click', () => {
-      editForm.style.display = editForm.style.display === 'none' ? 'flex' : 'none';
-    });
-
-    const lectureSection = document.createElement('div');
-    lectureSection.className = 'settings-lecture-section';
-    lectureSection.hidden = lecturesCollapsed;
-
-    const lecList = document.createElement('ul');
-    lectures.forEach(l => {
-      const li = document.createElement('li');
-      li.className = 'row';
-      const span = document.createElement('span');
-      span.textContent = `${l.id}: ${l.name} (W${l.week})`;
-      li.appendChild(span);
-
-      const editLec = document.createElement('button');
-      editLec.className = 'btn';
-      editLec.textContent = 'Edit';
-      const delLec = document.createElement('button');
-      delLec.className = 'btn';
-      delLec.textContent = 'Delete';
-
-      editLec.addEventListener('click', () => {
-        li.innerHTML = '';
-        li.className = 'row';
-        const nameInput = document.createElement('input');
-        nameInput.className = 'input';
-        nameInput.value = l.name;
-        const weekInput = document.createElement('input');
-        weekInput.className = 'input';
-        weekInput.type = 'number';
-        weekInput.value = l.week;
-        const saveBtn = document.createElement('button');
-        saveBtn.className = 'btn';
-        saveBtn.textContent = 'Save';
-        const cancelBtn = document.createElement('button');
-        cancelBtn.className = 'btn';
-        cancelBtn.textContent = 'Cancel';
-        li.append(nameInput, weekInput, saveBtn, cancelBtn);
-        saveBtn.addEventListener('click', async () => {
-          const name = nameInput.value.trim();
-          const week = Number(weekInput.value);
-          if (!name || !week || week < 1 || week > b.weeks) return;
-          await updateLecture(b.blockId, { id: l.id, name, week });
-          await renderSettings(root);
-        });
-        cancelBtn.addEventListener('click', async () => {
-          await renderSettings(root);
-        });
-      });
-
-      delLec.addEventListener('click', async () => {
-        if (await confirmModal('Delete lecture?')) {
-          await deleteLecture(b.blockId, l.id);
-          await renderSettings(root);
-        }
-      });
-
-      li.append(editLec, delLec);
-      lecList.appendChild(li);
-    });
-    lectureSection.appendChild(lecList);
-
-    const lecForm = document.createElement('form');
-    lecForm.className = 'row';
-    const idInput = document.createElement('input');
-    idInput.className = 'input';
-    idInput.placeholder = 'id';
-    idInput.type = 'number';
-    const nameInput = document.createElement('input');
-    nameInput.className = 'input';
-    nameInput.placeholder = 'name';
-    const weekInput = document.createElement('input');
-    weekInput.className = 'input';
-    weekInput.placeholder = 'week';
-    weekInput.type = 'number';
-    const addBtn = document.createElement('button');
-    addBtn.className = 'btn';
-    addBtn.type = 'submit';
-    addBtn.textContent = 'Add lecture';
-    lecForm.append(idInput, nameInput, weekInput, addBtn);
-    lecForm.addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const lecture = { id: Number(idInput.value), name: nameInput.value.trim(), week: Number(weekInput.value) };
-      if (!lecture.id || !lecture.name || !lecture.week) return;
-      if (lecture.week < 1 || lecture.week > b.weeks) return;
-      const updated = { ...b, lectures: [...b.lectures, lecture] };
-      await upsertBlock(updated);
-      await renderSettings(root);
-    });
-    lectureSection.appendChild(lecForm);
-
-    wrap.appendChild(lectureSection);
-
-    list.appendChild(wrap);
+  const { panel: goalPanel, body: goalBody } = createPanel('Study goals', 'Set your daily target so the review queue stays manageable.');
+  const goalField = document.createElement('label');
+  goalField.className = 'settings-field';
+  goalField.textContent = 'Daily review target';
+  const goalHint = document.createElement('span');
+  goalHint.className = 'settings-field-hint';
+  goalHint.textContent = 'Number of cards to review each day';
+  goalField.appendChild(goalHint);
+  const goalInput = document.createElement('input');
+  goalInput.type = 'number';
+  goalInput.className = 'input';
+  goalInput.min = '1';
+  goalInput.value = settings.dailyCount;
+  goalInput.addEventListener('change', () => {
+    saveSettings({ dailyCount: Number(goalInput.value) });
   });
+  goalField.appendChild(goalInput);
+  goalBody.appendChild(goalField);
+  panels.appendChild(goalPanel);
 
-  const form = document.createElement('form');
-  form.className = 'row';
-  const id = document.createElement('input');
-  id.className = 'input';
-  id.placeholder = 'ID';
-  const titleInput = document.createElement('input');
-  titleInput.className = 'input';
-  titleInput.placeholder = 'Title';
-  const weeks = document.createElement('input');
-  weeks.className = 'input';
-  weeks.type = 'number';
-  weeks.placeholder = 'Weeks';
-  const color = document.createElement('input');
-  color.className = 'input';
-  color.type = 'color';
-  color.value = '#ffffff';
-  const add = document.createElement('button');
-  add.className = 'btn';
-  add.type = 'submit';
-  add.textContent = 'Add block';
-  form.append(id, titleInput, weeks, color, add);
-  form.addEventListener('submit', async (e) => {
-    e.preventDefault();
-    const def = {
-      blockId: id.value.trim(),
-      title: titleInput.value.trim(),
-      weeks: Number(weeks.value),
-      color: color.value,
-      lectures: [],
-    };
-    if (!def.blockId || !def.title || !def.weeks) return;
-    await upsertBlock(def);
-    await renderSettings(root);
-  });
-  blocksCard.appendChild(form);
-
-  root.appendChild(blocksCard);
-
-  const dataCard = document.createElement('section');
-  dataCard.className = 'card';
-  const dHeading = document.createElement('h2');
-  dHeading.textContent = 'Data';
-  dataCard.appendChild(dHeading);
+  const { panel: dataPanel, body: dataBody } = createPanel('Data & backups', 'Keep a local copy of your work or bring in data from elsewhere.');
+  const dataActions = document.createElement('div');
+  dataActions.className = 'settings-action-grid';
 
   const exportBtn = document.createElement('button');
   exportBtn.className = 'btn';
-  exportBtn.textContent = 'Export DB';
+  exportBtn.textContent = 'Export database';
   exportBtn.addEventListener('click', async () => {
     const dump = await exportJSON();
     const blob = new Blob([JSON.stringify(dump, null, 2)], { type: 'application/json' });
@@ -302,14 +102,17 @@ export async function renderSettings(root) {
     a.click();
     URL.revokeObjectURL(a.href);
   });
-  dataCard.appendChild(exportBtn);
+  dataActions.appendChild(exportBtn);
 
+  const importBtn = document.createElement('button');
+  importBtn.className = 'btn secondary';
+  importBtn.textContent = 'Import database';
   const importInput = document.createElement('input');
   importInput.type = 'file';
   importInput.accept = 'application/json';
-  importInput.style.display = 'none';
+  importInput.hidden = true;
   importInput.addEventListener('change', async () => {
-    const file = importInput.files[0];
+    const file = importInput.files?.[0];
     if (!file) return;
     try {
       const text = await file.text();
@@ -317,20 +120,15 @@ export async function renderSettings(root) {
       const res = await importJSON(json);
       alert(res.message);
       location.reload();
-    } catch (e) {
+    } catch (err) {
       alert('Import failed');
     }
   });
-
-  const importBtn = document.createElement('button');
-  importBtn.className = 'btn';
-  importBtn.textContent = 'Import DB';
   importBtn.addEventListener('click', () => importInput.click());
-  dataCard.appendChild(importBtn);
-  dataCard.appendChild(importInput);
+  dataActions.appendChild(importBtn);
 
   const ankiBtn = document.createElement('button');
-  ankiBtn.className = 'btn';
+  ankiBtn.className = 'btn secondary';
   ankiBtn.textContent = 'Export Anki CSV';
   ankiBtn.addEventListener('click', async () => {
     const dump = await exportJSON();
@@ -341,7 +139,344 @@ export async function renderSettings(root) {
     a.click();
     URL.revokeObjectURL(a.href);
   });
-  dataCard.appendChild(ankiBtn);
+  dataActions.appendChild(ankiBtn);
 
-  root.appendChild(dataCard);
+  dataBody.appendChild(dataActions);
+  dataBody.appendChild(importInput);
+  panels.appendChild(dataPanel);
+
+  const { panel: blockPanel, body: blockBody } = createPanel('Curriculum blocks', 'Organise blocks, weeks, and lectures to match the way you study.');
+  blockPanel.classList.add('settings-panel-wide');
+  page.appendChild(blockPanel);
+
+  const blockList = document.createElement('div');
+  blockList.className = 'settings-block-list';
+  blockBody.appendChild(blockList);
+
+  if (!blocks.length) {
+    const empty = document.createElement('p');
+    empty.className = 'settings-empty';
+    empty.textContent = 'No blocks yet. Use the form below to start building your curriculum structure.';
+    blockList.appendChild(empty);
+  } else {
+    blocks.forEach((block, index) => {
+      blockList.appendChild(createBlockCard(block, index));
+    });
+  }
+
+  const createWrap = document.createElement('div');
+  createWrap.className = 'settings-block-create-wrap';
+  const createTitle = document.createElement('h4');
+  createTitle.textContent = 'Add new block';
+  createWrap.appendChild(createTitle);
+
+  const createForm = document.createElement('form');
+  createForm.className = 'settings-inline-form settings-block-create';
+  const idInput = document.createElement('input');
+  idInput.className = 'input';
+  idInput.placeholder = 'ID';
+  const titleInput = document.createElement('input');
+  titleInput.className = 'input';
+  titleInput.placeholder = 'Title';
+  const weeksInput = document.createElement('input');
+  weeksInput.className = 'input';
+  weeksInput.type = 'number';
+  weeksInput.min = '1';
+  weeksInput.placeholder = 'Weeks';
+  const colorInput = document.createElement('input');
+  colorInput.className = 'input';
+  colorInput.type = 'color';
+  colorInput.value = '#ffffff';
+  const addBtn = document.createElement('button');
+  addBtn.className = 'btn';
+  addBtn.type = 'submit';
+  addBtn.textContent = 'Create block';
+  createForm.append(idInput, titleInput, weeksInput, colorInput, addBtn);
+  createForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const def = {
+      blockId: idInput.value.trim(),
+      title: titleInput.value.trim(),
+      weeks: Number(weeksInput.value),
+      color: colorInput.value,
+      lectures: [],
+    };
+    if (!def.blockId || !def.title || !def.weeks) return;
+    await upsertBlock(def);
+    await renderSettings(root);
+  });
+  createWrap.appendChild(createForm);
+  blockBody.appendChild(createWrap);
+
+  function createBlockCard(block, index) {
+    const card = document.createElement('article');
+    card.className = 'settings-block-card';
+    card.style.setProperty('--block-color', block.color || '#38bdf8');
+    let collapsed = isBlockCollapsed(block.blockId);
+    if (collapsed) card.classList.add('collapsed');
+
+    const header = document.createElement('div');
+    header.className = 'settings-block-header';
+    card.appendChild(header);
+
+    const info = document.createElement('div');
+    info.className = 'settings-block-info';
+    const badge = document.createElement('span');
+    badge.className = 'settings-block-id';
+    badge.textContent = block.blockId;
+    const name = document.createElement('h4');
+    name.className = 'settings-block-title';
+    name.textContent = block.title;
+    const meta = document.createElement('p');
+    meta.className = 'settings-block-meta';
+    const lectures = (block.lectures || []).slice().sort((a, b) => a.week - b.week || a.id - b.id);
+    const metaParts = [];
+    metaParts.push(`${block.weeks} ${block.weeks === 1 ? 'week' : 'weeks'}`);
+    metaParts.push(`${lectures.length} ${lectures.length === 1 ? 'lecture' : 'lectures'}`);
+    meta.textContent = metaParts.join(' • ');
+    info.append(badge, name, meta);
+    header.appendChild(info);
+
+    const actions = document.createElement('div');
+    actions.className = 'settings-block-actions';
+
+    const collapseBtn = document.createElement('button');
+    collapseBtn.className = 'icon-btn ghost settings-collapse-btn';
+    const updateCollapseBtn = () => {
+      collapseBtn.textContent = collapsed ? '▸' : '▾';
+      collapseBtn.title = collapsed ? 'Show lectures' : 'Hide lectures';
+      collapseBtn.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+    };
+    updateCollapseBtn();
+    collapseBtn.addEventListener('click', () => {
+      collapsed = !collapsed;
+      card.classList.toggle('collapsed', collapsed);
+      content.hidden = collapsed;
+      setBlockCollapsed(block.blockId, collapsed);
+      updateCollapseBtn();
+    });
+    actions.appendChild(collapseBtn);
+
+    const upBtn = document.createElement('button');
+    upBtn.className = 'icon-btn ghost';
+    upBtn.textContent = '▲';
+    upBtn.title = 'Move up';
+    upBtn.disabled = index === 0;
+    if (!upBtn.disabled) {
+      upBtn.addEventListener('click', async () => {
+        const other = blocks[index - 1];
+        const tmp = block.order; block.order = other.order; other.order = tmp;
+        await upsertBlock(block); await upsertBlock(other);
+        await renderSettings(root);
+      });
+    }
+    actions.appendChild(upBtn);
+
+    const downBtn = document.createElement('button');
+    downBtn.className = 'icon-btn ghost';
+    downBtn.textContent = '▼';
+    downBtn.title = 'Move down';
+    downBtn.disabled = index === blocks.length - 1;
+    if (!downBtn.disabled) {
+      downBtn.addEventListener('click', async () => {
+        const other = blocks[index + 1];
+        const tmp = block.order; block.order = other.order; other.order = tmp;
+        await upsertBlock(block); await upsertBlock(other);
+        await renderSettings(root);
+      });
+    }
+    actions.appendChild(downBtn);
+
+    const editBtn = document.createElement('button');
+    editBtn.className = 'icon-btn ghost';
+    editBtn.textContent = '✎';
+    editBtn.title = 'Edit block';
+    actions.appendChild(editBtn);
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.className = 'icon-btn danger';
+    deleteBtn.textContent = '🗑';
+    deleteBtn.title = 'Delete block';
+    deleteBtn.addEventListener('click', async () => {
+      if (await confirmModal('Delete block?')) {
+        await deleteBlock(block.blockId);
+        await renderSettings(root);
+      }
+    });
+    actions.appendChild(deleteBtn);
+
+    header.appendChild(actions);
+
+    const content = document.createElement('div');
+    content.className = 'settings-block-content';
+    content.hidden = collapsed;
+    card.appendChild(content);
+
+    const editForm = document.createElement('form');
+    editForm.className = 'settings-inline-form settings-block-edit';
+    editForm.hidden = true;
+    const editTitle = document.createElement('input');
+    editTitle.className = 'input';
+    editTitle.value = block.title;
+    const editWeeks = document.createElement('input');
+    editWeeks.className = 'input';
+    editWeeks.type = 'number';
+    editWeeks.min = '1';
+    editWeeks.value = block.weeks;
+    const editColor = document.createElement('input');
+    editColor.className = 'input';
+    editColor.type = 'color';
+    editColor.value = block.color || '#ffffff';
+    const saveBtn = document.createElement('button');
+    saveBtn.className = 'btn';
+    saveBtn.type = 'submit';
+    saveBtn.textContent = 'Save changes';
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'btn secondary';
+    cancelBtn.type = 'button';
+    cancelBtn.textContent = 'Cancel';
+    editForm.append(editTitle, editWeeks, editColor, saveBtn, cancelBtn);
+    editForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const updated = { ...block, title: editTitle.value.trim(), weeks: Number(editWeeks.value), color: editColor.value };
+      await upsertBlock(updated);
+      await renderSettings(root);
+    });
+    cancelBtn.addEventListener('click', () => {
+      editTitle.value = block.title;
+      editWeeks.value = block.weeks;
+      editColor.value = block.color || '#ffffff';
+      editForm.hidden = true;
+      editBtn.setAttribute('aria-expanded', 'false');
+    });
+    content.appendChild(editForm);
+
+    editBtn.addEventListener('click', () => {
+      const showing = !editForm.hidden;
+      editForm.hidden = showing;
+      editBtn.setAttribute('aria-expanded', showing ? 'false' : 'true');
+    });
+
+    const lectureSection = document.createElement('section');
+    lectureSection.className = 'settings-lecture-section';
+    content.appendChild(lectureSection);
+
+    if (!lectures.length) {
+      const empty = document.createElement('p');
+      empty.className = 'settings-empty';
+      empty.textContent = 'No lectures yet for this block.';
+      lectureSection.appendChild(empty);
+    } else {
+      const lectureList = document.createElement('div');
+      lectureList.className = 'settings-lecture-list';
+      lectureSection.appendChild(lectureList);
+
+      lectures.forEach((lecture) => {
+        const row = document.createElement('div');
+        row.className = 'settings-lecture-row';
+
+        const details = document.createElement('div');
+        details.className = 'settings-lecture-info';
+        const nameEl = document.createElement('div');
+        nameEl.className = 'settings-lecture-name';
+        nameEl.textContent = lecture.name;
+        const metaEl = document.createElement('div');
+        metaEl.className = 'settings-lecture-meta';
+        metaEl.textContent = `Week ${lecture.week} • ID ${lecture.id}`;
+        details.append(nameEl, metaEl);
+        row.appendChild(details);
+
+        const rowActions = document.createElement('div');
+        rowActions.className = 'settings-lecture-actions';
+        const editLectureBtn = document.createElement('button');
+        editLectureBtn.className = 'icon-btn ghost';
+        editLectureBtn.textContent = '✎';
+        editLectureBtn.title = 'Edit lecture';
+        const deleteLectureBtn = document.createElement('button');
+        deleteLectureBtn.className = 'icon-btn danger';
+        deleteLectureBtn.textContent = '🗑';
+        deleteLectureBtn.title = 'Delete lecture';
+        rowActions.append(editLectureBtn, deleteLectureBtn);
+        row.appendChild(rowActions);
+
+        editLectureBtn.addEventListener('click', () => {
+          const form = document.createElement('form');
+          form.className = 'settings-inline-form settings-lecture-edit';
+          const nameInput = document.createElement('input');
+          nameInput.className = 'input';
+          nameInput.value = lecture.name;
+          const weekInput = document.createElement('input');
+          weekInput.className = 'input';
+          weekInput.type = 'number';
+          weekInput.min = '1';
+          weekInput.max = block.weeks;
+          weekInput.value = lecture.week;
+          const saveLectureBtn = document.createElement('button');
+          saveLectureBtn.className = 'btn';
+          saveLectureBtn.type = 'submit';
+          saveLectureBtn.textContent = 'Save';
+          const cancelLectureBtn = document.createElement('button');
+          cancelLectureBtn.className = 'btn secondary';
+          cancelLectureBtn.type = 'button';
+          cancelLectureBtn.textContent = 'Cancel';
+          form.append(nameInput, weekInput, saveLectureBtn, cancelLectureBtn);
+          row.replaceChildren(form);
+          form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const name = nameInput.value.trim();
+            const week = Number(weekInput.value);
+            if (!name || !week || week < 1 || week > block.weeks) return;
+            await updateLecture(block.blockId, { id: lecture.id, name, week });
+            await renderSettings(root);
+          });
+          cancelLectureBtn.addEventListener('click', async () => {
+            await renderSettings(root);
+          });
+        });
+
+        deleteLectureBtn.addEventListener('click', async () => {
+          if (await confirmModal('Delete lecture?')) {
+            await deleteLecture(block.blockId, lecture.id);
+            await renderSettings(root);
+          }
+        });
+
+        lectureList.appendChild(row);
+      });
+    }
+
+    const lectureForm = document.createElement('form');
+    lectureForm.className = 'settings-inline-form settings-lecture-add';
+    const lectureId = document.createElement('input');
+    lectureId.className = 'input';
+    lectureId.placeholder = 'Lecture ID';
+    lectureId.type = 'number';
+    lectureId.min = '1';
+    const lectureName = document.createElement('input');
+    lectureName.className = 'input';
+    lectureName.placeholder = 'Lecture name';
+    const lectureWeek = document.createElement('input');
+    lectureWeek.className = 'input';
+    lectureWeek.placeholder = 'Week';
+    lectureWeek.type = 'number';
+    lectureWeek.min = '1';
+    lectureWeek.max = block.weeks;
+    const lectureAdd = document.createElement('button');
+    lectureAdd.className = 'btn subtle';
+    lectureAdd.type = 'submit';
+    lectureAdd.textContent = 'Add lecture';
+    lectureForm.append(lectureId, lectureName, lectureWeek, lectureAdd);
+    lectureForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+    const lecture = { id: Number(lectureId.value), name: lectureName.value.trim(), week: Number(lectureWeek.value) };
+    if (!lecture.id || !lecture.name || !lecture.week) return;
+    if (lecture.week < 1 || lecture.week > block.weeks) return;
+    const updated = { ...block, lectures: [...(block.lectures || []), lecture] };
+      await upsertBlock(updated);
+      await renderSettings(root);
+    });
+    lectureSection.appendChild(lectureForm);
+
+    return card;
+  }
 }

--- a/style.css
+++ b/style.css
@@ -164,6 +164,269 @@ button:not(.tab):not(.fab-btn):hover {
   flex-wrap: wrap;
 }
 
+/* Settings */
+.settings-root {
+  padding: var(--pad-lg);
+  display: flex;
+  justify-content: center;
+  overflow: auto;
+}
+
+.settings-page {
+  width: min(1200px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-lg);
+  padding-bottom: 96px;
+}
+
+.settings-hero {
+  background: linear-gradient(145deg, rgba(56, 189, 248, 0.18), rgba(192, 132, 252, 0.12));
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  border-radius: var(--radius-lg);
+  padding: clamp(20px, 4vw, 36px);
+  box-shadow: 0 24px 60px rgba(2, 6, 23, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.settings-hero h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 2.4vw, 2rem);
+}
+
+.settings-hero p {
+  margin: 0;
+  color: rgba(248, 250, 252, 0.75);
+  max-width: 46ch;
+  font-size: 0.95rem;
+}
+
+.settings-panels {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--pad-lg);
+}
+
+.settings-panel {
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.85), rgba(8, 13, 23, 0.92));
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: var(--radius-lg);
+  padding: clamp(18px, 3.4vw, 32px);
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  box-shadow: 0 18px 45px rgba(2, 6, 23, 0.4);
+}
+
+.settings-panel-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.settings-panel-header h3 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.settings-panel-description {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.settings-panel-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+}
+
+.settings-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.settings-field-hint {
+  font-size: 0.8rem;
+  font-weight: 400;
+  color: var(--text-muted);
+}
+
+.settings-action-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.settings-panel-wide {
+  background: linear-gradient(170deg, rgba(15, 23, 42, 0.82), rgba(2, 6, 23, 0.88));
+}
+
+.settings-block-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+}
+
+.settings-block-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  padding: clamp(18px, 3vw, 28px);
+  border-radius: var(--radius-lg);
+  background: rgba(8, 13, 23, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  overflow: hidden;
+}
+
+.settings-block-card::before {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  pointer-events: none;
+}
+
+.settings-block-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  width: 6px;
+  background: linear-gradient(180deg, var(--block-accent, var(--accent)), rgba(56, 189, 248, 0));
+  opacity: 0.85;
+  border-radius: var(--radius-lg) 0 0 var(--radius-lg);
+}
+
+.settings-block-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--pad);
+}
+
+.settings-block-info {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-left: 12px;
+}
+
+.settings-block-id {
+  align-self: flex-start;
+  background: rgba(56, 189, 248, 0.16);
+  color: var(--accent);
+  border-radius: 999px;
+  padding: 4px 12px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.settings-block-title {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.settings-block-meta {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.settings-block-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.settings-block-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  padding-left: 12px;
+}
+
+.settings-block-card.collapsed .settings-block-content {
+  display: none;
+}
+
+.settings-inline-form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+  align-items: center;
+}
+
+.settings-lecture-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+}
+
+.settings-lecture-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.settings-lecture-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: var(--radius);
+  background: rgba(15, 23, 42, 0.5);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.settings-lecture-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+}
+
+.settings-lecture-name {
+  font-weight: 600;
+}
+
+.settings-lecture-meta {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.settings-lecture-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.settings-empty {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.settings-block-create-wrap {
+  border-top: 1px solid rgba(148, 163, 184, 0.16);
+  padding-top: var(--pad);
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+}
+
+.settings-block-create-wrap h4 {
+  margin: 0;
+  font-size: 1rem;
+}
+
 
 .entry-add-control {
   position: fixed;
@@ -744,8 +1007,8 @@ input[type="checkbox"]:checked::after {
   display: flex;
   flex-direction: column;
   gap: var(--pad);
-  min-height: 220px;
-  max-height: clamp(280px, 46vh, 420px);
+  min-height: 280px;
+  max-height: clamp(360px, 55vh, 520px);
   overflow: hidden;
 }
 
@@ -764,7 +1027,7 @@ input[type="checkbox"]:checked::after {
 .editor-block-panels {
   display: flex;
   flex-direction: column;
-  gap: var(--pad-sm);
+  gap: var(--pad);
   overflow-y: auto;
   padding-right: 6px;
   flex: 1;
@@ -774,10 +1037,10 @@ input[type="checkbox"]:checked::after {
   display: flex;
   flex-direction: column;
   gap: var(--pad-sm);
-  padding: var(--pad-sm);
+  padding: 14px 16px;
   border-radius: var(--radius);
   border: 1px solid rgba(148, 163, 184, 0.22);
-  background: rgba(8, 13, 23, 0.65);
+  background: rgba(8, 13, 23, 0.7);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
 }
 
@@ -947,33 +1210,35 @@ input[type="checkbox"]:checked::after {
 .rich-editor {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  background: rgba(15, 23, 42, 0.4);
-  border: 1px solid var(--border);
+  gap: 10px;
+  background: rgba(15, 23, 42, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.28);
   border-radius: var(--radius);
-  padding: var(--pad-sm);
+  padding: 14px;
 }
 
 .rich-editor-toolbar {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 6px;
   align-items: center;
+  background: rgba(8, 13, 23, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: var(--radius-sm);
+  padding: 6px;
 }
 
 .rich-editor-group {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 4px 6px;
-  border-radius: var(--radius-sm);
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  background: rgba(8, 13, 23, 0.6);
-  backdrop-filter: blur(6px);
+  gap: 4px;
+  padding: 0;
+  border: none;
+  background: transparent;
 }
 
 .rich-editor-label {
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--text-muted);
@@ -983,15 +1248,15 @@ input[type="checkbox"]:checked::after {
   background: transparent;
   border: none;
   color: var(--text-muted);
-  padding: 6px 8px;
-  font-size: 0.9rem;
+  padding: 4px 6px;
+  font-size: 0.85rem;
   cursor: pointer;
-  border-radius: var(--radius-sm);
+  border-radius: 8px;
 }
 
 .rich-editor-btn:hover,
 .rich-editor-btn:focus {
-  background: var(--muted);
+  background: rgba(148, 163, 184, 0.18);
   color: var(--text);
   outline: none;
 }
@@ -1002,39 +1267,39 @@ input[type="checkbox"]:checked::after {
 }
 
 .rich-editor-color input {
-  width: 34px;
-  height: 30px;
+  width: 28px;
+  height: 26px;
   border: 1px solid rgba(148, 163, 184, 0.25);
-  border-radius: var(--radius-sm);
+  border-radius: 8px;
   background: rgba(15, 23, 42, 0.4);
   padding: 0;
   cursor: pointer;
 }
 
 .rich-editor-highlight-group {
-  gap: 8px;
+  gap: 6px;
 }
 
 .rich-editor-swatch {
-  width: 26px;
-  height: 26px;
+  width: 22px;
+  height: 22px;
   border-radius: 50%;
-  border: 2px solid rgba(8, 13, 23, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.35);
   background: var(--swatch-color, transparent);
-  box-shadow: 0 0 0 2px rgba(148, 163, 184, 0.25);
+  box-shadow: none;
   cursor: pointer;
 }
 
 .rich-editor-swatch:hover,
 .rich-editor-swatch:focus {
-  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.45);
+  border-color: rgba(56, 189, 248, 0.6);
   outline: none;
 }
 
 .rich-editor-swatch--clear {
   background: rgba(15, 23, 42, 0.6);
   color: var(--text-muted);
-  font-size: 0.85rem;
+  font-size: 0.75rem;
   line-height: 1;
 }
 
@@ -1045,25 +1310,27 @@ input[type="checkbox"]:checked::after {
 
 .rich-editor-select,
 .rich-editor-size {
-  background: rgba(15, 23, 42, 0.6);
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  border-radius: var(--radius-sm);
+  background: rgba(15, 23, 42, 0.5);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 8px;
   color: var(--text);
-  padding: 6px 10px;
+  padding: 4px 8px;
   cursor: pointer;
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   min-width: 120px;
 }
 
 .rich-editor-area {
   min-height: 150px;
-  padding: 12px;
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
   border-radius: var(--radius);
   background: rgba(2, 6, 23, 0.55);
   overflow: auto;
   word-break: break-word;
   backdrop-filter: blur(4px);
+  font-size: 0.95rem;
+  line-height: 1.6;
 }
 
 .rich-editor-area:focus {
@@ -2105,137 +2372,287 @@ input[type="checkbox"]:checked::after {
   display: block;
 }
 
-/* Decks */
-.deck-list {
-  display:flex;
-  flex-wrap:wrap;
-  gap:var(--pad);
-  padding:var(--pad);
-}
-.deck {
-  background:var(--panel);
-  border:1px solid var(--border);
-  border-radius:var(--radius);
-  padding:var(--pad-lg);
-  cursor:pointer;
-  box-shadow:0 2px 4px rgba(0,0,0,0.2);
-  position:relative;
-  width:200px;
-  display:flex;
-  flex-direction:column;
-  align-items:center;
-  text-align:center;
-  transition:transform 0.3s ease;
-}
-.deck-title { font-weight:600; margin-bottom:4px; }
-.deck-meta { font-size:0.85rem; color:var(--gray); }
-.deck.pop { transform:scale(1.05); z-index:2; }
-.deck-fan {
-  position:absolute;
-  top:50%;
-  left:50%;
-  transform:translate(-50%,-50%);
-  pointer-events:none;
-}
-.deck-fan .fan-card {
-  position:absolute;
-  width:70px;
-  height:90px;
-  background:var(--panel);
-  border:1px solid var(--border);
-  border-radius:var(--radius);
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  font-size:0.65rem;
-  color:var(--text);
-  opacity:0;
-  transform-origin:bottom center;
-  transition:opacity 0.3s ease, transform 0.3s ease;
-  white-space:nowrap;
-  overflow:hidden;
-  text-overflow:ellipsis;
-}
-.deck-viewer {
-  position: relative;
-  text-align: center;
-  padding: var(--pad);
+/* Cards */
+.cards-workspace {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  min-height: 70vh;
+  gap: var(--pad-lg);
+  padding: var(--pad-lg);
 }
+
+.cards-browser {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-lg);
+}
+
+.cards-block {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  background: linear-gradient(150deg, rgba(15, 23, 42, 0.88), rgba(2, 6, 23, 0.9));
+  border-radius: var(--radius-lg);
+  padding: clamp(20px, 3vw, 32px);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  box-shadow: 0 24px 55px rgba(2, 6, 23, 0.42);
+}
+
+.cards-block::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  pointer-events: none;
+}
+
+.cards-block::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 5px;
+  border-radius: var(--radius-lg) 0 0 var(--radius-lg);
+  background: linear-gradient(180deg, var(--block-accent, rgba(56, 189, 248, 0.75)), transparent);
+  opacity: 0.9;
+}
+
+.cards-block-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--pad);
+}
+
+.cards-block-info {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-left: 8px;
+}
+
+.cards-block-info h2 {
+  margin: 0;
+  font-size: clamp(1.2rem, 2vw, 1.35rem);
+}
+
+.cards-block-meta {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.cards-collapse-btn {
+  margin-left: auto;
+}
+
+.cards-block-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  padding-left: 8px;
+}
+
+.cards-block.collapsed .cards-block-content {
+  display: none;
+}
+
+.cards-week {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+  padding: var(--pad);
+  border-radius: var(--radius);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(8, 13, 23, 0.65);
+}
+
+.cards-week.collapsed {
+  opacity: 0.7;
+}
+
+.cards-week-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--pad);
+}
+
+.cards-week-header h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.cards-week-meta {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.cards-week-content {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--pad);
+}
+
+.cards-week.collapsed .cards-week-content {
+  display: none;
+}
+
+.cards-deck {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: var(--radius);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(15, 23, 42, 0.55);
+  color: inherit;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.cards-deck:hover {
+  transform: translateY(-2px);
+  border-color: rgba(56, 189, 248, 0.45);
+  box-shadow: 0 18px 36px rgba(2, 6, 23, 0.35);
+}
+
+.cards-deck-title {
+  flex: 1;
+  text-align: left;
+}
+
+.cards-deck-count {
+  background: rgba(56, 189, 248, 0.16);
+  color: var(--accent);
+  border-radius: 999px;
+  padding: 4px 12px;
+  font-size: 0.85rem;
+}
+
+.cards-empty {
+  text-align: center;
+  padding: clamp(32px, 8vw, 48px);
+  border-radius: var(--radius-lg);
+  border: 1px dashed rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.45);
+  color: var(--text-muted);
+}
+
+.cards-viewer {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  background: linear-gradient(155deg, rgba(15, 23, 42, 0.9), rgba(2, 6, 23, 0.94));
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  padding: clamp(24px, 4vw, 36px);
+  box-shadow: 0 28px 60px rgba(2, 6, 23, 0.5);
+  min-height: 65vh;
+}
+
+.cards-viewer-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: flex-start;
+}
+
+.cards-viewer-header h2 {
+  margin: 0;
+}
+
+.cards-viewer-meta {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.cards-viewer-back {
+  align-self: flex-start;
+}
+
 .deck-card {
-  margin:0 auto;
+  margin: 0;
+  width: 100%;
+  max-width: 820px;
+  align-self: center;
 }
 
 .deck-card .item-card {
-  width:40vw;
-  height:20vh;
-  overflow:hidden;
-  display:flex;
-  flex-direction:column;
-}
-
-.deck-card .item-card.expanded {
-  height:70vh;
+  width: 100%;
+  max-height: 65vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 .deck-card .item-card .card-body {
-  display:none;
-  flex:1;
-  overflow:auto;
+  flex: 1;
+  overflow: auto;
 }
 
-.deck-card .item-card.expanded .card-body {
-  display:block;
+.deck-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(15, 23, 42, 0.65);
+  color: var(--text);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 12px;
+  padding: 10px;
+  cursor: pointer;
 }
 
-.deck-card .item-card.expanded .section-content {
-  overflow-y:auto;
+.deck-prev {
+  left: clamp(16px, 3vw, 28px);
 }
-.deck-prev, .deck-next {
-  position:absolute;
-  top:50%;
-  transform:translateY(-50%);
-  background:var(--muted);
-  color:var(--text);
-  padding:8px;
-  border-radius:var(--radius);
-  cursor:pointer;
-  border:1px solid var(--border);
+
+.deck-next {
+  right: clamp(16px, 3vw, 28px);
 }
-.deck-prev { left:var(--pad); }
-.deck-next { right:var(--pad); }
-.deck-prev:hover, .deck-next:hover {
-  transform:translateY(calc(-50% - 2px));
+
+.deck-nav:hover {
+  transform: translateY(calc(-50% - 4px));
 }
+
+.deck-related-toggle {
+  align-self: flex-start;
+}
+
 .deck-related {
-  display:flex;
-  flex-wrap:wrap;
-  gap:var(--pad);
-  justify-content:center;
-  margin-top:var(--pad);
-  opacity:0;
-  transform:translateY(-10px);
-  transition:opacity 0.3s ease, transform 0.3s ease;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad);
+  justify-content: center;
+  margin-top: var(--pad);
+  opacity: 0;
+  transform: translateY(-10px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
 }
+
 .deck-related:not(.hidden) {
-  opacity:1;
-  transform:translateY(0);
+  opacity: 1;
+  transform: translateY(0);
 }
+
 .deck-related .related-card {
-  opacity:0;
-  transform:scale(0.95);
-  transition:opacity 0.3s ease, transform 0.3s ease;
+  opacity: 0;
+  transform: scale(0.95);
+  transition: opacity 0.3s ease, transform 0.3s ease;
 }
+
 .deck-related .related-card.visible {
-  opacity:1;
-  transform:scale(1);
+  opacity: 1;
+  transform: scale(1);
 }
+
 .deck-close {
-  margin-top:var(--pad);
+  align-self: flex-end;
 }
 .hidden { display:none !important; }
 


### PR DESCRIPTION
## Summary
- redesign the settings tab with modular panels, collapsible block management, and reliable lecture toggles
- streamline the entry editor toolbar and expand the curriculum tagging workspace
- reorganize the cards tab by block and week with collapsible sections and refreshed deck viewer styling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc321904748322a034cacdc6b84d28