### PR TITLE
Redesign settings and cards experiences

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -145,7 +145,7 @@ async function render() {
     main.appendChild(content);
     const filter = { ...state.filters, query: state.query };
     const items = await findItemsByFilter(filter);
-    renderCards(content, items, render);
+    await renderCards(content, items, render);
   } else if (state.tab === 'Study') {
     main.appendChild(createEntryAddControl(render, 'disease'));
     const content = document.createElement('div');

--- a/js/ui/components/cards.js
+++ b/js/ui/components/cards.js
@@ -1,4 +1,5 @@
 import { createItemCard } from './cardlist.js';
+import { listBlocks } from '../../storage/storage.js';
 
 /**
  * Render lecture-based decks combining all item types.
@@ -6,92 +7,296 @@ import { createItemCard } from './cardlist.js';
  * @param {import('../../types.js').Item[]} items
  * @param {Function} onChange
  */
-export function renderCards(container, items, onChange){
+export async function renderCards(container, items, onChange){
   container.innerHTML = '';
-  const decks = new Map();
-  items.forEach(it => {
-    if (it.lectures && it.lectures.length){
-      it.lectures.forEach(l => {
-        const key = l.name || `Lecture ${l.id}`;
-        if (!decks.has(key)) decks.set(key, []);
-        decks.get(key).push(it);
+
+  const blocks = await listBlocks();
+  const blockMap = new Map(blocks.map(b => [b.blockId, b]));
+  const groups = buildCardGroups(items, blockMap);
+
+  const collection = document.createElement('div');
+  collection.className = 'cards-collection';
+  container.appendChild(collection);
+
+  const viewer = createDeckViewer();
+  container.appendChild(viewer.element);
+
+  if (!groups.length) {
+    const empty = document.createElement('div');
+    empty.className = 'cards-empty';
+    empty.textContent = 'No cards match your filters just yet.';
+    collection.appendChild(empty);
+    return;
+  }
+
+  groups.forEach(group => {
+    const blockSection = document.createElement('details');
+    blockSection.className = 'cards-block';
+    blockSection.open = true;
+
+    const summary = document.createElement('summary');
+    summary.className = 'cards-block-header';
+    const accent = document.createElement('span');
+    accent.className = 'cards-block-accent';
+    accent.style.setProperty('--accent', group.color);
+    summary.appendChild(accent);
+
+    const text = document.createElement('div');
+    text.className = 'cards-block-text';
+    const title = document.createElement('h3');
+    title.textContent = group.title;
+    text.appendChild(title);
+    const meta = document.createElement('span');
+    meta.className = 'cards-block-meta';
+    meta.textContent = `${group.count} card${group.count === 1 ? '' : 's'}`;
+    text.appendChild(meta);
+    summary.appendChild(text);
+
+    blockSection.appendChild(summary);
+
+    const weekContainer = document.createElement('div');
+    weekContainer.className = 'cards-week-container';
+
+    group.weeks.forEach(week => {
+      const weekSection = document.createElement('details');
+      weekSection.className = 'cards-week';
+      weekSection.open = true;
+
+      const weekSummary = document.createElement('summary');
+      weekSummary.className = 'cards-week-header';
+      weekSummary.textContent = `${week.label} • ${week.count} card${week.count === 1 ? '' : 's'}`;
+      weekSection.appendChild(weekSummary);
+
+      const deckGrid = document.createElement('div');
+      deckGrid.className = 'cards-deck-grid';
+
+      week.lectures.forEach(lecture => {
+        deckGrid.appendChild(createDeckTile({
+          title: lecture.label,
+          meta: lecture.meta,
+          cards: lecture.cards,
+          onOpen: viewer.open,
+          onPreviewStart: viewer.startPreview,
+          onPreviewStop: viewer.stopPreview,
+          allItems: items,
+          onChange
+        }));
       });
-    } else {
-      if (!decks.has('Unassigned')) decks.set('Unassigned', []);
-      decks.get('Unassigned').push(it);
+
+      if (week.loose.length) {
+        const overviewTitle = week.label === 'Unscheduled' ? 'Unscheduled cards' : `${week.label} overview`;
+        deckGrid.appendChild(createDeckTile({
+          title: overviewTitle,
+          meta: week.meta,
+          cards: week.loose,
+          onOpen: viewer.open,
+          onPreviewStart: viewer.startPreview,
+          onPreviewStop: viewer.stopPreview,
+          allItems: items,
+          onChange
+        }));
+      }
+
+      weekSection.appendChild(deckGrid);
+      weekContainer.appendChild(weekSection);
+    });
+
+    if (!group.weeks.length) {
+      const noWeeks = document.createElement('div');
+      noWeeks.className = 'cards-empty';
+      noWeeks.textContent = 'No scheduling information yet.';
+      weekContainer.appendChild(noWeeks);
     }
+
+    blockSection.appendChild(weekContainer);
+    collection.appendChild(blockSection);
   });
 
-  const list = document.createElement('div');
-  list.className = 'deck-list';
-  container.appendChild(list);
+  function createDeckTile({ title, meta, cards, onOpen, onPreviewStart, onPreviewStop, allItems, onChange }) {
+    const deck = document.createElement('button');
+    deck.type = 'button';
+    deck.className = 'cards-deck';
 
+    const heading = document.createElement('div');
+    heading.className = 'cards-deck-title';
+    heading.textContent = title;
+    deck.appendChild(heading);
+
+    if (meta) {
+      const sub = document.createElement('div');
+      sub.className = 'cards-deck-meta';
+      sub.textContent = meta;
+      deck.appendChild(sub);
+    }
+
+    let previewTimer;
+
+    deck.addEventListener('click', () => {
+      onPreviewStop(deck);
+      onOpen(title, cards, allItems, onChange);
+    });
+
+    deck.addEventListener('mouseenter', () => {
+      previewTimer = setTimeout(() => onPreviewStart(deck, cards), 1600);
+    });
+
+    deck.addEventListener('mouseleave', () => {
+      clearTimeout(previewTimer);
+      onPreviewStop(deck);
+    });
+
+    return deck;
+  }
+}
+
+function buildCardGroups(items, blockMap) {
+  const groups = new Map();
+
+  const ensureBlock = (blockId) => {
+    const key = blockId || '__unassigned';
+    if (!groups.has(key)) {
+      const block = blockMap.get(blockId);
+      groups.set(key, {
+        id: key,
+        title: block?.title || block?.blockId || (key === '__unassigned' ? 'Unassigned' : key),
+        color: block?.color || 'rgba(56, 189, 248, 0.65)',
+        order: block?.order ?? (key === '__unassigned' ? Number.POSITIVE_INFINITY : 0),
+        weeks: new Map(),
+        itemIds: new Set(),
+      });
+    }
+    return groups.get(key);
+  };
+
+  const ensureWeek = (blockGroup, weekKey, weekValue) => {
+    if (!blockGroup.weeks.has(weekKey)) {
+      blockGroup.weeks.set(weekKey, {
+        key: weekKey,
+        order: typeof weekValue === 'number' ? weekValue : Number.POSITIVE_INFINITY,
+        label: typeof weekValue === 'number' ? `Week ${weekValue}` : 'Unscheduled',
+        lectures: new Map(),
+        loose: [],
+        itemIds: new Set(),
+      });
+    }
+    return blockGroup.weeks.get(weekKey);
+  };
+
+  const ensureLecture = (weekGroup, lectureKey, attachment) => {
+    if (!weekGroup.lectures.has(lectureKey)) {
+      weekGroup.lectures.set(lectureKey, {
+        key: lectureKey,
+        order: attachment.lectureId ?? Number.POSITIVE_INFINITY,
+        label: attachment.lectureName || (attachment.lectureId != null ? `Lecture ${attachment.lectureId}` : 'Lecture'),
+        meta: attachment.meta,
+        cards: [],
+        itemIds: new Set(),
+      });
+    }
+    return weekGroup.lectures.get(lectureKey);
+  };
+
+  items.forEach(item => {
+    const attachments = extractAttachments(item);
+    const seen = new Set();
+
+    attachments.forEach(att => {
+      const blockId = att.blockId || '__unassigned';
+      const blockGroup = ensureBlock(blockId);
+      const weekValue = typeof att.week === 'number' ? att.week : null;
+      const weekKey = weekValue === null ? '__unscheduled' : String(weekValue);
+      const lectureKey = att.lectureId != null ? `${blockId}|${att.lectureId}` : null;
+      const dedupeKey = `${blockId}|${weekKey}|${lectureKey ?? 'week'}`;
+      if (seen.has(dedupeKey)) return;
+      seen.add(dedupeKey);
+
+      const weekGroup = ensureWeek(blockGroup, weekKey, weekValue);
+      blockGroup.itemIds.add(item.id);
+      weekGroup.itemIds.add(item.id);
+
+      if (lectureKey) {
+        const lectureGroup = ensureLecture(weekGroup, lectureKey, att);
+        lectureGroup.cards.push(item);
+        lectureGroup.itemIds.add(item.id);
+      } else {
+        weekGroup.loose.push(item);
+      }
+    });
+  });
+
+  return Array.from(groups.values())
+    .sort((a, b) => a.order - b.order || a.title.localeCompare(b.title))
+    .map(group => ({
+      ...group,
+      count: group.itemIds.size,
+      weeks: Array.from(group.weeks.values())
+        .sort((a, b) => a.order - b.order || a.label.localeCompare(b.label))
+        .map(week => ({
+          ...week,
+          count: week.itemIds.size,
+          meta: week.label === 'Unscheduled'
+            ? 'Cards without a planned week'
+            : `Cards spanning ${week.label.toLowerCase()}`,
+          lectures: Array.from(week.lectures.values())
+            .sort((a, b) => a.order - b.order || a.label.localeCompare(b.label))
+            .map(lecture => ({
+              ...lecture,
+              meta: lecture.meta || `Includes ${lecture.itemIds.size} card${lecture.itemIds.size === 1 ? '' : 's'}`,
+            })),
+        })),
+    }));
+}
+
+function extractAttachments(item) {
+  const attachments = [];
+  if (Array.isArray(item.lectures) && item.lectures.length) {
+    item.lectures.forEach(lecture => {
+      const parts = [];
+      if (typeof lecture.week === 'number') parts.push(`Week ${lecture.week}`);
+      if (lecture.name) parts.push(lecture.name);
+      attachments.push({
+        blockId: lecture.blockId,
+        week: lecture.week,
+        lectureId: lecture.id,
+        lectureName: lecture.name,
+        meta: parts.join(' • '),
+      });
+    });
+  } else if (Array.isArray(item.blocks) && item.blocks.length) {
+    const weeks = Array.isArray(item.weeks) && item.weeks.length ? item.weeks : [null];
+    item.blocks.forEach(blockId => {
+      weeks.forEach(week => {
+        const numericWeek = typeof week === 'number' ? week : (week != null ? Number(week) : null);
+        attachments.push({ blockId, week: Number.isFinite(numericWeek) ? numericWeek : null });
+      });
+    });
+  } else {
+    attachments.push({ blockId: '__unassigned', week: null });
+  }
+  return attachments;
+}
+
+function createDeckViewer(){
   const viewer = document.createElement('div');
   viewer.className = 'deck-viewer hidden';
-  container.appendChild(viewer);
 
-  decks.forEach((cards, lecture) => {
-    const deck = document.createElement('div');
-    deck.className = 'deck';
-    const title = document.createElement('div');
-    title.className = 'deck-title';
-    title.textContent = lecture;
-    const meta = document.createElement('div');
-    meta.className = 'deck-meta';
-    const blocks = Array.from(new Set(cards.flatMap(c => c.blocks || []))).join(', ');
-    const weeks = Array.from(new Set(cards.flatMap(c => c.weeks || []))).join(', ');
-    meta.textContent = `${blocks}${blocks && weeks ? ' • ' : ''}${weeks ? 'Week ' + weeks : ''}`;
-    deck.appendChild(title);
-    deck.appendChild(meta);
-    deck.addEventListener('click', () => { stopPreview(deck); openDeck(lecture, cards); });
-    let hoverTimer;
-    deck.addEventListener('mouseenter', () => {
-      hoverTimer = setTimeout(() => startPreview(deck, cards), 3000);
-    });
-    deck.addEventListener('mouseleave', () => {
-      clearTimeout(hoverTimer);
-      stopPreview(deck);
-    });
-    list.appendChild(deck);
-  });
+  let teardown = null;
 
-  function startPreview(deckEl, cards){
-    if (deckEl._preview) return;
-    deckEl.classList.add('pop');
-    const fan = document.createElement('div');
-    fan.className = 'deck-fan';
-    deckEl.appendChild(fan);
-    const show = cards.slice(0,5);
-    const spread = 20;
-    const offset = (show.length - 1) * spread / 2;
-    show.forEach((c,i) => {
-      const mini = document.createElement('div');
-      mini.className = 'fan-card';
-      mini.textContent = c.name || c.concept || '';
-      fan.appendChild(mini);
-      const angle = -offset + i * spread;
-      mini.style.transform = `rotate(${angle}deg) translateY(-80px)`;
-      setTimeout(() => { mini.style.opacity = 1; }, i * 100);
-    });
-    deckEl._preview = { fan };
-  }
-
-  function stopPreview(deckEl){
-    const prev = deckEl._preview;
-    if (prev){
-      prev.fan.remove();
-      deckEl.classList.remove('pop');
-      deckEl._preview = null;
-    }
-  }
-
-  function openDeck(title, cards){
-    list.classList.add('hidden');
+  function open(title, cards, allItems, onChange){
+    if (typeof teardown === 'function') teardown();
     viewer.classList.remove('hidden');
     viewer.innerHTML = '';
 
-    const header = document.createElement('h2');
-    header.textContent = title;
+    const header = document.createElement('div');
+    header.className = 'cards-viewer-header';
+    const heading = document.createElement('h2');
+    heading.textContent = title;
+    header.appendChild(heading);
+    const closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.className = 'deck-close btn secondary';
+    closeBtn.textContent = 'Close';
+    header.appendChild(closeBtn);
     viewer.appendChild(header);
 
     const cardHolder = document.createElement('div');
@@ -108,73 +313,109 @@ export function renderCards(container, items, onChange){
     viewer.appendChild(next);
 
     const toggle = document.createElement('button');
-    toggle.className = 'deck-related-toggle btn';
-    toggle.textContent = 'Show Related';
+    toggle.className = 'deck-related-toggle btn secondary';
+    toggle.textContent = 'Show related';
     viewer.appendChild(toggle);
 
     const relatedWrap = document.createElement('div');
     relatedWrap.className = 'deck-related hidden';
     viewer.appendChild(relatedWrap);
 
-    const close = document.createElement('button');
-    close.className = 'deck-close btn';
-    close.textContent = 'Close';
-    viewer.appendChild(close);
-
     let idx = 0;
     let showRelated = false;
 
-    function renderCard(){
+    const renderCard = () => {
       cardHolder.innerHTML = '';
       cardHolder.appendChild(createItemCard(cards[idx], onChange));
       renderRelated();
-    }
+    };
 
-    function renderRelated(){
+    const renderRelated = () => {
       relatedWrap.innerHTML = '';
       if (!showRelated) return;
       const current = cards[idx];
-      (current.links || []).forEach(l => {
-        const item = items.find(it => it.id === l.id);
-        if (item) {
-          const el = createItemCard(item, onChange);
-          el.classList.add('related-card');
-          relatedWrap.appendChild(el);
-          requestAnimationFrame(() => el.classList.add('visible'));
-        }
+      (current.links || []).forEach(link => {
+        const linked = allItems.find(it => it.id === link.id);
+        if (!linked) return;
+        const el = createItemCard(linked, onChange);
+        el.classList.add('related-card');
+        relatedWrap.appendChild(el);
+        requestAnimationFrame(() => el.classList.add('visible'));
       });
-    }
+    };
 
-    prev.addEventListener('click', () => {
+    const handlePrev = () => {
       idx = (idx - 1 + cards.length) % cards.length;
       renderCard();
-    });
-    next.addEventListener('click', () => {
+    };
+
+    const handleNext = () => {
       idx = (idx + 1) % cards.length;
       renderCard();
-    });
+    };
+
+    prev.addEventListener('click', handlePrev);
+    next.addEventListener('click', handleNext);
 
     toggle.addEventListener('click', () => {
       showRelated = !showRelated;
-      toggle.textContent = showRelated ? 'Hide Related' : 'Show Related';
+      toggle.textContent = showRelated ? 'Hide related' : 'Show related';
       relatedWrap.classList.toggle('hidden', !showRelated);
       renderRelated();
     });
 
-    close.addEventListener('click', () => {
-      document.removeEventListener('keydown', keyHandler);
+    const handleClose = () => {
       viewer.classList.add('hidden');
       viewer.innerHTML = '';
-      list.classList.remove('hidden');
-    });
+      document.removeEventListener('keydown', handleKeys);
+      teardown = null;
+    };
 
-    function keyHandler(e){
-      if (e.key === 'ArrowLeft') prev.click();
-      if (e.key === 'ArrowRight') next.click();
-      if (e.key === 'Escape') close.click();
-    }
-    document.addEventListener('keydown', keyHandler);
+    const handleKeys = (event) => {
+      if (event.key === 'ArrowLeft') handlePrev();
+      if (event.key === 'ArrowRight') handleNext();
+      if (event.key === 'Escape') handleClose();
+    };
 
+    closeBtn.addEventListener('click', handleClose);
+    document.addEventListener('keydown', handleKeys);
+
+    teardown = handleClose;
     renderCard();
   }
+
+  function close(){
+    if (typeof teardown === 'function') teardown();
+  }
+
+  function startPreview(deckEl, cards){
+    if (deckEl._preview) return;
+    deckEl.classList.add('previewing');
+    const fan = document.createElement('div');
+    fan.className = 'cards-deck-preview';
+    deckEl.appendChild(fan);
+    const spread = 16;
+    const show = cards.slice(0, 4);
+    const offset = (show.length - 1) * spread / 2;
+    show.forEach((card, index) => {
+      const mini = document.createElement('div');
+      mini.className = 'cards-preview-card';
+      mini.textContent = card.name || card.concept || '';
+      fan.appendChild(mini);
+      const angle = -offset + index * spread;
+      mini.style.transform = `rotate(${angle}deg) translateY(-64px)`;
+      requestAnimationFrame(() => mini.classList.add('visible'));
+    });
+    deckEl._preview = { fan };
+  }
+
+  function stopPreview(deckEl){
+    const preview = deckEl._preview;
+    if (!preview) return;
+    preview.fan.remove();
+    deckEl.classList.remove('previewing');
+    deckEl._preview = null;
+  }
+
+  return { element: viewer, open, close, startPreview, stopPreview };
 }

--- a/js/ui/components/editor.js
+++ b/js/ui/components/editor.js
@@ -46,7 +46,7 @@ function escapeHtml(str = '') {
 export async function openEditor(kind, onSave, existing = null) {
   const win = createFloatingWindow({
     title: `${existing ? 'Edit' : 'Add'} ${titleMap[kind] || kind}`,
-    width: 600
+    width: 760
   });
 
   const form = document.createElement('form');

--- a/js/ui/settings.js
+++ b/js/ui/settings.js
@@ -8,308 +8,164 @@ function isLectureListCollapsed(blockId) {
 }
 
 function toggleLectureListCollapse(blockId) {
+  let collapsed;
   if (collapsedLectureBlocks.has(blockId)) {
     collapsedLectureBlocks.delete(blockId);
+    collapsed = false;
   } else {
     collapsedLectureBlocks.add(blockId);
+    collapsed = true;
   }
+  return collapsed;
 }
 
 export async function renderSettings(root) {
   root.innerHTML = '';
 
   const settings = await getSettings();
+  const blocks = await listBlocks();
 
-  const settingsCard = document.createElement('section');
-  settingsCard.className = 'card';
-  const heading = document.createElement('h2');
-  heading.textContent = 'Settings';
-  settingsCard.appendChild(heading);
+  const layout = document.createElement('div');
+  layout.className = 'settings-layout';
+  root.appendChild(layout);
 
-  const dailyLabel = document.createElement('label');
-  dailyLabel.textContent = 'Daily review target:';
+  const generalCard = document.createElement('section');
+  generalCard.className = 'settings-card';
+  const generalHeader = document.createElement('div');
+  generalHeader.className = 'settings-card-header';
+  const generalTitle = document.createElement('h2');
+  generalTitle.textContent = 'Review preferences';
+  generalHeader.appendChild(generalTitle);
+  const generalHint = document.createElement('p');
+  generalHint.className = 'settings-card-subtitle';
+  generalHint.textContent = 'Tailor how many items surface in a day to match your pace.';
+  generalHeader.appendChild(generalHint);
+  generalCard.appendChild(generalHeader);
+
+  const dailyField = document.createElement('label');
+  dailyField.className = 'settings-field';
+  const dailyLabel = document.createElement('span');
+  dailyLabel.className = 'settings-field-label';
+  dailyLabel.textContent = 'Daily review target';
+  dailyField.appendChild(dailyLabel);
   const dailyInput = document.createElement('input');
   dailyInput.type = 'number';
   dailyInput.className = 'input';
   dailyInput.min = '1';
   dailyInput.value = settings.dailyCount;
   dailyInput.addEventListener('change', () => {
-    saveSettings({ dailyCount: Number(dailyInput.value) });
+    saveSettings({ dailyCount: Number(dailyInput.value) || 1 });
   });
-  dailyLabel.appendChild(dailyInput);
-  settingsCard.appendChild(dailyLabel);
+  dailyField.appendChild(dailyInput);
+  generalCard.appendChild(dailyField);
 
-  root.appendChild(settingsCard);
+  layout.appendChild(generalCard);
 
   const blocksCard = document.createElement('section');
-  blocksCard.className = 'card';
-  const bHeading = document.createElement('h2');
-  bHeading.textContent = 'Blocks';
-  blocksCard.appendChild(bHeading);
+  blocksCard.className = 'settings-card settings-card--wide';
+  const blocksHeader = document.createElement('div');
+  blocksHeader.className = 'settings-card-header';
+  const blocksTitle = document.createElement('h2');
+  blocksTitle.textContent = 'Curriculum blocks';
+  blocksHeader.appendChild(blocksTitle);
+  const blocksHint = document.createElement('p');
+  blocksHint.className = 'settings-card-subtitle';
+  blocksHint.textContent = 'Organize blocks, lectures, and weekly structure in one place.';
+  blocksHeader.appendChild(blocksHint);
+  blocksCard.appendChild(blocksHeader);
 
-  const list = document.createElement('div');
-  list.className = 'block-list';
-  blocksCard.appendChild(list);
+  const blockList = document.createElement('div');
+  blockList.className = 'settings-block-list';
+  const nextOrder = blocks.reduce((max, block, idx) => Math.max(max, block.order ?? idx), -1) + 1;
 
-  const blocks = await listBlocks();
-  blocks.forEach((b,i) => {
-    const wrap = document.createElement('div');
-    wrap.className = 'block';
-    const lectures = (b.lectures || []).slice().sort((a,b)=> b.week - a.week || b.id - a.id);
-    const lecturesCollapsed = isLectureListCollapsed(b.blockId);
-    const title = document.createElement('h3');
-    title.textContent = `${b.blockId} – ${b.title}`;
-    wrap.appendChild(title);
-
-    const wkInfo = document.createElement('div');
-    wkInfo.textContent = `Weeks: ${b.weeks}`;
-    wrap.appendChild(wkInfo);
-
-    if (lectures.length || lecturesCollapsed) {
-      const toggleLecturesBtn = document.createElement('button');
-      toggleLecturesBtn.type = 'button';
-      toggleLecturesBtn.className = 'btn secondary settings-lecture-toggle';
-      toggleLecturesBtn.textContent = lecturesCollapsed ? 'Show lectures' : 'Hide lectures';
-      toggleLecturesBtn.addEventListener('click', async () => {
-        toggleLectureListCollapse(b.blockId);
-        await renderSettings(root);
-      });
-      wrap.appendChild(toggleLecturesBtn);
-    }
-
-    const controls = document.createElement('div');
-    controls.className = 'row';
-
-    const upBtn = document.createElement('button');
-    upBtn.className = 'btn';
-    upBtn.textContent = '↑';
-    upBtn.disabled = i === 0;
-    upBtn.addEventListener('click', async () => {
-      const other = blocks[i-1];
-      const tmp = b.order; b.order = other.order; other.order = tmp;
-      await upsertBlock(b); await upsertBlock(other);
-      await renderSettings(root);
+  blocks
+    .slice()
+    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0) || (a.blockId || '').localeCompare(b.blockId || ''))
+    .forEach((block, index, arr) => {
+      blockList.appendChild(renderBlockRow(block, index, arr));
     });
-    controls.appendChild(upBtn);
+  blocksCard.appendChild(blockList);
 
-    const downBtn = document.createElement('button');
-    downBtn.className = 'btn';
-    downBtn.textContent = '↓';
-    downBtn.disabled = i === blocks.length - 1;
-    downBtn.addEventListener('click', async () => {
-      const other = blocks[i+1];
-      const tmp = b.order; b.order = other.order; other.order = tmp;
-      await upsertBlock(b); await upsertBlock(other);
-      await renderSettings(root);
-    });
-    controls.appendChild(downBtn);
+  const newBlockForm = document.createElement('form');
+  newBlockForm.className = 'settings-inline-form settings-block-add';
+  const newBlockTitle = document.createElement('h3');
+  newBlockTitle.textContent = 'Add a new block';
+  newBlockForm.appendChild(newBlockTitle);
 
-    const edit = document.createElement('button');
-    edit.className = 'btn';
-    edit.textContent = 'Edit';
-    controls.appendChild(edit);
+  const newBlockFields = document.createElement('div');
+  newBlockFields.className = 'settings-inline-grid';
 
-    const del = document.createElement('button');
-    del.className = 'btn';
-    del.textContent = 'Delete';
-    del.addEventListener('click', async () => {
-      if (await confirmModal('Delete block?')) {
-        await deleteBlock(b.blockId);
-        await renderSettings(root);
-      }
-    });
-    controls.appendChild(del);
-    wrap.appendChild(controls);
+  const idField = createInlineInput('ID', 'text', 'e.g. MSK');
+  const titleField = createInlineInput('Title', 'text', 'Musculoskeletal');
+  const weeksField = createInlineInput('Weeks', 'number', '6');
+  weeksField.input.min = '1';
+  const colorField = createInlineInput('Accent color', 'color');
+  colorField.input.value = '#1e293b';
 
-    const editForm = document.createElement('form');
-    editForm.className = 'row';
-    editForm.style.display = 'none';
-    const titleInput = document.createElement('input');
-    titleInput.className = 'input';
-    titleInput.value = b.title;
-    const weeksInput = document.createElement('input');
-    weeksInput.className = 'input';
-    weeksInput.type = 'number';
-    weeksInput.value = b.weeks;
-    const colorInput = document.createElement('input');
-    colorInput.className = 'input';
-    colorInput.type = 'color';
-    colorInput.value = b.color || '#ffffff';
-    const saveBtn = document.createElement('button');
-    saveBtn.className = 'btn';
-    saveBtn.type = 'submit';
-    saveBtn.textContent = 'Save';
-    editForm.append(titleInput, weeksInput, colorInput, saveBtn);
-    editForm.addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const updated = { ...b, title: titleInput.value.trim(), weeks: Number(weeksInput.value), color: colorInput.value };
-      await upsertBlock(updated);
-      await renderSettings(root);
-    });
-    wrap.appendChild(editForm);
+  newBlockFields.append(idField.element, titleField.element, weeksField.element, colorField.element);
+  newBlockForm.appendChild(newBlockFields);
 
-    edit.addEventListener('click', () => {
-      editForm.style.display = editForm.style.display === 'none' ? 'flex' : 'none';
-    });
+  const addBlockBtn = document.createElement('button');
+  addBlockBtn.className = 'btn primary';
+  addBlockBtn.type = 'submit';
+  addBlockBtn.textContent = 'Create block';
+  newBlockForm.appendChild(addBlockBtn);
 
-    const lectureSection = document.createElement('div');
-    lectureSection.className = 'settings-lecture-section';
-    lectureSection.hidden = lecturesCollapsed;
-
-    const lecList = document.createElement('ul');
-    lectures.forEach(l => {
-      const li = document.createElement('li');
-      li.className = 'row';
-      const span = document.createElement('span');
-      span.textContent = `${l.id}: ${l.name} (W${l.week})`;
-      li.appendChild(span);
-
-      const editLec = document.createElement('button');
-      editLec.className = 'btn';
-      editLec.textContent = 'Edit';
-      const delLec = document.createElement('button');
-      delLec.className = 'btn';
-      delLec.textContent = 'Delete';
-
-      editLec.addEventListener('click', () => {
-        li.innerHTML = '';
-        li.className = 'row';
-        const nameInput = document.createElement('input');
-        nameInput.className = 'input';
-        nameInput.value = l.name;
-        const weekInput = document.createElement('input');
-        weekInput.className = 'input';
-        weekInput.type = 'number';
-        weekInput.value = l.week;
-        const saveBtn = document.createElement('button');
-        saveBtn.className = 'btn';
-        saveBtn.textContent = 'Save';
-        const cancelBtn = document.createElement('button');
-        cancelBtn.className = 'btn';
-        cancelBtn.textContent = 'Cancel';
-        li.append(nameInput, weekInput, saveBtn, cancelBtn);
-        saveBtn.addEventListener('click', async () => {
-          const name = nameInput.value.trim();
-          const week = Number(weekInput.value);
-          if (!name || !week || week < 1 || week > b.weeks) return;
-          await updateLecture(b.blockId, { id: l.id, name, week });
-          await renderSettings(root);
-        });
-        cancelBtn.addEventListener('click', async () => {
-          await renderSettings(root);
-        });
-      });
-
-      delLec.addEventListener('click', async () => {
-        if (await confirmModal('Delete lecture?')) {
-          await deleteLecture(b.blockId, l.id);
-          await renderSettings(root);
-        }
-      });
-
-      li.append(editLec, delLec);
-      lecList.appendChild(li);
-    });
-    lectureSection.appendChild(lecList);
-
-    const lecForm = document.createElement('form');
-    lecForm.className = 'row';
-    const idInput = document.createElement('input');
-    idInput.className = 'input';
-    idInput.placeholder = 'id';
-    idInput.type = 'number';
-    const nameInput = document.createElement('input');
-    nameInput.className = 'input';
-    nameInput.placeholder = 'name';
-    const weekInput = document.createElement('input');
-    weekInput.className = 'input';
-    weekInput.placeholder = 'week';
-    weekInput.type = 'number';
-    const addBtn = document.createElement('button');
-    addBtn.className = 'btn';
-    addBtn.type = 'submit';
-    addBtn.textContent = 'Add lecture';
-    lecForm.append(idInput, nameInput, weekInput, addBtn);
-    lecForm.addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const lecture = { id: Number(idInput.value), name: nameInput.value.trim(), week: Number(weekInput.value) };
-      if (!lecture.id || !lecture.name || !lecture.week) return;
-      if (lecture.week < 1 || lecture.week > b.weeks) return;
-      const updated = { ...b, lectures: [...b.lectures, lecture] };
-      await upsertBlock(updated);
-      await renderSettings(root);
-    });
-    lectureSection.appendChild(lecForm);
-
-    wrap.appendChild(lectureSection);
-
-    list.appendChild(wrap);
-  });
-
-  const form = document.createElement('form');
-  form.className = 'row';
-  const id = document.createElement('input');
-  id.className = 'input';
-  id.placeholder = 'ID';
-  const titleInput = document.createElement('input');
-  titleInput.className = 'input';
-  titleInput.placeholder = 'Title';
-  const weeks = document.createElement('input');
-  weeks.className = 'input';
-  weeks.type = 'number';
-  weeks.placeholder = 'Weeks';
-  const color = document.createElement('input');
-  color.className = 'input';
-  color.type = 'color';
-  color.value = '#ffffff';
-  const add = document.createElement('button');
-  add.className = 'btn';
-  add.type = 'submit';
-  add.textContent = 'Add block';
-  form.append(id, titleInput, weeks, color, add);
-  form.addEventListener('submit', async (e) => {
-    e.preventDefault();
-    const def = {
-      blockId: id.value.trim(),
-      title: titleInput.value.trim(),
-      weeks: Number(weeks.value),
-      color: color.value,
+  newBlockForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const payload = {
+      blockId: idField.input.value.trim(),
+      title: titleField.input.value.trim(),
+      weeks: Number(weeksField.input.value),
+      color: colorField.input.value,
       lectures: [],
+      order: nextOrder,
     };
-    if (!def.blockId || !def.title || !def.weeks) return;
-    await upsertBlock(def);
+    if (!payload.blockId || !payload.title || !payload.weeks) return;
+    await upsertBlock(payload);
     await renderSettings(root);
   });
-  blocksCard.appendChild(form);
 
-  root.appendChild(blocksCard);
+  blocksCard.appendChild(newBlockForm);
+  layout.appendChild(blocksCard);
 
   const dataCard = document.createElement('section');
-  dataCard.className = 'card';
-  const dHeading = document.createElement('h2');
-  dHeading.textContent = 'Data';
-  dataCard.appendChild(dHeading);
+  dataCard.className = 'settings-card';
+  const dataHeader = document.createElement('div');
+  dataHeader.className = 'settings-card-header';
+  const dataTitle = document.createElement('h2');
+  dataTitle.textContent = 'Data management';
+  dataHeader.appendChild(dataTitle);
+  const dataHint = document.createElement('p');
+  dataHint.className = 'settings-card-subtitle';
+  dataHint.textContent = 'Safeguard your progress or migrate to another device.';
+  dataHeader.appendChild(dataHint);
+  dataCard.appendChild(dataHeader);
+
+  const dataActions = document.createElement('div');
+  dataActions.className = 'settings-action-grid';
 
   const exportBtn = document.createElement('button');
-  exportBtn.className = 'btn';
-  exportBtn.textContent = 'Export DB';
+  exportBtn.className = 'btn secondary';
+  exportBtn.type = 'button';
+  exportBtn.textContent = 'Export database';
   exportBtn.addEventListener('click', async () => {
     const dump = await exportJSON();
     const blob = new Blob([JSON.stringify(dump, null, 2)], { type: 'application/json' });
-    const a = document.createElement('a');
-    a.href = URL.createObjectURL(blob);
-    a.download = 'sevenn-export.json';
-    a.click();
-    URL.revokeObjectURL(a.href);
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = 'sevenn-export.json';
+    link.click();
+    URL.revokeObjectURL(link.href);
   });
-  dataCard.appendChild(exportBtn);
+  dataActions.appendChild(exportBtn);
 
   const importInput = document.createElement('input');
   importInput.type = 'file';
   importInput.accept = 'application/json';
-  importInput.style.display = 'none';
+  importInput.hidden = true;
   importInput.addEventListener('change', async () => {
-    const file = importInput.files[0];
+    const file = importInput.files?.[0];
     if (!file) return;
     try {
       const text = await file.text();
@@ -317,31 +173,359 @@ export async function renderSettings(root) {
       const res = await importJSON(json);
       alert(res.message);
       location.reload();
-    } catch (e) {
+    } catch (err) {
+      console.error(err);
       alert('Import failed');
     }
   });
 
   const importBtn = document.createElement('button');
-  importBtn.className = 'btn';
-  importBtn.textContent = 'Import DB';
+  importBtn.className = 'btn secondary';
+  importBtn.type = 'button';
+  importBtn.textContent = 'Import database';
   importBtn.addEventListener('click', () => importInput.click());
-  dataCard.appendChild(importBtn);
-  dataCard.appendChild(importInput);
+  dataActions.appendChild(importBtn);
+  dataActions.appendChild(importInput);
 
   const ankiBtn = document.createElement('button');
-  ankiBtn.className = 'btn';
+  ankiBtn.className = 'btn secondary';
+  ankiBtn.type = 'button';
   ankiBtn.textContent = 'Export Anki CSV';
   ankiBtn.addEventListener('click', async () => {
     const dump = await exportJSON();
     const blob = await exportAnkiCSV('qa', dump.items || []);
-    const a = document.createElement('a');
-    a.href = URL.createObjectURL(blob);
-    a.download = 'sevenn-anki.csv';
-    a.click();
-    URL.revokeObjectURL(a.href);
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = 'sevenn-anki.csv';
+    link.click();
+    URL.revokeObjectURL(link.href);
   });
-  dataCard.appendChild(ankiBtn);
+  dataActions.appendChild(ankiBtn);
 
-  root.appendChild(dataCard);
+  dataCard.appendChild(dataActions);
+  layout.appendChild(dataCard);
+
+  function createInlineInput(label, type, placeholder = '') {
+    const field = document.createElement('label');
+    field.className = 'settings-inline-field';
+    const span = document.createElement('span');
+    span.className = 'settings-inline-label';
+    span.textContent = label;
+    field.appendChild(span);
+    const input = document.createElement('input');
+    input.className = 'input';
+    input.type = type;
+    if (placeholder) input.placeholder = placeholder;
+    field.appendChild(input);
+    return { element: field, input };
+  }
+
+  function renderBlockRow(block, index, arr) {
+    const card = document.createElement('article');
+    card.className = 'settings-block-card';
+
+    const header = document.createElement('div');
+    header.className = 'settings-block-header';
+    card.appendChild(header);
+
+    const info = document.createElement('div');
+    info.className = 'settings-block-info';
+
+    const accent = document.createElement('span');
+    accent.className = 'settings-block-accent';
+    accent.style.setProperty('--accent', block.color || '#38bdf8');
+    info.appendChild(accent);
+
+    const textWrap = document.createElement('div');
+    textWrap.className = 'settings-block-text';
+    const title = document.createElement('h3');
+    title.textContent = block.title || block.blockId;
+    textWrap.appendChild(title);
+    const subtitle = document.createElement('span');
+    subtitle.className = 'settings-block-subtitle';
+    const lectureCount = block.lectures?.length || 0;
+    const metaParts = [block.blockId];
+    if (block.weeks) metaParts.push(`${block.weeks} week${block.weeks === 1 ? '' : 's'}`);
+    if (lectureCount) metaParts.push(`${lectureCount} lecture${lectureCount === 1 ? '' : 's'}`);
+    subtitle.textContent = metaParts.join(' • ');
+    textWrap.appendChild(subtitle);
+    info.appendChild(textWrap);
+    header.appendChild(info);
+
+    const actions = document.createElement('div');
+    actions.className = 'settings-block-actions';
+
+    const toggleBtn = document.createElement('button');
+    toggleBtn.type = 'button';
+    toggleBtn.className = 'settings-icon-btn';
+    const collapsedInitially = isLectureListCollapsed(block.blockId);
+    toggleBtn.textContent = collapsedInitially ? 'Show lectures' : 'Hide lectures';
+    toggleBtn.setAttribute('aria-expanded', String(!collapsedInitially));
+    actions.appendChild(toggleBtn);
+
+    const upBtn = document.createElement('button');
+    upBtn.type = 'button';
+    upBtn.className = 'settings-icon-btn';
+    upBtn.textContent = 'Move up';
+    upBtn.disabled = index === 0;
+    upBtn.addEventListener('click', async () => {
+      const other = arr[index - 1];
+      const currentOrder = block.order ?? index;
+      const otherOrder = other.order ?? (index - 1);
+      block.order = otherOrder;
+      other.order = currentOrder;
+      await upsertBlock(block);
+      await upsertBlock(other);
+      await renderSettings(root);
+    });
+    actions.appendChild(upBtn);
+
+    const downBtn = document.createElement('button');
+    downBtn.type = 'button';
+    downBtn.className = 'settings-icon-btn';
+    downBtn.textContent = 'Move down';
+    downBtn.disabled = index === arr.length - 1;
+    downBtn.addEventListener('click', async () => {
+      const other = arr[index + 1];
+      const currentOrder = block.order ?? index;
+      const otherOrder = other.order ?? (index + 1);
+      block.order = otherOrder;
+      other.order = currentOrder;
+      await upsertBlock(block);
+      await upsertBlock(other);
+      await renderSettings(root);
+    });
+    actions.appendChild(downBtn);
+
+    const editBtn = document.createElement('button');
+    editBtn.type = 'button';
+    editBtn.className = 'settings-icon-btn';
+    editBtn.textContent = 'Edit block';
+    actions.appendChild(editBtn);
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.type = 'button';
+    deleteBtn.className = 'settings-icon-btn destructive';
+    deleteBtn.textContent = 'Delete';
+    deleteBtn.addEventListener('click', async () => {
+      if (await confirmModal('Delete block?')) {
+        await deleteBlock(block.blockId);
+        await renderSettings(root);
+      }
+    });
+    actions.appendChild(deleteBtn);
+
+    header.appendChild(actions);
+
+    const editForm = document.createElement('form');
+    editForm.className = 'settings-inline-form hidden';
+    const editGrid = document.createElement('div');
+    editGrid.className = 'settings-inline-grid';
+
+    const titleField = createInlineInput('Title', 'text', 'Block title');
+    titleField.input.value = block.title || '';
+    const weekField = createInlineInput('Weeks', 'number', '0');
+    weekField.input.value = block.weeks ?? 0;
+    weekField.input.min = '0';
+    const colorField = createInlineInput('Accent color', 'color');
+    colorField.input.value = block.color || '#1e293b';
+
+    editGrid.append(titleField.element, weekField.element, colorField.element);
+    editForm.appendChild(editGrid);
+
+    const editActions = document.createElement('div');
+    editActions.className = 'settings-inline-actions';
+    const saveBtn = document.createElement('button');
+    saveBtn.type = 'submit';
+    saveBtn.className = 'btn primary';
+    saveBtn.textContent = 'Save changes';
+    editActions.appendChild(saveBtn);
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.className = 'btn ghost';
+    cancelBtn.textContent = 'Cancel';
+    cancelBtn.addEventListener('click', () => {
+      editForm.classList.add('hidden');
+    });
+    editActions.appendChild(cancelBtn);
+    editForm.appendChild(editActions);
+
+    editForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const payload = {
+        ...block,
+        title: titleField.input.value.trim(),
+        weeks: Number(weekField.input.value),
+        color: colorField.input.value,
+      };
+      await upsertBlock(payload);
+      await renderSettings(root);
+    });
+
+    card.appendChild(editForm);
+
+    editBtn.addEventListener('click', () => {
+      editForm.classList.toggle('hidden');
+    });
+
+    const lectureSection = document.createElement('div');
+    lectureSection.className = 'settings-lecture-section';
+    if (isLectureListCollapsed(block.blockId)) {
+      lectureSection.classList.add('collapsed');
+    }
+    card.appendChild(lectureSection);
+
+    const lectureList = document.createElement('div');
+    lectureList.className = 'settings-lecture-list';
+
+    const sortedLectures = (block.lectures || [])
+      .slice()
+      .sort((a, b) => (a.week ?? 0) - (b.week ?? 0) || (a.id ?? 0) - (b.id ?? 0));
+
+    if (!sortedLectures.length) {
+      const empty = document.createElement('div');
+      empty.className = 'settings-empty';
+      empty.textContent = 'No lectures yet. Add one to start tagging entries.';
+      lectureList.appendChild(empty);
+    } else {
+      sortedLectures.forEach((lecture) => {
+        lectureList.appendChild(renderLectureRow(block, lecture));
+      });
+    }
+
+    lectureSection.appendChild(lectureList);
+
+    const lectureForm = document.createElement('form');
+    lectureForm.className = 'settings-inline-form settings-lecture-form';
+
+    const lectureGrid = document.createElement('div');
+    lectureGrid.className = 'settings-inline-grid';
+
+    const lectureId = createInlineInput('Lecture ID', 'number', '1');
+    lectureId.input.min = '1';
+    const lectureName = createInlineInput('Lecture name', 'text', 'Intro to anatomy');
+    const lectureWeek = createInlineInput('Week', 'number', '1');
+    lectureWeek.input.min = '1';
+
+    lectureGrid.append(lectureId.element, lectureName.element, lectureWeek.element);
+    lectureForm.appendChild(lectureGrid);
+
+    const lectureActions = document.createElement('div');
+    lectureActions.className = 'settings-inline-actions';
+    const addBtn = document.createElement('button');
+    addBtn.type = 'submit';
+    addBtn.className = 'btn primary';
+    addBtn.textContent = 'Add lecture';
+    lectureActions.appendChild(addBtn);
+    lectureForm.appendChild(lectureActions);
+
+    lectureForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const payload = {
+        id: Number(lectureId.input.value),
+        name: lectureName.input.value.trim(),
+        week: Number(lectureWeek.input.value),
+      };
+      if (!payload.id || !payload.name || !payload.week) return;
+      if (block.weeks && (payload.week < 1 || payload.week > block.weeks)) return;
+      const updated = {
+        ...block,
+        lectures: [...(block.lectures || []), payload],
+      };
+      await upsertBlock(updated);
+      await renderSettings(root);
+    });
+
+    lectureSection.appendChild(lectureForm);
+
+    toggleBtn.addEventListener('click', () => {
+      const collapsed = toggleLectureListCollapse(block.blockId);
+      lectureSection.classList.toggle('collapsed', collapsed);
+      toggleBtn.textContent = collapsed ? 'Show lectures' : 'Hide lectures';
+      toggleBtn.setAttribute('aria-expanded', String(!collapsed));
+    });
+
+    return card;
+  }
+
+  function renderLectureRow(block, lecture) {
+    const row = document.createElement('div');
+    row.className = 'settings-lecture-item';
+
+    const info = document.createElement('div');
+    info.className = 'settings-lecture-info';
+    info.textContent = `${lecture.id}: ${lecture.name || 'Untitled'} (Week ${lecture.week || '?'})`;
+    row.appendChild(info);
+
+    const actions = document.createElement('div');
+    actions.className = 'settings-lecture-actions';
+
+    const editBtn = document.createElement('button');
+    editBtn.type = 'button';
+    editBtn.className = 'settings-icon-btn';
+    editBtn.textContent = 'Edit';
+    actions.appendChild(editBtn);
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.type = 'button';
+    deleteBtn.className = 'settings-icon-btn destructive';
+    deleteBtn.textContent = 'Delete';
+    actions.appendChild(deleteBtn);
+
+    row.appendChild(actions);
+
+    editBtn.addEventListener('click', () => {
+      const form = document.createElement('form');
+      form.className = 'settings-inline-form settings-lecture-edit';
+
+      const grid = document.createElement('div');
+      grid.className = 'settings-inline-grid';
+
+      const nameField = createInlineInput('Lecture name', 'text', 'Lecture title');
+      nameField.input.value = lecture.name || '';
+      const weekField = createInlineInput('Week', 'number', '1');
+      weekField.input.value = lecture.week ?? '';
+      weekField.input.min = '1';
+
+      grid.append(nameField.element, weekField.element);
+      form.appendChild(grid);
+
+      const formActions = document.createElement('div');
+      formActions.className = 'settings-inline-actions';
+      const saveBtn = document.createElement('button');
+      saveBtn.type = 'submit';
+      saveBtn.className = 'btn primary';
+      saveBtn.textContent = 'Save lecture';
+      formActions.appendChild(saveBtn);
+      const cancelBtn = document.createElement('button');
+      cancelBtn.type = 'button';
+      cancelBtn.className = 'btn ghost';
+      cancelBtn.textContent = 'Cancel';
+      cancelBtn.addEventListener('click', () => {
+        form.replaceWith(renderLectureRow(block, lecture));
+      });
+      formActions.appendChild(cancelBtn);
+      form.appendChild(formActions);
+
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const name = nameField.input.value.trim();
+        const week = Number(weekField.input.value);
+        if (!name || !week || (block.weeks && (week < 1 || week > block.weeks))) return;
+        await updateLecture(block.blockId, { id: lecture.id, name, week });
+        await renderSettings(root);
+      });
+
+      row.replaceWith(form);
+    });
+
+    deleteBtn.addEventListener('click', async () => {
+      if (await confirmModal('Delete lecture?')) {
+        await deleteLecture(block.blockId, lecture.id);
+        await renderSettings(root);
+      }
+    });
+
+    return row;
+  }
 }

--- a/style.css
+++ b/style.css
@@ -741,33 +741,38 @@ input[type="checkbox"]:checked::after {
   border-radius: var(--radius-lg);
   border: 1px solid rgba(148, 163, 184, 0.32);
   background: linear-gradient(155deg, rgba(15, 23, 42, 0.85), rgba(8, 13, 23, 0.92));
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-rows: auto auto 1fr;
   gap: var(--pad);
-  min-height: 220px;
-  max-height: clamp(280px, 46vh, 420px);
-  overflow: hidden;
+  min-height: 320px;
+  max-height: clamp(420px, 62vh, 640px);
 }
 
 .editor-tags-title {
+  grid-column: 1 / -1;
   font-size: 1rem;
   font-weight: 600;
   color: var(--text);
 }
 
 .editor-chip-row {
+  grid-column: 1 / -1;
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+  max-height: 120px;
+  overflow-y: auto;
+  padding-right: 6px;
 }
 
 .editor-block-panels {
-  display: flex;
-  flex-direction: column;
+  grid-column: 1 / -1;
+  display: grid;
   gap: var(--pad-sm);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   overflow-y: auto;
   padding-right: 6px;
-  flex: 1;
 }
 
 .editor-block-panel {
@@ -957,19 +962,23 @@ input[type="checkbox"]:checked::after {
 .rich-editor-toolbar {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 8px;
   align-items: center;
+  padding: 6px 8px;
+  border-radius: var(--radius);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(8, 13, 23, 0.55);
+  overflow-x: auto;
 }
 
 .rich-editor-group {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 4px 6px;
+  gap: 4px;
+  padding: 3px 4px;
   border-radius: var(--radius-sm);
   border: 1px solid rgba(148, 163, 184, 0.18);
-  background: rgba(8, 13, 23, 0.6);
-  backdrop-filter: blur(6px);
+  background: rgba(15, 23, 42, 0.65);
 }
 
 .rich-editor-label {
@@ -983,8 +992,8 @@ input[type="checkbox"]:checked::after {
   background: transparent;
   border: none;
   color: var(--text-muted);
-  padding: 6px 8px;
-  font-size: 0.9rem;
+  padding: 4px 6px;
+  font-size: 0.8rem;
   cursor: pointer;
   border-radius: var(--radius-sm);
 }
@@ -1002,8 +1011,8 @@ input[type="checkbox"]:checked::after {
 }
 
 .rich-editor-color input {
-  width: 34px;
-  height: 30px;
+  width: 28px;
+  height: 26px;
   border: 1px solid rgba(148, 163, 184, 0.25);
   border-radius: var(--radius-sm);
   background: rgba(15, 23, 42, 0.4);
@@ -1016,8 +1025,8 @@ input[type="checkbox"]:checked::after {
 }
 
 .rich-editor-swatch {
-  width: 26px;
-  height: 26px;
+  width: 22px;
+  height: 22px;
   border-radius: 50%;
   border: 2px solid rgba(8, 13, 23, 0.7);
   background: var(--swatch-color, transparent);
@@ -1443,9 +1452,193 @@ input[type="checkbox"]:checked::after {
   gap: var(--pad-sm);
 }
 
-.settings-lecture-toggle {
-  margin-top: var(--pad-sm);
-  align-self: flex-start;
+.settings-layout {
+  display: grid;
+  gap: var(--pad-lg);
+  align-items: start;
+}
+
+@media (min-width: 960px) {
+  .settings-layout {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .settings-card--wide {
+    grid-column: 1 / -1;
+  }
+}
+
+.settings-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  padding: var(--pad);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: linear-gradient(165deg, rgba(15, 23, 42, 0.9), rgba(8, 13, 23, 0.92));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.settings-card-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.settings-card-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.settings-card-subtitle {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.settings-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.settings-field-label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.settings-block-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+}
+
+.settings-block-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+  padding: var(--pad-sm) var(--pad);
+  border-radius: var(--radius);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(8, 13, 23, 0.55);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.settings-block-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--pad);
+}
+
+.settings-block-info {
+  display: flex;
+  gap: var(--pad-sm);
+}
+
+.settings-block-accent {
+  --size: 14px;
+  width: var(--size);
+  height: var(--size);
+  margin-top: 4px;
+  border-radius: 999px;
+  background: var(--accent, #38bdf8);
+  box-shadow: 0 0 0 2px rgba(15, 23, 42, 0.75);
+}
+
+.settings-block-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.settings-block-text h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.settings-block-subtitle {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.settings-block-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.settings-icon-btn {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-size: 0.8rem;
+  color: var(--text);
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.settings-icon-btn:hover,
+.settings-icon-btn:focus-visible {
+  background: rgba(56, 189, 248, 0.18);
+  border-color: rgba(56, 189, 248, 0.35);
+  color: #e2f3ff;
+  outline: none;
+}
+
+.settings-icon-btn.destructive {
+  color: #fecaca;
+  border-color: rgba(248, 113, 113, 0.35);
+}
+
+.settings-icon-btn.destructive:hover,
+.settings-icon-btn.destructive:focus-visible {
+  background: rgba(248, 113, 113, 0.18);
+  color: #fee2e2;
+}
+
+.settings-inline-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+  padding: var(--pad-sm) var(--pad);
+  border-radius: var(--radius);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.settings-inline-form.hidden {
+  display: none;
+}
+
+.settings-inline-grid {
+  display: grid;
+  gap: var(--pad-sm);
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.settings-inline-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.settings-inline-label {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.settings-inline-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad-sm);
+  justify-content: flex-end;
 }
 
 .settings-lecture-section {
@@ -1453,6 +1646,69 @@ input[type="checkbox"]:checked::after {
   flex-direction: column;
   gap: var(--pad-sm);
   margin-top: var(--pad-sm);
+}
+
+.settings-lecture-section.collapsed {
+  display: none;
+}
+
+.settings-lecture-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 320px;
+  overflow: auto;
+  padding-right: 6px;
+}
+
+.settings-lecture-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--pad-sm);
+  padding: 8px 12px;
+  border-radius: var(--radius);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(8, 13, 23, 0.55);
+}
+
+.settings-lecture-info {
+  font-size: 0.9rem;
+  color: var(--text);
+}
+
+.settings-lecture-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.settings-lecture-form .settings-inline-grid {
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.settings-empty {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.settings-action-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad-sm);
+}
+
+.btn.ghost {
+  background: transparent;
+  border: 1px dashed rgba(148, 163, 184, 0.3);
+  color: var(--text-muted);
+  box-shadow: none;
+}
+
+.btn.ghost:hover,
+.btn.ghost:focus-visible {
+  border-color: rgba(56, 189, 248, 0.45);
+  color: #e2f3ff;
+  background: rgba(56, 189, 248, 0.1);
 }
 
 .builder-controls {
@@ -2106,136 +2362,301 @@ input[type="checkbox"]:checked::after {
 }
 
 /* Decks */
-.deck-list {
-  display:flex;
-  flex-wrap:wrap;
-  gap:var(--pad);
-  padding:var(--pad);
-}
-.deck {
-  background:var(--panel);
-  border:1px solid var(--border);
-  border-radius:var(--radius);
-  padding:var(--pad-lg);
-  cursor:pointer;
-  box-shadow:0 2px 4px rgba(0,0,0,0.2);
-  position:relative;
-  width:200px;
-  display:flex;
-  flex-direction:column;
-  align-items:center;
-  text-align:center;
-  transition:transform 0.3s ease;
-}
-.deck-title { font-weight:600; margin-bottom:4px; }
-.deck-meta { font-size:0.85rem; color:var(--gray); }
-.deck.pop { transform:scale(1.05); z-index:2; }
-.deck-fan {
-  position:absolute;
-  top:50%;
-  left:50%;
-  transform:translate(-50%,-50%);
-  pointer-events:none;
-}
-.deck-fan .fan-card {
-  position:absolute;
-  width:70px;
-  height:90px;
-  background:var(--panel);
-  border:1px solid var(--border);
-  border-radius:var(--radius);
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  font-size:0.65rem;
-  color:var(--text);
-  opacity:0;
-  transform-origin:bottom center;
-  transition:opacity 0.3s ease, transform 0.3s ease;
-  white-space:nowrap;
-  overflow:hidden;
-  text-overflow:ellipsis;
-}
-.deck-viewer {
-  position: relative;
-  text-align: center;
-  padding: var(--pad);
+.cards-collection {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  min-height: 70vh;
+  gap: var(--pad-lg);
 }
+
+.cards-block {
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.85), rgba(8, 13, 23, 0.92));
+  overflow: hidden;
+}
+
+.cards-block > summary {
+  list-style: none;
+}
+
+.cards-block > summary::-webkit-details-marker {
+  display: none;
+}
+
+.cards-block-header {
+  display: flex;
+  align-items: center;
+  gap: var(--pad);
+  padding: var(--pad);
+  cursor: pointer;
+  position: relative;
+}
+
+.cards-block-header::after {
+  content: '\25BC';
+  font-size: 0.85rem;
+  margin-left: auto;
+  color: var(--text-muted);
+  transition: transform 0.2s ease;
+}
+
+.cards-block[open] .cards-block-header::after {
+  transform: rotate(-180deg);
+}
+
+.cards-block-accent {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: var(--accent, rgba(56, 189, 248, 0.65));
+  box-shadow: 0 0 0 2px rgba(15, 23, 42, 0.75);
+}
+
+.cards-block-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.cards-block-text h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.cards-block-meta {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.cards-week-container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  padding: 0 var(--pad) var(--pad);
+}
+
+.cards-week {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: var(--radius);
+  background: rgba(8, 13, 23, 0.55);
+  overflow: hidden;
+}
+
+.cards-week > summary {
+  list-style: none;
+}
+
+.cards-week > summary::-webkit-details-marker {
+  display: none;
+}
+
+.cards-week-header {
+  padding: 12px 16px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  position: relative;
+}
+
+.cards-week-header::after {
+  content: '\25BC';
+  margin-left: auto;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  transition: transform 0.2s ease;
+}
+
+.cards-week[open] .cards-week-header::after {
+  transform: rotate(-180deg);
+}
+
+.cards-deck-grid {
+  display: grid;
+  gap: var(--pad);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  padding: 0 16px 16px;
+}
+
+.cards-deck {
+  position: relative;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: var(--radius);
+  padding: 16px 18px;
+  width: 100%;
+  text-align: left;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
+}
+
+.cards-deck:hover,
+.cards-deck:focus-visible {
+  outline: none;
+  transform: translateY(-4px);
+  border-color: rgba(56, 189, 248, 0.35);
+  box-shadow: 0 20px 34px rgba(2, 6, 23, 0.45);
+}
+
+.cards-deck-title {
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.cards-deck-meta {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.cards-deck-preview {
+  position: absolute;
+  bottom: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 160px;
+  height: 120px;
+  pointer-events: none;
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+}
+
+.cards-preview-card {
+  width: 88px;
+  height: 52px;
+  margin: 0 -20px;
+  padding: 8px;
+  border-radius: var(--radius-sm);
+  background: rgba(56, 189, 248, 0.16);
+  color: rgba(226, 232, 240, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  box-shadow: 0 12px 24px rgba(2, 6, 23, 0.4);
+  opacity: 0;
+  transform-origin: bottom center;
+  transition: opacity 0.22s ease;
+}
+
+.cards-preview-card.visible {
+  opacity: 1;
+}
+
+.cards-empty {
+  padding: var(--pad);
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.deck-viewer {
+  position: relative;
+  margin-top: var(--pad-lg);
+  padding: var(--pad-lg);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.92), rgba(8, 13, 23, 0.96));
+  box-shadow: 0 32px 60px rgba(2, 6, 23, 0.55);
+}
+
+.cards-viewer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--pad);
+  margin-bottom: var(--pad);
+}
+
+.cards-viewer-header h2 {
+  margin: 0;
+}
+
 .deck-card {
-  margin:0 auto;
+  margin: 0 auto;
 }
 
 .deck-card .item-card {
-  width:40vw;
-  height:20vh;
-  overflow:hidden;
-  display:flex;
-  flex-direction:column;
+  width: min(560px, 60vw);
+  max-height: 60vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 .deck-card .item-card.expanded {
-  height:70vh;
+  max-height: none;
 }
 
 .deck-card .item-card .card-body {
-  display:none;
-  flex:1;
-  overflow:auto;
+  display: none;
+  flex: 1;
+  overflow: auto;
 }
 
 .deck-card .item-card.expanded .card-body {
-  display:block;
+  display: block;
 }
 
 .deck-card .item-card.expanded .section-content {
-  overflow-y:auto;
+  overflow-y: auto;
 }
-.deck-prev, .deck-next {
-  position:absolute;
-  top:50%;
-  transform:translateY(-50%);
-  background:var(--muted);
-  color:var(--text);
-  padding:8px;
-  border-radius:var(--radius);
-  cursor:pointer;
-  border:1px solid var(--border);
+
+.deck-prev,
+.deck-next {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text);
+  padding: 10px;
+  border-radius: var(--radius);
+  cursor: pointer;
+  border: 1px solid rgba(148, 163, 184, 0.25);
 }
-.deck-prev { left:var(--pad); }
-.deck-next { right:var(--pad); }
-.deck-prev:hover, .deck-next:hover {
-  transform:translateY(calc(-50% - 2px));
+
+.deck-prev { left: var(--pad); }
+.deck-next { right: var(--pad); }
+
+.deck-prev:hover,
+.deck-next:hover {
+  transform: translateY(calc(-50% - 2px));
 }
+
 .deck-related {
-  display:flex;
-  flex-wrap:wrap;
-  gap:var(--pad);
-  justify-content:center;
-  margin-top:var(--pad);
-  opacity:0;
-  transform:translateY(-10px);
-  transition:opacity 0.3s ease, transform 0.3s ease;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad);
+  justify-content: center;
+  margin-top: var(--pad);
+  opacity: 0;
+  transform: translateY(-10px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
 }
+
 .deck-related:not(.hidden) {
-  opacity:1;
-  transform:translateY(0);
+  opacity: 1;
+  transform: translateY(0);
 }
+
 .deck-related .related-card {
-  opacity:0;
-  transform:scale(0.95);
-  transition:opacity 0.3s ease, transform 0.3s ease;
+  opacity: 0;
+  transform: scale(0.95);
+  transition: opacity 0.3s ease, transform 0.3s ease;
 }
+
 .deck-related .related-card.visible {
-  opacity:1;
-  transform:scale(1);
+  opacity: 1;
+  transform: scale(1);
 }
+
 .deck-close {
-  margin-top:var(--pad);
+  margin-top: var(--pad);
 }
 .hidden { display:none !important; }
 


### PR DESCRIPTION
## Summary
- rebuild the settings tab with card-based layout, collapsible block/lecture management, and inline block editing
- widen the editor window, condense the rich text toolbar, and expand the curriculum tagging workspace
- reorganize the cards tab into collapsible block/week groupings with refreshed deck tiles and viewer interactions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc321904748322a034cacdc6b84d28