### PR TITLE
Revamp Cards tab decks and streamline editor toolbar

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -145,7 +145,7 @@ async function render() {
     main.appendChild(content);
     const filter = { ...state.filters, query: state.query };
     const items = await findItemsByFilter(filter);
-    renderCards(content, items, render);
+    await renderCards(content, items, render);
   } else if (state.tab === 'Study') {
     main.appendChild(createEntryAddControl(render, 'disease'));
     const content = document.createElement('div');

--- a/js/ui/components/cards.js
+++ b/js/ui/components/cards.js
@@ -1,4 +1,5 @@
 import { createItemCard } from './cardlist.js';
+import { listBlocks } from '../../storage/storage.js';
 
 /**
  * Render lecture-based decks combining all item types.
@@ -6,110 +7,182 @@ import { createItemCard } from './cardlist.js';
  * @param {import('../../types.js').Item[]} items
  * @param {Function} onChange
  */
-export function renderCards(container, items, onChange){
+export async function renderCards(container, items, onChange){
   container.innerHTML = '';
-  const decks = new Map();
-  items.forEach(it => {
-    if (it.lectures && it.lectures.length){
-      it.lectures.forEach(l => {
-        const key = l.name || `Lecture ${l.id}`;
-        if (!decks.has(key)) decks.set(key, []);
-        decks.get(key).push(it);
-      });
-    } else {
-      if (!decks.has('Unassigned')) decks.set('Unassigned', []);
-      decks.get('Unassigned').push(it);
-    }
-  });
 
-  const list = document.createElement('div');
-  list.className = 'deck-list';
-  container.appendChild(list);
+  const blocks = await listBlocks();
+  const blockMap = new Map(blocks.map(b => [b.blockId, b]));
+
+  const hierarchy = buildHierarchy(items, blockMap);
+
+  const layout = document.createElement('div');
+  layout.className = 'cards-layout';
+  container.appendChild(layout);
+
+  const tree = document.createElement('div');
+  tree.className = 'cards-hierarchy';
+  layout.appendChild(tree);
 
   const viewer = document.createElement('div');
   viewer.className = 'deck-viewer hidden';
-  container.appendChild(viewer);
+  layout.appendChild(viewer);
 
-  decks.forEach((cards, lecture) => {
-    const deck = document.createElement('div');
-    deck.className = 'deck';
-    const title = document.createElement('div');
-    title.className = 'deck-title';
-    title.textContent = lecture;
-    const meta = document.createElement('div');
-    meta.className = 'deck-meta';
-    const blocks = Array.from(new Set(cards.flatMap(c => c.blocks || []))).join(', ');
-    const weeks = Array.from(new Set(cards.flatMap(c => c.weeks || []))).join(', ');
-    meta.textContent = `${blocks}${blocks && weeks ? ' • ' : ''}${weeks ? 'Week ' + weeks : ''}`;
-    deck.appendChild(title);
-    deck.appendChild(meta);
-    deck.addEventListener('click', () => { stopPreview(deck); openDeck(lecture, cards); });
-    let hoverTimer;
-    deck.addEventListener('mouseenter', () => {
-      hoverTimer = setTimeout(() => startPreview(deck, cards), 3000);
+  if (!hierarchy.length){
+    const empty = document.createElement('div');
+    empty.className = 'cards-empty';
+    empty.textContent = 'No cards match your filters yet.';
+    tree.appendChild(empty);
+    return;
+  }
+
+  hierarchy.forEach(block => {
+    const section = document.createElement('section');
+    section.className = 'cards-block';
+    if (block.color) section.style.setProperty('--block-accent', block.color);
+
+    const header = document.createElement('button');
+    header.type = 'button';
+    header.className = 'cards-block-header';
+    header.setAttribute('aria-expanded', 'true');
+
+    const heading = document.createElement('div');
+    heading.className = 'cards-block-heading';
+    const title = document.createElement('h3');
+    title.textContent = block.title;
+    heading.appendChild(title);
+    if (block.subtitle){
+      const subtitle = document.createElement('span');
+      subtitle.className = 'cards-block-subtitle';
+      subtitle.textContent = block.subtitle;
+      heading.appendChild(subtitle);
+    }
+    header.appendChild(heading);
+
+    const count = document.createElement('span');
+    count.className = 'cards-count';
+    count.textContent = `${block.total} card${block.total === 1 ? '' : 's'}`;
+    header.appendChild(count);
+
+    section.appendChild(header);
+
+    const body = document.createElement('div');
+    body.className = 'cards-block-content';
+    section.appendChild(body);
+
+    header.addEventListener('click', () => {
+      const expanded = header.getAttribute('aria-expanded') === 'true';
+      header.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+      body.classList.toggle('collapsed', expanded);
     });
-    deck.addEventListener('mouseleave', () => {
-      clearTimeout(hoverTimer);
-      stopPreview(deck);
-    });
-    list.appendChild(deck);
+
+    if (!block.weeks.length){
+      const emptyWeek = document.createElement('div');
+      emptyWeek.className = 'cards-week-empty';
+      emptyWeek.textContent = 'No lectures assigned yet.';
+      body.appendChild(emptyWeek);
+    } else {
+      block.weeks.forEach(week => {
+        const weekSection = document.createElement('section');
+        weekSection.className = 'cards-week';
+
+        const weekHeader = document.createElement('button');
+        weekHeader.type = 'button';
+        weekHeader.className = 'cards-week-header';
+        weekHeader.setAttribute('aria-expanded', 'true');
+
+        const weekTitle = document.createElement('span');
+        weekTitle.className = 'cards-week-title';
+        weekTitle.textContent = week.title;
+        weekHeader.appendChild(weekTitle);
+
+        const weekMeta = document.createElement('span');
+        weekMeta.className = 'cards-count';
+        weekMeta.textContent = `${week.total} card${week.total === 1 ? '' : 's'}`;
+        weekHeader.appendChild(weekMeta);
+
+        weekSection.appendChild(weekHeader);
+
+        const lecturesWrap = document.createElement('div');
+        lecturesWrap.className = 'cards-week-content';
+        weekSection.appendChild(lecturesWrap);
+
+        weekHeader.addEventListener('click', () => {
+          const expanded = weekHeader.getAttribute('aria-expanded') === 'true';
+          weekHeader.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+          lecturesWrap.classList.toggle('collapsed', expanded);
+        });
+
+        if (!week.lectures.length){
+          const emptyLect = document.createElement('div');
+          emptyLect.className = 'cards-week-empty';
+          emptyLect.textContent = 'No lectures for this week yet.';
+          lecturesWrap.appendChild(emptyLect);
+        } else {
+          const grid = document.createElement('div');
+          grid.className = 'cards-lecture-grid';
+          lecturesWrap.appendChild(grid);
+
+          week.lectures.forEach(lecture => {
+            const deck = createLectureDeck(lecture);
+            deck.addEventListener('click', () => openDeck(lecture));
+            grid.appendChild(deck);
+          });
+        }
+
+        body.appendChild(weekSection);
+      });
+    }
+
+    tree.appendChild(section);
   });
 
-  function startPreview(deckEl, cards){
-    if (deckEl._preview) return;
-    deckEl.classList.add('pop');
-    const fan = document.createElement('div');
-    fan.className = 'deck-fan';
-    deckEl.appendChild(fan);
-    const show = cards.slice(0,5);
-    const spread = 20;
-    const offset = (show.length - 1) * spread / 2;
-    show.forEach((c,i) => {
-      const mini = document.createElement('div');
-      mini.className = 'fan-card';
-      mini.textContent = c.name || c.concept || '';
-      fan.appendChild(mini);
-      const angle = -offset + i * spread;
-      mini.style.transform = `rotate(${angle}deg) translateY(-80px)`;
-      setTimeout(() => { mini.style.opacity = 1; }, i * 100);
-    });
-    deckEl._preview = { fan };
-  }
-
-  function stopPreview(deckEl){
-    const prev = deckEl._preview;
-    if (prev){
-      prev.fan.remove();
-      deckEl.classList.remove('pop');
-      deckEl._preview = null;
-    }
-  }
-
-  function openDeck(title, cards){
-    list.classList.add('hidden');
+  function openDeck(lecture){
+    tree.classList.add('hidden');
     viewer.classList.remove('hidden');
     viewer.innerHTML = '';
 
-    const header = document.createElement('h2');
-    header.textContent = title;
+    const header = document.createElement('div');
+    header.className = 'deck-viewer-header';
     viewer.appendChild(header);
 
+    const crumb = document.createElement('div');
+    crumb.className = 'deck-viewer-crumb';
+    const crumbs = [lecture.blockTitle, lecture.weekTitle].filter(Boolean);
+    crumb.textContent = crumbs.join(' • ');
+    header.appendChild(crumb);
+
+    const title = document.createElement('h2');
+    title.textContent = lecture.title;
+    header.appendChild(title);
+
+    const headerMeta = document.createElement('span');
+    headerMeta.className = 'deck-viewer-count';
+    headerMeta.textContent = `${lecture.items.length} card${lecture.items.length === 1 ? '' : 's'}`;
+    header.appendChild(headerMeta);
+
     const cardHolder = document.createElement('div');
-    cardHolder.className = 'deck-card';
+    cardHolder.className = 'deck-viewer-card';
     viewer.appendChild(cardHolder);
+
+    const controls = document.createElement('div');
+    controls.className = 'deck-viewer-controls';
+    viewer.appendChild(controls);
 
     const prev = document.createElement('button');
     prev.className = 'deck-prev';
-    prev.textContent = '◀';
+    prev.setAttribute('aria-label', 'Previous card');
+    prev.innerHTML = '&#9664;';
+    controls.appendChild(prev);
+
     const next = document.createElement('button');
     next.className = 'deck-next';
-    next.textContent = '▶';
-    viewer.appendChild(prev);
-    viewer.appendChild(next);
+    next.setAttribute('aria-label', 'Next card');
+    next.innerHTML = '&#9654;';
+    controls.appendChild(next);
 
     const toggle = document.createElement('button');
-    toggle.className = 'deck-related-toggle btn';
-    toggle.textContent = 'Show Related';
+    toggle.className = 'deck-related-toggle btn subtle';
+    toggle.textContent = 'Show related';
     viewer.appendChild(toggle);
 
     const relatedWrap = document.createElement('div');
@@ -117,8 +190,8 @@ export function renderCards(container, items, onChange){
     viewer.appendChild(relatedWrap);
 
     const close = document.createElement('button');
-    close.className = 'deck-close btn';
-    close.textContent = 'Close';
+    close.className = 'deck-close btn ghost';
+    close.textContent = 'Back to decks';
     viewer.appendChild(close);
 
     let idx = 0;
@@ -126,14 +199,14 @@ export function renderCards(container, items, onChange){
 
     function renderCard(){
       cardHolder.innerHTML = '';
-      cardHolder.appendChild(createItemCard(cards[idx], onChange));
+      cardHolder.appendChild(createItemCard(lecture.items[idx], onChange));
       renderRelated();
     }
 
     function renderRelated(){
       relatedWrap.innerHTML = '';
       if (!showRelated) return;
-      const current = cards[idx];
+      const current = lecture.items[idx];
       (current.links || []).forEach(l => {
         const item = items.find(it => it.id === l.id);
         if (item) {
@@ -146,17 +219,18 @@ export function renderCards(container, items, onChange){
     }
 
     prev.addEventListener('click', () => {
-      idx = (idx - 1 + cards.length) % cards.length;
+      idx = (idx - 1 + lecture.items.length) % lecture.items.length;
       renderCard();
     });
+
     next.addEventListener('click', () => {
-      idx = (idx + 1) % cards.length;
+      idx = (idx + 1) % lecture.items.length;
       renderCard();
     });
 
     toggle.addEventListener('click', () => {
       showRelated = !showRelated;
-      toggle.textContent = showRelated ? 'Hide Related' : 'Show Related';
+      toggle.textContent = showRelated ? 'Hide related' : 'Show related';
       relatedWrap.classList.toggle('hidden', !showRelated);
       renderRelated();
     });
@@ -165,7 +239,7 @@ export function renderCards(container, items, onChange){
       document.removeEventListener('keydown', keyHandler);
       viewer.classList.add('hidden');
       viewer.innerHTML = '';
-      list.classList.remove('hidden');
+      tree.classList.remove('hidden');
     });
 
     function keyHandler(e){
@@ -173,8 +247,215 @@ export function renderCards(container, items, onChange){
       if (e.key === 'ArrowRight') next.click();
       if (e.key === 'Escape') close.click();
     }
-    document.addEventListener('keydown', keyHandler);
 
+    document.addEventListener('keydown', keyHandler);
     renderCard();
   }
+}
+
+function buildHierarchy(items, blockMap){
+  const blocks = new Map();
+
+  function ensureBlock(blockId, title, options = {}){
+    if (!blocks.has(blockId)) {
+      blocks.set(blockId, {
+        key: blockId,
+        title,
+        subtitle: options.subtitle || '',
+        color: options.color || '',
+        order: typeof options.order === 'number' ? options.order : Number.POSITIVE_INFINITY,
+        weeks: new Map(),
+        ids: new Set()
+      });
+    }
+    return blocks.get(blockId);
+  }
+
+  function ensureWeek(block, weekKey, title, order){
+    if (!block.weeks.has(weekKey)) {
+      block.weeks.set(weekKey, {
+        key: weekKey,
+        title,
+        order,
+        lectures: new Map(),
+        ids: new Set()
+      });
+    }
+    return block.weeks.get(weekKey);
+  }
+
+  function ensureLecture(week, lectureKey, lectureTitle, meta){
+    if (!week.lectures.has(lectureKey)) {
+      week.lectures.set(lectureKey, {
+        key: lectureKey,
+        title: lectureTitle,
+        blockTitle: meta.blockTitle,
+        weekTitle: meta.weekTitle,
+        order: meta.order,
+        preview: meta.preview,
+        items: []
+      });
+    }
+    return week.lectures.get(lectureKey);
+  }
+
+  const fallbackBlockId = '__unassigned';
+
+  items.forEach(item => {
+    let placed = false;
+    if (item.lectures && item.lectures.length){
+      item.lectures.forEach(ref => {
+        const blockDef = blockMap.get(ref.blockId);
+        const weeksLabel = typeof blockDef?.weeks === 'number'
+          ? `${blockDef.weeks} week${blockDef.weeks === 1 ? '' : 's'}`
+          : '';
+        const block = ensureBlock(
+          ref.blockId || fallbackBlockId,
+          blockDef?.title || ref.blockId || 'Unassigned',
+          {
+            subtitle: weeksLabel,
+            color: blockDef?.color,
+            order: blockDef?.order
+          }
+        );
+        const weekLabel = typeof ref.week === 'number' ? `Week ${ref.week}` : 'General';
+        const week = ensureWeek(
+          block,
+          typeof ref.week === 'number' ? `week-${ref.week}` : 'general',
+          weekLabel,
+          typeof ref.week === 'number' ? ref.week : Number.POSITIVE_INFINITY
+        );
+
+        const lectureDef = blockDef?.lectures?.find(l => l.id === ref.id);
+        const lectureTitle = lectureDef?.name || ref.name || `Lecture ${ref.id ?? ''}`.trim() || 'Lecture';
+        const lectureKey = `${ref.blockId || 'blockless'}|${ref.id ?? lectureTitle}`;
+        const lecture = ensureLecture(week, lectureKey, lectureTitle, {
+          blockTitle: block.title,
+          weekTitle: week.title,
+          order: typeof lectureDef?.week === 'number'
+            ? lectureDef.week * 1000 + (lectureDef.id ?? 0)
+            : (typeof ref.week === 'number' ? ref.week : Number.POSITIVE_INFINITY),
+          preview: lectureDef?.name || lectureTitle
+        });
+        lecture.items.push(item);
+        week.ids.add(item.id);
+        block.ids.add(item.id);
+        placed = true;
+      });
+    }
+
+    if (!placed){
+      const blockIds = item.blocks && item.blocks.length ? item.blocks : [fallbackBlockId];
+      const weeks = item.weeks && item.weeks.length ? item.weeks : [null];
+      blockIds.forEach(blockId => {
+        const blockDef = blockMap.get(blockId);
+        const weeksLabel = typeof blockDef?.weeks === 'number'
+          ? `${blockDef.weeks} week${blockDef.weeks === 1 ? '' : 's'}`
+          : '';
+        const block = ensureBlock(
+          blockDef?.blockId || blockId || fallbackBlockId,
+          blockDef?.title || blockId || 'Unassigned',
+          {
+            subtitle: weeksLabel,
+            color: blockDef?.color,
+            order: blockDef?.order
+          }
+        );
+        weeks.forEach(weekNum => {
+          const isNumber = typeof weekNum === 'number' && Number.isFinite(weekNum);
+          const week = ensureWeek(
+            block,
+            isNumber ? `week-${weekNum}` : 'general',
+            isNumber ? `Week ${weekNum}` : 'General',
+            isNumber ? weekNum : Number.POSITIVE_INFINITY
+          );
+          const lectureKey = `${block.key}|week-${weekNum ?? 'general'}`;
+          const lecture = ensureLecture(week, lectureKey, 'General deck', {
+            blockTitle: block.title,
+            weekTitle: week.title,
+            order: week.order,
+            preview: item.name || item.concept || 'Card'
+          });
+          lecture.items.push(item);
+          week.ids.add(item.id);
+          block.ids.add(item.id);
+        });
+      });
+    }
+  });
+
+  const blockList = Array.from(blocks.values()).map(block => {
+    const total = block.ids.size;
+    const weekList = Array.from(block.weeks.values())
+      .map(week => {
+        const weekTotal = week.ids.size;
+        const lectureList = Array.from(week.lectures.values())
+          .sort((a, b) => {
+            const orderA = typeof a.order === 'number' ? a.order : Number.POSITIVE_INFINITY;
+            const orderB = typeof b.order === 'number' ? b.order : Number.POSITIVE_INFINITY;
+            if (orderA !== orderB) return orderA - orderB;
+            return a.title.localeCompare(b.title);
+          });
+        const { ids, ...restWeek } = week;
+        return { ...restWeek, total: weekTotal, lectures: lectureList };
+      })
+      .sort((a, b) => {
+        if (a.order !== b.order) return a.order - b.order;
+        return a.title.localeCompare(b.title);
+      });
+    const { ids, ...restBlock } = block;
+    return { ...restBlock, total, weeks: weekList };
+  });
+
+  return blockList.sort((a, b) => {
+    if (a.order !== b.order) return a.order - b.order;
+    return a.title.localeCompare(b.title);
+  });
+}
+
+function createLectureDeck(lecture){
+  const deck = document.createElement('button');
+  deck.type = 'button';
+  deck.className = 'cards-deck';
+
+  const stack = document.createElement('div');
+  stack.className = 'cards-deck-stack';
+  deck.appendChild(stack);
+
+  const layers = Math.max(3, Math.min(lecture.items.length, 4));
+  for (let i = 0; i < layers; i++) {
+    const layer = document.createElement('div');
+    layer.className = 'cards-deck-layer';
+    layer.style.setProperty('--layer', `${i}`);
+    if (i === 0) {
+      const label = document.createElement('div');
+      label.className = 'cards-deck-layer-label';
+      label.textContent = lecture.items[0]?.name || lecture.items[0]?.concept || 'Card';
+      layer.appendChild(label);
+    }
+    stack.appendChild(layer);
+  }
+
+  const info = document.createElement('div');
+  info.className = 'cards-deck-info';
+
+  const title = document.createElement('h4');
+  title.className = 'cards-deck-title';
+  title.textContent = lecture.title;
+  info.appendChild(title);
+
+  if (lecture.weekTitle) {
+    const meta = document.createElement('div');
+    meta.className = 'cards-deck-meta';
+    meta.textContent = lecture.weekTitle;
+    info.appendChild(meta);
+  }
+
+  const count = document.createElement('div');
+  count.className = 'cards-deck-count';
+  count.textContent = `${lecture.items.length} card${lecture.items.length === 1 ? '' : 's'}`;
+  info.appendChild(count);
+
+  deck.appendChild(info);
+  return deck;
 }

--- a/js/ui/components/editor.js
+++ b/js/ui/components/editor.js
@@ -46,7 +46,7 @@ function escapeHtml(str = '') {
 export async function openEditor(kind, onSave, existing = null) {
   const win = createFloatingWindow({
     title: `${existing ? 'Edit' : 'Add'} ${titleMap[kind] || kind}`,
-    width: 600
+    width: 720
   });
 
   const form = document.createElement('form');

--- a/js/ui/components/rich-text.js
+++ b/js/ui/components/rich-text.js
@@ -166,6 +166,7 @@ export function createRichTextEditor({ value = '' } = {}){
 
   const toolbar = document.createElement('div');
   toolbar.className = 'rich-editor-toolbar';
+  toolbar.setAttribute('role', 'toolbar');
   wrapper.appendChild(toolbar);
 
   const editable = document.createElement('div');
@@ -195,14 +196,15 @@ export function createRichTextEditor({ value = '' } = {}){
     return editable.contains(anchor) && editable.contains(focus);
   }
 
-  function createGroup(){
+  function createGroup(variant){
     const group = document.createElement('div');
     group.className = 'rich-editor-group';
+    if (variant) group.classList.add(`rich-editor-group--${variant}`);
     toolbar.appendChild(group);
     return group;
   }
 
-  const inlineGroup = createGroup();
+  const inlineGroup = createGroup('inline');
   [
     createToolbarButton('B', 'Bold', () => exec('bold')),
     createToolbarButton('I', 'Italic', () => exec('italic')),
@@ -215,8 +217,9 @@ export function createRichTextEditor({ value = '' } = {}){
   colorWrap.title = 'Text color';
   const colorInput = document.createElement('input');
   colorInput.type = 'color';
-  colorInput.value = '#ffffff';
-  colorInput.dataset.lastColor = '#ffffff';
+  colorInput.value = '#e2e8f0';
+  colorInput.dataset.lastColor = '#e2e8f0';
+  colorInput.setAttribute('aria-label', 'Text color');
   colorInput.addEventListener('input', () => {
     if (!hasActiveSelection()) {
       const previous = colorInput.dataset.lastColor || '#ffffff';
@@ -227,15 +230,11 @@ export function createRichTextEditor({ value = '' } = {}){
     colorInput.dataset.lastColor = colorInput.value;
   });
   colorWrap.appendChild(colorInput);
-  const colorGroup = createGroup();
+  const colorGroup = createGroup('color');
   colorGroup.appendChild(colorWrap);
 
-  const highlightGroup = createGroup();
-  highlightGroup.classList.add('rich-editor-highlight-group');
-  const highlightLabel = document.createElement('span');
-  highlightLabel.className = 'rich-editor-label';
-  highlightLabel.textContent = 'Highlight';
-  highlightGroup.appendChild(highlightLabel);
+  const highlightGroup = createGroup('swatches');
+  highlightGroup.setAttribute('aria-label', 'Highlight color');
 
   const highlightColors = [
     ['#facc15', 'Yellow'],
@@ -278,9 +277,10 @@ export function createRichTextEditor({ value = '' } = {}){
   clearSwatch.addEventListener('click', clearHighlight);
   highlightGroup.appendChild(clearSwatch);
 
-  const listGroup = createGroup();
+  const listGroup = createGroup('lists');
   const listSelect = document.createElement('select');
   listSelect.className = 'rich-editor-select';
+  listSelect.setAttribute('aria-label', 'Insert list');
   [
     ['', 'Lists'],
     ['unordered', 'Bulleted'],
@@ -331,6 +331,7 @@ export function createRichTextEditor({ value = '' } = {}){
 
   const sizeSelect = document.createElement('select');
   sizeSelect.className = 'rich-editor-size';
+  sizeSelect.setAttribute('aria-label', 'Adjust font size');
   const sizes = [
     ['Default', ''],
     ['Small', '0.85rem'],
@@ -375,7 +376,7 @@ export function createRichTextEditor({ value = '' } = {}){
   });
   listGroup.appendChild(sizeSelect);
 
-  const mediaGroup = createGroup();
+  const mediaGroup = createGroup('media');
 
   const linkBtn = createToolbarButton('🔗', 'Insert link', () => {
     focusEditor();
@@ -414,11 +415,8 @@ export function createRichTextEditor({ value = '' } = {}){
   mediaGroup.appendChild(mediaBtn);
 
   const clearBtn = createToolbarButton('⌫', 'Clear formatting', () => exec('removeFormat'));
-  const utilityGroup = createGroup();
+  const utilityGroup = createGroup('utility');
   utilityGroup.appendChild(clearBtn);
-
-  const clearHighlightBtn = createToolbarButton('⨯', 'Remove highlight', clearHighlight);
-  utilityGroup.appendChild(clearHighlightBtn);
 
   editable.addEventListener('keydown', (e) => {
     if (e.key === 'Tab') {

--- a/style.css
+++ b/style.css
@@ -20,6 +20,7 @@
   --radius: 14px;
   --radius-lg: 20px;
   --radius-sm: 8px;
+  --radius-xl: 26px;
   --pad: 16px;
   --pad-lg: 24px;
   --pad-sm: 10px;
@@ -642,6 +643,17 @@ input[type="checkbox"]:checked::after {
   border: 1px solid transparent;
   box-shadow: none;
 }
+.btn.ghost {
+  background: transparent;
+  color: var(--text-muted);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  box-shadow: none;
+}
+.btn.ghost:hover {
+  color: var(--text);
+  border-color: rgba(148, 163, 184, 0.45);
+  transform: translateY(-1px);
+}
 .btn.danger {
   background: linear-gradient(135deg, rgba(254, 202, 202, 0.95), rgba(248, 113, 113, 0.88));
   color: #30090f;
@@ -744,8 +756,8 @@ input[type="checkbox"]:checked::after {
   display: flex;
   flex-direction: column;
   gap: var(--pad);
-  min-height: 220px;
-  max-height: clamp(280px, 46vh, 420px);
+  min-height: 260px;
+  max-height: clamp(340px, 58vh, 560px);
   overflow: hidden;
 }
 
@@ -947,29 +959,45 @@ input[type="checkbox"]:checked::after {
 .rich-editor {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  background: rgba(15, 23, 42, 0.4);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: var(--pad-sm);
+  gap: 10px;
+  background: linear-gradient(160deg, rgba(10, 16, 28, 0.92), rgba(12, 21, 38, 0.82));
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: var(--radius-lg);
+  padding: var(--pad-sm) var(--pad);
+  box-shadow: 0 18px 46px -28px rgba(2, 6, 23, 0.8);
 }
 
 .rich-editor-toolbar {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 8px;
   align-items: center;
+  padding: 6px 8px;
+  border-radius: var(--radius-lg);
+  background: rgba(6, 12, 24, 0.64);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  backdrop-filter: blur(8px);
 }
 
 .rich-editor-group {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
   padding: 4px 6px;
-  border-radius: var(--radius-sm);
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  background: rgba(8, 13, 23, 0.6);
-  backdrop-filter: blur(6px);
+  border-radius: var(--radius);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(12, 20, 36, 0.55);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+}
+
+.rich-editor-group--swatches {
+  gap: 6px;
+  padding: 4px 8px;
+}
+
+.rich-editor-group--lists,
+.rich-editor-group--utility {
+  background: rgba(10, 18, 32, 0.48);
 }
 
 .rich-editor-label {
@@ -983,15 +1011,18 @@ input[type="checkbox"]:checked::after {
   background: transparent;
   border: none;
   color: var(--text-muted);
-  padding: 6px 8px;
-  font-size: 0.9rem;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+  font-size: 0.85rem;
+  font-weight: 600;
   cursor: pointer;
-  border-radius: var(--radius-sm);
+  border-radius: 8px;
 }
 
 .rich-editor-btn:hover,
 .rich-editor-btn:focus {
-  background: var(--muted);
+  background: rgba(148, 163, 184, 0.18);
   color: var(--text);
   outline: none;
 }
@@ -1002,39 +1033,35 @@ input[type="checkbox"]:checked::after {
 }
 
 .rich-editor-color input {
-  width: 34px;
-  height: 30px;
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  border-radius: var(--radius-sm);
-  background: rgba(15, 23, 42, 0.4);
+  width: 32px;
+  height: 28px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 8px;
+  background: rgba(10, 18, 32, 0.6);
   padding: 0;
   cursor: pointer;
 }
 
-.rich-editor-highlight-group {
-  gap: 8px;
-}
-
 .rich-editor-swatch {
-  width: 26px;
-  height: 26px;
+  width: 24px;
+  height: 24px;
   border-radius: 50%;
-  border: 2px solid rgba(8, 13, 23, 0.7);
+  border: 2px solid rgba(8, 13, 23, 0.65);
   background: var(--swatch-color, transparent);
-  box-shadow: 0 0 0 2px rgba(148, 163, 184, 0.25);
+  box-shadow: 0 0 0 2px rgba(148, 163, 184, 0.3);
   cursor: pointer;
 }
 
 .rich-editor-swatch:hover,
 .rich-editor-swatch:focus {
-  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.45);
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.55);
   outline: none;
 }
 
 .rich-editor-swatch--clear {
-  background: rgba(15, 23, 42, 0.6);
+  background: rgba(12, 20, 36, 0.7);
   color: var(--text-muted);
-  font-size: 0.85rem;
+  font-size: 0.75rem;
   line-height: 1;
 }
 
@@ -1045,25 +1072,29 @@ input[type="checkbox"]:checked::after {
 
 .rich-editor-select,
 .rich-editor-size {
-  background: rgba(15, 23, 42, 0.6);
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  border-radius: var(--radius-sm);
+  background: rgba(12, 20, 36, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 8px;
   color: var(--text);
-  padding: 6px 10px;
+  padding: 4px 10px;
   cursor: pointer;
-  font-size: 0.9rem;
-  min-width: 120px;
+  font-size: 0.85rem;
+  min-width: 110px;
+  height: 30px;
 }
 
 .rich-editor-area {
-  min-height: 150px;
-  padding: 12px;
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  border-radius: var(--radius);
-  background: rgba(2, 6, 23, 0.55);
+  min-height: 180px;
+  padding: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: var(--radius-lg);
+  background: rgba(2, 6, 23, 0.6);
   overflow: auto;
   word-break: break-word;
   backdrop-filter: blur(4px);
+  line-height: 1.5;
+  font-size: 0.95rem;
+  font-weight: 400;
 }
 
 .rich-editor-area:focus {
@@ -1092,25 +1123,6 @@ input[type="checkbox"]:checked::after {
   margin-left: auto;
   font-size: 0.85rem;
   opacity: 0.8;
-}
-
-.editor-tags {
-  margin-top: var(--pad);
-  padding: var(--pad);
-  background: rgba(15, 23, 42, 0.45);
-  border-radius: var(--radius);
-  border: 1px solid var(--border);
-  max-height: min(420px, 50vh);
-  overflow: auto;
-  display: flex;
-  flex-direction: column;
-  gap: var(--pad-sm);
-}
-
-.editor-tags-title {
-  font-weight: 600;
-  margin: 0;
-  font-size: 1rem;
 }
 
 .editor-tag-block {
@@ -2106,136 +2118,447 @@ input[type="checkbox"]:checked::after {
 }
 
 /* Decks */
-.deck-list {
-  display:flex;
-  flex-wrap:wrap;
-  gap:var(--pad);
-  padding:var(--pad);
-}
-.deck {
-  background:var(--panel);
-  border:1px solid var(--border);
-  border-radius:var(--radius);
-  padding:var(--pad-lg);
-  cursor:pointer;
-  box-shadow:0 2px 4px rgba(0,0,0,0.2);
-  position:relative;
-  width:200px;
-  display:flex;
-  flex-direction:column;
-  align-items:center;
-  text-align:center;
-  transition:transform 0.3s ease;
-}
-.deck-title { font-weight:600; margin-bottom:4px; }
-.deck-meta { font-size:0.85rem; color:var(--gray); }
-.deck.pop { transform:scale(1.05); z-index:2; }
-.deck-fan {
-  position:absolute;
-  top:50%;
-  left:50%;
-  transform:translate(-50%,-50%);
-  pointer-events:none;
-}
-.deck-fan .fan-card {
-  position:absolute;
-  width:70px;
-  height:90px;
-  background:var(--panel);
-  border:1px solid var(--border);
-  border-radius:var(--radius);
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  font-size:0.65rem;
-  color:var(--text);
-  opacity:0;
-  transform-origin:bottom center;
-  transition:opacity 0.3s ease, transform 0.3s ease;
-  white-space:nowrap;
-  overflow:hidden;
-  text-overflow:ellipsis;
-}
-.deck-viewer {
-  position: relative;
-  text-align: center;
-  padding: var(--pad);
+.cards-layout {
   display: flex;
   flex-direction: column;
+  gap: var(--pad-lg);
+  position: relative;
+}
+
+.cards-hierarchy {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-lg);
+}
+
+.cards-empty {
+  padding: calc(var(--pad-lg) * 1.2);
+  border-radius: var(--radius-xl);
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  background: rgba(10, 17, 29, 0.6);
+  color: var(--text-muted);
+  text-align: center;
+  font-size: 1rem;
+}
+
+.cards-block {
+  position: relative;
+  padding: var(--pad-lg);
+  border-radius: var(--radius-xl);
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.92), rgba(7, 12, 24, 0.9));
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 28px 60px -40px rgba(2, 6, 23, 0.9);
+  overflow: hidden;
+  --block-accent: rgba(56, 189, 248, 0.45);
+}
+
+.cards-block::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: linear-gradient(120deg, rgba(148, 163, 184, 0.12), transparent 55%);
+}
+
+.cards-block::after {
+  content: '';
+  position: absolute;
+  top: var(--pad-lg);
+  bottom: var(--pad-lg);
+  left: 0;
+  width: 4px;
+  border-radius: 999px;
+  background: var(--block-accent);
+  opacity: 0.75;
+}
+
+.cards-block-header {
+  display: flex;
   align-items: center;
-  justify-content: center;
+  gap: var(--pad);
+  justify-content: space-between;
+  width: 100%;
+  padding: 14px calc(var(--pad-lg) * 1.1);
+  margin-left: var(--pad-sm);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: rgba(9, 15, 26, 0.75);
+  color: var(--text);
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.3s ease, border-color 0.3s ease, transform 0.3s ease;
+  position: relative;
+  padding-right: 58px;
+}
+
+.cards-block-header::after {
+  content: '';
+  position: absolute;
+  right: 22px;
+  top: 50%;
+  width: 12px;
+  height: 12px;
+  border-right: 2px solid rgba(148, 163, 184, 0.65);
+  border-bottom: 2px solid rgba(148, 163, 184, 0.65);
+  transform: translateY(-50%) rotate(45deg);
+  transition: transform 0.3s ease, border-color 0.3s ease;
+}
+
+.cards-block-header:hover {
+  border-color: rgba(148, 163, 184, 0.32);
+  background: rgba(9, 15, 26, 0.82);
+}
+
+.cards-block-header[aria-expanded="false"]::after {
+  transform: translateY(-50%) rotate(-45deg);
+}
+
+.cards-block-heading h3 {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+.cards-block-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.cards-block-subtitle {
+  display: block;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.75);
+  margin-top: 2px;
+}
+
+.cards-count {
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.cards-block-content {
+  margin-top: var(--pad);
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(8, 13, 23, 0.65);
+  padding: var(--pad);
+}
+
+.cards-block-content.collapsed {
+  display: none;
+}
+
+.cards-week {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(10, 17, 29, 0.65);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.cards-week-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--pad);
+  padding: 12px 18px;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  text-align: left;
+  font-size: 1rem;
+  position: relative;
+  padding-right: 52px;
+}
+
+.cards-week-header::after {
+  content: '';
+  position: absolute;
+  right: 18px;
+  top: 50%;
+  width: 10px;
+  height: 10px;
+  border-right: 2px solid rgba(148, 163, 184, 0.55);
+  border-bottom: 2px solid rgba(148, 163, 184, 0.55);
+  transform: translateY(-50%) rotate(45deg);
+  transition: transform 0.3s ease, border-color 0.3s ease;
+}
+
+.cards-week-header:hover {
+  color: rgba(226, 232, 240, 0.95);
+}
+
+.cards-week-header[aria-expanded="false"]::after {
+  transform: translateY(-50%) rotate(-45deg);
+}
+
+.cards-week-title {
+  font-weight: 600;
+}
+
+.cards-week-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  padding: 0 18px 18px;
+}
+
+.cards-week-content.collapsed {
+  display: none;
+}
+
+.cards-week-empty {
+  padding: 18px;
+  border-radius: var(--radius);
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  color: rgba(148, 163, 184, 0.8);
+  text-align: center;
+  font-size: 0.9rem;
+  background: rgba(8, 13, 23, 0.6);
+}
+
+.cards-lecture-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--pad-lg);
+}
+
+.cards-deck {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: transparent;
+  border: none;
+  padding: 10px;
+  border-radius: var(--radius-lg);
+  cursor: pointer;
+  color: var(--text);
+  text-align: left;
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
+}
+
+.cards-deck:hover,
+.cards-deck:focus-visible {
+  outline: 2px solid rgba(94, 234, 212, 0.35);
+  outline-offset: 6px;
+  transform: translateY(-4px);
+  box-shadow: 0 24px 50px -32px rgba(2, 6, 23, 0.9);
+}
+
+.cards-deck-stack {
+  position: relative;
+  width: 100%;
+  padding-top: 70%;
+  perspective: 900px;
+}
+
+.cards-deck-layer {
+  position: absolute;
+  inset: 0;
+  border-radius: calc(var(--radius-lg) * 0.9);
+  background: linear-gradient(150deg, rgba(30, 41, 59, 0.95), rgba(15, 23, 42, 0.82));
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  box-shadow: 0 22px 45px -28px rgba(2, 6, 23, 0.85);
+  transform-style: preserve-3d;
+  transform: translate3d(calc(var(--layer) * -6px), calc(var(--layer) * -8px), calc(var(--layer) * -14px)) rotateZ(calc(var(--layer) * -2deg));
+  transition: transform 0.4s ease, box-shadow 0.4s ease, filter 0.4s ease;
+  display: flex;
+  align-items: flex-end;
+  padding: 16px;
+  overflow: hidden;
+}
+
+.cards-deck:hover .cards-deck-layer,
+.cards-deck:focus-visible .cards-deck-layer {
+  transform: translate3d(calc((var(--layer) - 1) * 22px), calc((var(--layer) - 1) * -12px), calc(var(--layer) * 18px)) rotateZ(calc((var(--layer) - 1) * 7deg));
+  box-shadow: 0 28px 58px -26px rgba(2, 6, 23, 0.9);
+  filter: brightness(1.05);
+}
+
+.cards-deck-layer-label {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: rgba(248, 250, 252, 0.85);
+  text-shadow: 0 6px 16px rgba(2, 6, 23, 0.8);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
+}
+
+.cards-deck-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 0 6px 4px;
+}
+
+.cards-deck-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.cards-deck-meta {
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.cards-deck-count {
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(94, 234, 212, 0.8);
+}
+
+.deck-viewer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-lg);
+  padding: var(--pad-lg);
+  width: 100%;
+  align-items: center;
+  justify-content: flex-start;
   min-height: 70vh;
-}
-.deck-card {
-  margin:0 auto;
-}
-
-.deck-card .item-card {
-  width:40vw;
-  height:20vh;
-  overflow:hidden;
-  display:flex;
-  flex-direction:column;
+  background: linear-gradient(160deg, rgba(10, 18, 32, 0.82), rgba(6, 12, 24, 0.9));
+  border-radius: var(--radius-xl);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 32px 80px -44px rgba(2, 6, 23, 0.92);
 }
 
-.deck-card .item-card.expanded {
-  height:70vh;
+.deck-viewer-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: center;
+  text-align: center;
 }
 
-.deck-card .item-card .card-body {
-  display:none;
-  flex:1;
-  overflow:auto;
+.deck-viewer-crumb {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: rgba(148, 163, 184, 0.75);
 }
 
-.deck-card .item-card.expanded .card-body {
-  display:block;
+.deck-viewer-header h2 {
+  margin: 0;
+  font-size: 1.6rem;
+  font-weight: 600;
 }
 
-.deck-card .item-card.expanded .section-content {
-  overflow-y:auto;
+.deck-viewer-count {
+  font-size: 0.85rem;
+  color: rgba(94, 234, 212, 0.85);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
 }
-.deck-prev, .deck-next {
-  position:absolute;
-  top:50%;
-  transform:translateY(-50%);
-  background:var(--muted);
-  color:var(--text);
-  padding:8px;
-  border-radius:var(--radius);
-  cursor:pointer;
-  border:1px solid var(--border);
+
+.deck-viewer-card {
+  width: min(760px, 92vw);
+  display: flex;
+  justify-content: center;
 }
-.deck-prev { left:var(--pad); }
-.deck-next { right:var(--pad); }
-.deck-prev:hover, .deck-next:hover {
-  transform:translateY(calc(-50% - 2px));
+
+.deck-viewer-card .item-card {
+  width: 100%;
+  min-height: 220px;
+  display: flex;
+  flex-direction: column;
 }
+
+.deck-viewer-card .item-card.expanded {
+  min-height: 60vh;
+}
+
+.deck-viewer-card .item-card .card-body {
+  display: none;
+  flex: 1;
+  overflow: auto;
+}
+
+.deck-viewer-card .item-card.expanded .card-body {
+  display: block;
+}
+
+.deck-viewer-card .item-card.expanded .section-content {
+  overflow-y: auto;
+}
+
+.deck-viewer-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--pad);
+}
+
+.deck-prev,
+.deck-next {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(12, 20, 36, 0.75);
+  color: var(--text);
+  cursor: pointer;
+  font-size: 1.1rem;
+  display: grid;
+  place-items: center;
+  transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+}
+
+.deck-prev:hover,
+.deck-next:hover {
+  transform: translateY(-2px);
+  background: rgba(94, 234, 212, 0.18);
+  border-color: rgba(94, 234, 212, 0.4);
+}
+
 .deck-related {
-  display:flex;
-  flex-wrap:wrap;
-  gap:var(--pad);
-  justify-content:center;
-  margin-top:var(--pad);
-  opacity:0;
-  transform:translateY(-10px);
-  transition:opacity 0.3s ease, transform 0.3s ease;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad);
+  justify-content: center;
+  margin-top: var(--pad);
+  opacity: 0;
+  transform: translateY(-10px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
 }
+
 .deck-related:not(.hidden) {
-  opacity:1;
-  transform:translateY(0);
+  opacity: 1;
+  transform: translateY(0);
 }
+
 .deck-related .related-card {
-  opacity:0;
-  transform:scale(0.95);
-  transition:opacity 0.3s ease, transform 0.3s ease;
+  opacity: 0;
+  transform: scale(0.95);
+  transition: opacity 0.3s ease, transform 0.3s ease;
 }
+
 .deck-related .related-card.visible {
-  opacity:1;
-  transform:scale(1);
+  opacity: 1;
+  transform: scale(1);
 }
+
+.deck-related-toggle {
+  margin-top: var(--pad-sm);
+}
+
 .deck-close {
-  margin-top:var(--pad);
+  margin-top: var(--pad-sm);
 }
 .hidden { display:none !important; }
 


### PR DESCRIPTION
## Summary
- group Cards tab decks by block and week with collapsible sections and an immersive deck viewer
- restyle card decks with layered 3D hover treatments to align with Study/Exams aesthetics
- compact the rich text editor toolbar, prevent default bolding, and expand curriculum tagging space in the editor modal

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc444feadc8322a6d27ecfc47327bb