### PR TITLE
Revamp cards view and streamline editor toolbar

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -145,7 +145,7 @@ async function render() {
     main.appendChild(content);
     const filter = { ...state.filters, query: state.query };
     const items = await findItemsByFilter(filter);
-    renderCards(content, items, render);
+    await renderCards(content, items, render);
   } else if (state.tab === 'Study') {
     main.appendChild(createEntryAddControl(render, 'disease'));
     const content = document.createElement('div');

--- a/js/ui/components/cards.js
+++ b/js/ui/components/cards.js
@@ -1,141 +1,279 @@
+import { listBlocks } from '../../storage/storage.js';
 import { createItemCard } from './cardlist.js';
 
+const UNASSIGNED_KEY = '__unassigned';
+
 /**
- * Render lecture-based decks combining all item types.
+ * @param {import('../../types.js').Item} item
+ */
+function titleOf(item){
+  return item.name || item.concept || 'Untitled card';
+}
+
+function createStack(cards, accent){
+  const stack = document.createElement('div');
+  stack.className = 'card-deck-stack';
+  const preview = cards.slice(0, 5);
+  stack.style.setProperty('--count', String(preview.length || 1));
+  if (accent) stack.style.setProperty('--stack-accent', accent);
+  preview.forEach((card, index) => {
+    const tile = document.createElement('div');
+    tile.className = 'card-stack-card';
+    tile.textContent = titleOf(card);
+    tile.title = titleOf(card);
+    tile.style.setProperty('--index', String(index));
+    const offset = index - (preview.length - 1) / 2;
+    tile.style.setProperty('--offset', String(offset));
+    stack.appendChild(tile);
+  });
+  return stack;
+}
+
+/**
+ * Render lecture-based decks combining all item types with grouping by block and week.
  * @param {HTMLElement} container
  * @param {import('../../types.js').Item[]} items
  * @param {Function} onChange
  */
-export function renderCards(container, items, onChange){
+export async function renderCards(container, items, onChange){
   container.innerHTML = '';
-  const decks = new Map();
-  items.forEach(it => {
-    if (it.lectures && it.lectures.length){
-      it.lectures.forEach(l => {
-        const key = l.name || `Lecture ${l.id}`;
-        if (!decks.has(key)) decks.set(key, []);
-        decks.get(key).push(it);
+
+  const blocks = await listBlocks();
+  const blockIndex = new Map(blocks.map((block, idx) => [block.blockId, { block, order: idx }]));
+
+  const blockRecords = new Map();
+
+  function ensureBlock(blockId){
+    const key = blockId || UNASSIGNED_KEY;
+    if (!blockRecords.has(key)) {
+      const def = blockId ? blockIndex.get(blockId)?.block : null;
+      const order = blockId ? (blockIndex.get(blockId)?.order ?? Number.MAX_SAFE_INTEGER - 10) : Number.MAX_SAFE_INTEGER;
+      const title = def?.title || (blockId || 'Unassigned');
+      blockRecords.set(key, {
+        key,
+        blockId: blockId || null,
+        title,
+        color: def?.color || null,
+        order,
+        weeks: new Map(),
+        itemIds: new Set()
       });
-    } else {
-      if (!decks.has('Unassigned')) decks.set('Unassigned', []);
-      decks.get('Unassigned').push(it);
+    }
+    return blockRecords.get(key);
+  }
+
+  function ensureWeek(blockRec, weekValue, options = {}){
+    const key = typeof weekValue === 'number' ? `week-${weekValue}` : options.key || 'general';
+    if (!blockRec.weeks.has(key)) {
+      const label = options.label || (typeof weekValue === 'number' ? `Week ${weekValue}` : 'General');
+      const order = typeof weekValue === 'number' ? weekValue : options.order ?? Number.MAX_SAFE_INTEGER - 5;
+      blockRec.weeks.set(key, {
+        key,
+        week: typeof weekValue === 'number' ? weekValue : null,
+        label,
+        order,
+        lectures: new Map(),
+        itemIds: new Set()
+      });
+    }
+    return blockRec.weeks.get(key);
+  }
+
+  function ensureLecture(weekRec, lectureId, info){
+    if (!weekRec.lectures.has(lectureId)) {
+      weekRec.lectures.set(lectureId, {
+        id: lectureId,
+        title: info.name || info.title || 'Lecture',
+        subtitle: info.subtitle || '',
+        order: info.order ?? Number.MAX_SAFE_INTEGER,
+        accent: info.accent || null,
+        items: [],
+        itemIds: new Set(),
+        meta: info.meta || {}
+      });
+    }
+    return weekRec.lectures.get(lectureId);
+  }
+
+  function registerItem(blockRec, weekRec, lectureRec, item){
+    if (!lectureRec.itemIds.has(item.id)) {
+      lectureRec.itemIds.add(item.id);
+      lectureRec.items.push(item);
+    }
+    if (!weekRec.itemIds.has(item.id)) weekRec.itemIds.add(item.id);
+    if (!blockRec.itemIds.has(item.id)) blockRec.itemIds.add(item.id);
+  }
+
+  function addToLecture(blockId, weekValue, lectureInfo, item){
+    const blockRec = ensureBlock(blockId);
+    const weekRec = ensureWeek(blockRec, weekValue, lectureInfo.weekOptions || {});
+    const lectureRec = ensureLecture(weekRec, lectureInfo.id, lectureInfo);
+    registerItem(blockRec, weekRec, lectureRec, item);
+  }
+
+  items.forEach(item => {
+    let handled = false;
+    if (Array.isArray(item.lectures) && item.lectures.length) {
+      item.lectures.forEach(lecture => {
+        const infoBlock = lecture.blockId || null;
+        const blockDef = infoBlock ? blockIndex.get(infoBlock)?.block : null;
+        const blockColor = blockDef?.color || null;
+        const blockLectures = blockDef?.lectures || [];
+        const lectureOrder = blockLectures.findIndex(l => l.id === lecture.id);
+        addToLecture(infoBlock, lecture.week, {
+          id: `lecture-${infoBlock || 'na'}-${lecture.id}`,
+          name: lecture.name || `Lecture ${lecture.id}`,
+          subtitle: lecture.week != null ? `Week ${lecture.week}` : '',
+          order: lectureOrder >= 0 ? lectureOrder : Number.MAX_SAFE_INTEGER - 2,
+          accent: blockColor,
+          meta: {
+            blockTitle: blockDef?.title || infoBlock || 'Unassigned',
+            weekLabel: lecture.week != null ? `Week ${lecture.week}` : 'General',
+            lectureName: lecture.name || `Lecture ${lecture.id}`
+          }
+        }, item);
+        handled = true;
+      });
+    }
+
+    if (!handled && Array.isArray(item.blocks) && item.blocks.length) {
+      const weeks = Array.isArray(item.weeks) && item.weeks.length ? item.weeks : [null];
+      item.blocks.forEach(blockId => {
+        const def = blockIndex.get(blockId)?.block;
+        const accent = def?.color || null;
+        weeks.forEach(weekValue => {
+          const weekOptions = {
+            label: typeof weekValue === 'number' ? `Week ${weekValue}` : 'General',
+            order: typeof weekValue === 'number' ? weekValue : Number.MAX_SAFE_INTEGER - 4,
+            key: typeof weekValue === 'number' ? `week-${weekValue}` : 'general'
+          };
+          addToLecture(blockId, weekValue, {
+            id: `block-${blockId}-${weekValue ?? 'general'}`,
+            name: typeof weekValue === 'number' ? 'Week Highlights' : 'Block Highlights',
+            subtitle: def?.title || blockId,
+            order: Number.MAX_SAFE_INTEGER - 3,
+            accent,
+            weekOptions,
+            meta: {
+              blockTitle: def?.title || blockId,
+              weekLabel: weekOptions.label,
+              lectureName: typeof weekValue === 'number' ? `${def?.title || blockId} • Week ${weekValue}` : `${def?.title || blockId} Highlights`
+            }
+          }, item);
+        });
+      });
+      handled = true;
+    }
+
+    if (!handled) {
+      addToLecture(null, null, {
+        id: 'unassigned',
+        name: 'Unassigned Cards',
+        subtitle: '',
+        order: Number.MAX_SAFE_INTEGER - 1,
+        meta: {
+          blockTitle: 'Unassigned',
+          weekLabel: 'General',
+          lectureName: 'Unassigned Cards'
+        }
+      }, item);
     }
   });
 
+  const blockEntries = Array.from(blockRecords.values())
+    .filter(block => block.itemIds.size)
+    .sort((a, b) => a.order - b.order || a.title.localeCompare(b.title));
+
+  if (!blockEntries.length) {
+    const empty = document.createElement('div');
+    empty.className = 'cards-empty';
+    empty.textContent = 'No cards match your filters yet. Add lectures or remove filters to see decks.';
+    container.appendChild(empty);
+    return;
+  }
+
   const list = document.createElement('div');
-  list.className = 'deck-list';
+  list.className = 'cards-browser';
   container.appendChild(list);
 
   const viewer = document.createElement('div');
   viewer.className = 'deck-viewer hidden';
   container.appendChild(viewer);
 
-  decks.forEach((cards, lecture) => {
-    const deck = document.createElement('div');
-    deck.className = 'deck';
-    const title = document.createElement('div');
-    title.className = 'deck-title';
-    title.textContent = lecture;
-    const meta = document.createElement('div');
-    meta.className = 'deck-meta';
-    const blocks = Array.from(new Set(cards.flatMap(c => c.blocks || []))).join(', ');
-    const weeks = Array.from(new Set(cards.flatMap(c => c.weeks || []))).join(', ');
-    meta.textContent = `${blocks}${blocks && weeks ? ' • ' : ''}${weeks ? 'Week ' + weeks : ''}`;
-    deck.appendChild(title);
-    deck.appendChild(meta);
-    deck.addEventListener('click', () => { stopPreview(deck); openDeck(lecture, cards); });
-    let hoverTimer;
-    deck.addEventListener('mouseenter', () => {
-      hoverTimer = setTimeout(() => startPreview(deck, cards), 3000);
-    });
-    deck.addEventListener('mouseleave', () => {
-      clearTimeout(hoverTimer);
-      stopPreview(deck);
-    });
-    list.appendChild(deck);
-  });
-
-  function startPreview(deckEl, cards){
-    if (deckEl._preview) return;
-    deckEl.classList.add('pop');
-    const fan = document.createElement('div');
-    fan.className = 'deck-fan';
-    deckEl.appendChild(fan);
-    const show = cards.slice(0,5);
-    const spread = 20;
-    const offset = (show.length - 1) * spread / 2;
-    show.forEach((c,i) => {
-      const mini = document.createElement('div');
-      mini.className = 'fan-card';
-      mini.textContent = c.name || c.concept || '';
-      fan.appendChild(mini);
-      const angle = -offset + i * spread;
-      mini.style.transform = `rotate(${angle}deg) translateY(-80px)`;
-      setTimeout(() => { mini.style.opacity = 1; }, i * 100);
-    });
-    deckEl._preview = { fan };
-  }
-
-  function stopPreview(deckEl){
-    const prev = deckEl._preview;
-    if (prev){
-      prev.fan.remove();
-      deckEl.classList.remove('pop');
-      deckEl._preview = null;
-    }
-  }
-
-  function openDeck(title, cards){
+  function openDeck(blockRec, weekRec, lectureRec){
     list.classList.add('hidden');
     viewer.classList.remove('hidden');
     viewer.innerHTML = '';
 
-    const header = document.createElement('h2');
-    header.textContent = title;
+    const header = document.createElement('div');
+    header.className = 'deck-viewer-header';
+
+    const titleWrap = document.createElement('div');
+    titleWrap.className = 'deck-viewer-title';
+    const heading = document.createElement('h2');
+    heading.textContent = lectureRec.title;
+    titleWrap.appendChild(heading);
+
+    const subtitle = document.createElement('div');
+    subtitle.className = 'deck-viewer-meta';
+    const trail = [lectureRec.meta?.blockTitle || blockRec.title, lectureRec.meta?.weekLabel || weekRec.label]
+      .filter(Boolean)
+      .join(' • ');
+    subtitle.textContent = `${trail}${trail ? ' • ' : ''}${lectureRec.items.length} cards`;
+    titleWrap.appendChild(subtitle);
+    header.appendChild(titleWrap);
+
+    const controls = document.createElement('div');
+    controls.className = 'deck-viewer-controls';
+
+    const counter = document.createElement('span');
+    counter.className = 'deck-viewer-counter';
+
+    const prev = document.createElement('button');
+    prev.type = 'button';
+    prev.className = 'deck-nav-btn deck-nav-prev';
+    prev.innerHTML = '<span aria-hidden="true">‹</span><span class="sr-only">Previous card</span>';
+
+    const next = document.createElement('button');
+    next.type = 'button';
+    next.className = 'deck-nav-btn deck-nav-next';
+    next.innerHTML = '<span aria-hidden="true">›</span><span class="sr-only">Next card</span>';
+
+    const toggle = document.createElement('button');
+    toggle.type = 'button';
+    toggle.className = 'deck-related-toggle';
+    toggle.textContent = 'Related cards';
+    toggle.setAttribute('aria-pressed', 'false');
+
+    const close = document.createElement('button');
+    close.type = 'button';
+    close.className = 'deck-close';
+    close.textContent = 'Back to decks';
+
+    controls.appendChild(prev);
+    controls.appendChild(counter);
+    controls.appendChild(next);
+    controls.appendChild(toggle);
+    controls.appendChild(close);
+    header.appendChild(controls);
     viewer.appendChild(header);
 
     const cardHolder = document.createElement('div');
     cardHolder.className = 'deck-card';
     viewer.appendChild(cardHolder);
 
-    const prev = document.createElement('button');
-    prev.className = 'deck-prev';
-    prev.textContent = '◀';
-    const next = document.createElement('button');
-    next.className = 'deck-next';
-    next.textContent = '▶';
-    viewer.appendChild(prev);
-    viewer.appendChild(next);
-
-    const toggle = document.createElement('button');
-    toggle.className = 'deck-related-toggle btn';
-    toggle.textContent = 'Show Related';
-    viewer.appendChild(toggle);
-
     const relatedWrap = document.createElement('div');
     relatedWrap.className = 'deck-related hidden';
     viewer.appendChild(relatedWrap);
 
-    const close = document.createElement('button');
-    close.className = 'deck-close btn';
-    close.textContent = 'Close';
-    viewer.appendChild(close);
-
     let idx = 0;
     let showRelated = false;
 
-    function renderCard(){
-      cardHolder.innerHTML = '';
-      cardHolder.appendChild(createItemCard(cards[idx], onChange));
-      renderRelated();
-    }
-
-    function renderRelated(){
+    function renderRelated(current){
       relatedWrap.innerHTML = '';
       if (!showRelated) return;
-      const current = cards[idx];
-      (current.links || []).forEach(l => {
-        const item = items.find(it => it.id === l.id);
+      (current.links || []).forEach(link => {
+        const item = items.find(it => it.id === link.id);
         if (item) {
           const el = createItemCard(item, onChange);
           el.classList.add('related-card');
@@ -145,36 +283,187 @@ export function renderCards(container, items, onChange){
       });
     }
 
+    function renderCard(){
+      const current = lectureRec.items[idx];
+      counter.textContent = `${idx + 1} / ${lectureRec.items.length}`;
+      cardHolder.innerHTML = '';
+      cardHolder.appendChild(createItemCard(current, onChange));
+      renderRelated(current);
+    }
+
     prev.addEventListener('click', () => {
-      idx = (idx - 1 + cards.length) % cards.length;
+      idx = (idx - 1 + lectureRec.items.length) % lectureRec.items.length;
       renderCard();
     });
     next.addEventListener('click', () => {
-      idx = (idx + 1) % cards.length;
+      idx = (idx + 1) % lectureRec.items.length;
       renderCard();
     });
 
     toggle.addEventListener('click', () => {
       showRelated = !showRelated;
-      toggle.textContent = showRelated ? 'Hide Related' : 'Show Related';
+      toggle.classList.toggle('active', showRelated);
       relatedWrap.classList.toggle('hidden', !showRelated);
-      renderRelated();
+      toggle.textContent = showRelated ? 'Hide related' : 'Related cards';
+      toggle.setAttribute('aria-pressed', showRelated.toString());
+      renderRelated(lectureRec.items[idx]);
     });
 
-    close.addEventListener('click', () => {
+    function closeViewer(){
       document.removeEventListener('keydown', keyHandler);
       viewer.classList.add('hidden');
       viewer.innerHTML = '';
       list.classList.remove('hidden');
-    });
+    }
+
+    close.addEventListener('click', closeViewer);
 
     function keyHandler(e){
       if (e.key === 'ArrowLeft') prev.click();
       if (e.key === 'ArrowRight') next.click();
-      if (e.key === 'Escape') close.click();
+      if (e.key === 'Escape') closeViewer();
     }
     document.addEventListener('keydown', keyHandler);
 
     renderCard();
   }
+
+  function createDeck(blockRec, weekRec, lectureRec){
+    const deck = document.createElement('div');
+    deck.className = 'card-deck';
+    deck.setAttribute('role', 'button');
+    deck.setAttribute('tabindex', '0');
+    deck.setAttribute('aria-label', `${lectureRec.title} – ${lectureRec.items.length} cards`);
+    if (lectureRec.accent) deck.style.setProperty('--deck-accent', lectureRec.accent);
+
+    const stack = createStack(lectureRec.items, lectureRec.accent);
+    deck.appendChild(stack);
+
+    const info = document.createElement('div');
+    info.className = 'card-deck-info';
+
+    const title = document.createElement('h3');
+    title.className = 'card-deck-title';
+    title.textContent = lectureRec.title;
+    info.appendChild(title);
+
+    if (lectureRec.subtitle) {
+      const subtitle = document.createElement('div');
+      subtitle.className = 'card-deck-subtitle';
+      subtitle.textContent = lectureRec.subtitle;
+      info.appendChild(subtitle);
+    }
+
+    const meta = document.createElement('div');
+    meta.className = 'card-deck-meta';
+    const bits = [];
+    if (weekRec.label) bits.push(weekRec.label);
+    bits.push(`${lectureRec.items.length} ${lectureRec.items.length === 1 ? 'card' : 'cards'}`);
+    meta.textContent = bits.join(' • ');
+    info.appendChild(meta);
+
+    deck.appendChild(info);
+
+    const activate = () => openDeck(blockRec, weekRec, lectureRec);
+    deck.addEventListener('click', activate);
+    deck.addEventListener('keydown', e => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        activate();
+      }
+    });
+
+    return deck;
+  }
+
+  blockEntries.forEach(blockRec => {
+    const blockSection = document.createElement('section');
+    blockSection.className = 'card-block';
+    if (blockRec.color) blockSection.style.setProperty('--block-accent', blockRec.color);
+
+    const header = document.createElement('button');
+    header.type = 'button';
+    header.className = 'card-block-header';
+    header.setAttribute('aria-expanded', 'true');
+
+    const title = document.createElement('div');
+    title.className = 'card-block-title';
+    title.textContent = blockRec.title;
+    header.appendChild(title);
+
+    if (blockRec.blockId) {
+      const badge = document.createElement('span');
+      badge.className = 'card-block-badge';
+      badge.textContent = blockRec.blockId;
+      if (blockRec.color) badge.style.setProperty('--badge-accent', blockRec.color);
+      header.appendChild(badge);
+    }
+
+    const count = document.createElement('span');
+    count.className = 'card-block-count';
+    count.textContent = `${blockRec.itemIds.size} ${blockRec.itemIds.size === 1 ? 'card' : 'cards'}`;
+    header.appendChild(count);
+
+    header.addEventListener('click', () => {
+      const expanded = blockSection.classList.toggle('collapsed');
+      header.setAttribute('aria-expanded', (!expanded).toString());
+    });
+    blockSection.appendChild(header);
+
+    const body = document.createElement('div');
+    body.className = 'card-block-body';
+    blockSection.appendChild(body);
+
+    const weekEntries = Array.from(blockRec.weeks.values())
+      .filter(week => week.itemIds.size)
+      .sort((a, b) => a.order - b.order || a.label.localeCompare(b.label));
+
+    weekEntries.forEach(weekRec => {
+      const weekSection = document.createElement('section');
+      weekSection.className = 'card-week';
+
+      const weekHeader = document.createElement('button');
+      weekHeader.type = 'button';
+      weekHeader.className = 'card-week-header';
+      weekHeader.setAttribute('aria-expanded', 'true');
+
+      const weekTitle = document.createElement('div');
+      weekTitle.className = 'card-week-title';
+      weekTitle.textContent = weekRec.label;
+      weekHeader.appendChild(weekTitle);
+
+      const weekCount = document.createElement('span');
+      weekCount.className = 'card-week-count';
+      const deckCount = weekRec.lectures.size;
+      weekCount.textContent = `${weekRec.itemIds.size} ${weekRec.itemIds.size === 1 ? 'card' : 'cards'} • ${deckCount} ${deckCount === 1 ? 'deck' : 'decks'}`;
+      weekHeader.appendChild(weekCount);
+
+      weekHeader.addEventListener('click', () => {
+        const collapsed = weekSection.classList.toggle('collapsed');
+        weekHeader.setAttribute('aria-expanded', (!collapsed).toString());
+      });
+
+      weekSection.appendChild(weekHeader);
+
+      const weekBody = document.createElement('div');
+      weekBody.className = 'card-week-body';
+      weekSection.appendChild(weekBody);
+
+      const grid = document.createElement('div');
+      grid.className = 'card-deck-grid';
+      weekBody.appendChild(grid);
+
+      const lectureEntries = Array.from(weekRec.lectures.values())
+        .filter(lecture => lecture.items.length)
+        .sort((a, b) => a.order - b.order || a.title.localeCompare(b.title));
+
+      lectureEntries.forEach(lectureRec => {
+        grid.appendChild(createDeck(blockRec, weekRec, lectureRec));
+      });
+
+      body.appendChild(weekSection);
+    });
+
+    list.appendChild(blockSection);
+  });
 }

--- a/js/ui/components/editor.js
+++ b/js/ui/components/editor.js
@@ -46,7 +46,7 @@ function escapeHtml(str = '') {
 export async function openEditor(kind, onSave, existing = null) {
   const win = createFloatingWindow({
     title: `${existing ? 'Edit' : 'Add'} ${titleMap[kind] || kind}`,
-    width: 600
+    width: 720
   });
 
   const form = document.createElement('form');

--- a/js/ui/components/rich-text.js
+++ b/js/ui/components/rich-text.js
@@ -163,9 +163,11 @@ function createToolbarButton(label, title, onClick){
 export function createRichTextEditor({ value = '' } = {}){
   const wrapper = document.createElement('div');
   wrapper.className = 'rich-editor';
+  wrapper.classList.add('rich-editor--compact');
 
   const toolbar = document.createElement('div');
   toolbar.className = 'rich-editor-toolbar';
+  toolbar.classList.add('rich-editor-toolbar--condensed');
   wrapper.appendChild(toolbar);
 
   const editable = document.createElement('div');
@@ -195,14 +197,15 @@ export function createRichTextEditor({ value = '' } = {}){
     return editable.contains(anchor) && editable.contains(focus);
   }
 
-  function createGroup(){
+  function createGroup(...classNames){
     const group = document.createElement('div');
     group.className = 'rich-editor-group';
+    if (classNames.length) group.classList.add(...classNames);
     toolbar.appendChild(group);
     return group;
   }
 
-  const inlineGroup = createGroup();
+  const inlineGroup = createGroup('rich-editor-group--compact');
   [
     createToolbarButton('B', 'Bold', () => exec('bold')),
     createToolbarButton('I', 'Italic', () => exec('italic')),
@@ -227,15 +230,11 @@ export function createRichTextEditor({ value = '' } = {}){
     colorInput.dataset.lastColor = colorInput.value;
   });
   colorWrap.appendChild(colorInput);
-  const colorGroup = createGroup();
+  const colorGroup = createGroup('rich-editor-group--compact');
   colorGroup.appendChild(colorWrap);
 
-  const highlightGroup = createGroup();
+  const highlightGroup = createGroup('rich-editor-group--swatches');
   highlightGroup.classList.add('rich-editor-highlight-group');
-  const highlightLabel = document.createElement('span');
-  highlightLabel.className = 'rich-editor-label';
-  highlightLabel.textContent = 'Highlight';
-  highlightGroup.appendChild(highlightLabel);
 
   const highlightColors = [
     ['#facc15', 'Yellow'],
@@ -278,7 +277,7 @@ export function createRichTextEditor({ value = '' } = {}){
   clearSwatch.addEventListener('click', clearHighlight);
   highlightGroup.appendChild(clearSwatch);
 
-  const listGroup = createGroup();
+  const listGroup = createGroup('rich-editor-group--compact');
   const listSelect = document.createElement('select');
   listSelect.className = 'rich-editor-select';
   [
@@ -375,7 +374,7 @@ export function createRichTextEditor({ value = '' } = {}){
   });
   listGroup.appendChild(sizeSelect);
 
-  const mediaGroup = createGroup();
+  const mediaGroup = createGroup('rich-editor-group--compact');
 
   const linkBtn = createToolbarButton('🔗', 'Insert link', () => {
     focusEditor();
@@ -414,11 +413,8 @@ export function createRichTextEditor({ value = '' } = {}){
   mediaGroup.appendChild(mediaBtn);
 
   const clearBtn = createToolbarButton('⌫', 'Clear formatting', () => exec('removeFormat'));
-  const utilityGroup = createGroup();
+  const utilityGroup = createGroup('rich-editor-group--compact');
   utilityGroup.appendChild(clearBtn);
-
-  const clearHighlightBtn = createToolbarButton('⨯', 'Remove highlight', clearHighlight);
-  utilityGroup.appendChild(clearHighlightBtn);
 
   editable.addEventListener('keydown', (e) => {
     if (e.key === 'Tab') {

--- a/style.css
+++ b/style.css
@@ -88,7 +88,7 @@ button:focus-visible {
   outline-offset: 3px;
 }
 
-button:not(.tab):not(.fab-btn) {
+button:not(.tab):not(.fab-btn):not(.card-block-header):not(.card-week-header):not(.deck-nav-btn):not(.deck-related-toggle):not(.deck-close) {
   background: rgba(148, 163, 184, 0.14);
   color: var(--text);
   border: 1px solid var(--border);
@@ -97,7 +97,7 @@ button:not(.tab):not(.fab-btn) {
   box-shadow: none;
 }
 
-button:not(.tab):not(.fab-btn):hover {
+button:not(.tab):not(.fab-btn):not(.card-block-header):not(.card-week-header):not(.deck-nav-btn):not(.deck-related-toggle):not(.deck-close):hover {
   background: rgba(148, 163, 184, 0.22);
 }
 
@@ -737,16 +737,18 @@ input[type="checkbox"]:checked::after {
 
 .editor-tags {
   margin-top: var(--pad);
-  padding: var(--pad);
+  padding: var(--pad-lg);
   border-radius: var(--radius-lg);
   border: 1px solid rgba(148, 163, 184, 0.32);
-  background: linear-gradient(155deg, rgba(15, 23, 42, 0.85), rgba(8, 13, 23, 0.92));
+  background: linear-gradient(155deg, rgba(15, 23, 42, 0.92), rgba(8, 13, 23, 0.95));
   display: flex;
   flex-direction: column;
   gap: var(--pad);
-  min-height: 220px;
-  max-height: clamp(280px, 46vh, 420px);
+  flex: 1;
+  min-height: clamp(320px, 50vh, 620px);
+  max-height: clamp(420px, 70vh, 820px);
   overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
 }
 
 .editor-tags-title {
@@ -947,51 +949,69 @@ input[type="checkbox"]:checked::after {
 .rich-editor {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  background: rgba(15, 23, 42, 0.4);
-  border: 1px solid var(--border);
+  gap: 10px;
+  background: rgba(8, 13, 23, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.22);
   border-radius: var(--radius);
   padding: var(--pad-sm);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  backdrop-filter: blur(6px);
+}
+
+.rich-editor--compact {
+  gap: 8px;
+  padding: calc(var(--pad-sm) + 2px);
+  background: rgba(8, 13, 23, 0.52);
+  border-color: rgba(148, 163, 184, 0.24);
 }
 
 .rich-editor-toolbar {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
   align-items: center;
+  gap: 8px;
+}
+
+.rich-editor-toolbar--condensed {
+  gap: 8px;
+  justify-content: flex-start;
 }
 
 .rich-editor-group {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 6px;
+  padding: 5px 8px;
   border-radius: var(--radius-sm);
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  background: rgba(8, 13, 23, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(4, 10, 20, 0.72);
   backdrop-filter: blur(6px);
 }
 
-.rich-editor-label {
-  font-size: 0.75rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--text-muted);
+.rich-editor-group--compact {
+  gap: 4px;
+  padding: 4px 6px;
+}
+
+.rich-editor-group--swatches {
+  gap: 6px;
+  padding: 4px 6px;
 }
 
 .rich-editor-btn {
   background: transparent;
   border: none;
-  color: var(--text-muted);
-  padding: 6px 8px;
-  font-size: 0.9rem;
+  color: rgba(248, 250, 252, 0.7);
+  padding: 4px 7px;
+  font-size: 0.88rem;
   cursor: pointer;
-  border-radius: var(--radius-sm);
+  border-radius: 6px;
+  transition: background 0.2s ease, color 0.2s ease;
 }
 
 .rich-editor-btn:hover,
 .rich-editor-btn:focus {
-  background: var(--muted);
+  background: rgba(56, 189, 248, 0.18);
   color: var(--text);
   outline: none;
 }
@@ -1002,39 +1022,41 @@ input[type="checkbox"]:checked::after {
 }
 
 .rich-editor-color input {
-  width: 34px;
-  height: 30px;
-  border: 1px solid rgba(148, 163, 184, 0.25);
+  width: 30px;
+  height: 26px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
   border-radius: var(--radius-sm);
-  background: rgba(15, 23, 42, 0.4);
+  background: rgba(10, 16, 28, 0.7);
   padding: 0;
   cursor: pointer;
 }
 
 .rich-editor-highlight-group {
-  gap: 8px;
+  gap: 6px;
 }
 
 .rich-editor-swatch {
-  width: 26px;
-  height: 26px;
+  width: 24px;
+  height: 24px;
   border-radius: 50%;
   border: 2px solid rgba(8, 13, 23, 0.7);
   background: var(--swatch-color, transparent);
   box-shadow: 0 0 0 2px rgba(148, 163, 184, 0.25);
   cursor: pointer;
+  transition: box-shadow 0.25s ease, transform 0.25s ease;
 }
 
 .rich-editor-swatch:hover,
 .rich-editor-swatch:focus {
   box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.45);
   outline: none;
+  transform: translateY(-1px);
 }
 
 .rich-editor-swatch--clear {
   background: rgba(15, 23, 42, 0.6);
   color: var(--text-muted);
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   line-height: 1;
 }
 
@@ -1045,29 +1067,33 @@ input[type="checkbox"]:checked::after {
 
 .rich-editor-select,
 .rich-editor-size {
-  background: rgba(15, 23, 42, 0.6);
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(8, 13, 23, 0.68);
+  border: 1px solid rgba(148, 163, 184, 0.24);
   border-radius: var(--radius-sm);
   color: var(--text);
-  padding: 6px 10px;
+  padding: 5px 10px;
   cursor: pointer;
   font-size: 0.9rem;
-  min-width: 120px;
+  min-width: 110px;
 }
 
 .rich-editor-area {
-  min-height: 150px;
+  min-height: 140px;
   padding: 12px;
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  border: 1px solid rgba(148, 163, 184, 0.25);
   border-radius: var(--radius);
-  background: rgba(2, 6, 23, 0.55);
+  background: rgba(5, 10, 20, 0.72);
   overflow: auto;
   word-break: break-word;
-  backdrop-filter: blur(4px);
+  backdrop-filter: blur(6px);
+  font-size: 0.95rem;
+  line-height: 1.55;
+  font-weight: 400;
+  color: var(--text);
 }
 
 .rich-editor-area:focus {
-  outline: 2px solid var(--blue);
+  outline: 2px solid rgba(56, 189, 248, 0.35);
   outline-offset: 2px;
 }
 
@@ -1092,19 +1118,6 @@ input[type="checkbox"]:checked::after {
   margin-left: auto;
   font-size: 0.85rem;
   opacity: 0.8;
-}
-
-.editor-tags {
-  margin-top: var(--pad);
-  padding: var(--pad);
-  background: rgba(15, 23, 42, 0.45);
-  border-radius: var(--radius);
-  border: 1px solid var(--border);
-  max-height: min(420px, 50vh);
-  overflow: auto;
-  display: flex;
-  flex-direction: column;
-  gap: var(--pad-sm);
 }
 
 .editor-tags-title {
@@ -2105,137 +2118,470 @@ input[type="checkbox"]:checked::after {
   display: block;
 }
 
-/* Decks */
-.deck-list {
-  display:flex;
-  flex-wrap:wrap;
-  gap:var(--pad);
-  padding:var(--pad);
-}
-.deck {
-  background:var(--panel);
-  border:1px solid var(--border);
-  border-radius:var(--radius);
-  padding:var(--pad-lg);
-  cursor:pointer;
-  box-shadow:0 2px 4px rgba(0,0,0,0.2);
-  position:relative;
-  width:200px;
-  display:flex;
-  flex-direction:column;
-  align-items:center;
-  text-align:center;
-  transition:transform 0.3s ease;
-}
-.deck-title { font-weight:600; margin-bottom:4px; }
-.deck-meta { font-size:0.85rem; color:var(--gray); }
-.deck.pop { transform:scale(1.05); z-index:2; }
-.deck-fan {
-  position:absolute;
-  top:50%;
-  left:50%;
-  transform:translate(-50%,-50%);
-  pointer-events:none;
-}
-.deck-fan .fan-card {
-  position:absolute;
-  width:70px;
-  height:90px;
-  background:var(--panel);
-  border:1px solid var(--border);
-  border-radius:var(--radius);
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  font-size:0.65rem;
-  color:var(--text);
-  opacity:0;
-  transform-origin:bottom center;
-  transition:opacity 0.3s ease, transform 0.3s ease;
-  white-space:nowrap;
-  overflow:hidden;
-  text-overflow:ellipsis;
-}
-.deck-viewer {
-  position: relative;
-  text-align: center;
-  padding: var(--pad);
+/* Cards */
+.cards-browser {
   display: flex;
   flex-direction: column;
+  gap: calc(var(--pad-lg) + 6px);
+  padding: calc(var(--pad-lg) + 6px);
+}
+
+.cards-empty {
+  padding: 64px;
+  border-radius: var(--radius-lg);
+  border: 1px dashed var(--border);
+  background: rgba(15, 23, 42, 0.4);
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.card-block {
+  --block-accent-color: var(--block-accent, rgba(56, 189, 248, 0.45));
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  background:
+    radial-gradient(circle at top left, rgba(56, 189, 248, 0.12), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(192, 132, 252, 0.12), transparent 60%),
+    rgba(10, 16, 28, 0.82);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 18px 36px rgba(2, 6, 23, 0.45);
+  overflow: hidden;
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
+}
+
+.card-block:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 26px 48px rgba(2, 6, 23, 0.55);
+}
+
+.card-block::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(56, 189, 248, 0.12), rgba(192, 132, 252, 0.08));
+  opacity: 0.6;
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.card-block::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-left: 4px solid var(--block-accent-color);
+  opacity: 0.7;
+  border-radius: var(--radius-lg);
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.card-block-header {
+  position: relative;
+  display: flex;
   align-items: center;
-  justify-content: center;
+  gap: var(--pad);
+  justify-content: space-between;
+  padding: var(--pad-lg);
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  backdrop-filter: blur(6px);
+  z-index: 1;
+}
+
+.card-block-header:hover {
+  background: rgba(8, 13, 23, 0.65);
+}
+
+.card-block-header::after {
+  content: '▾';
+  font-size: 1.15rem;
+  color: var(--text-muted);
+  transition: transform 0.25s ease;
+}
+
+.card-block.collapsed .card-block-header::after {
+  transform: rotate(-180deg);
+}
+
+.card-block-title {
+  font-size: 1.2rem;
+  font-weight: 600;
+  flex: 1;
+}
+
+.card-block-badge {
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.18);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: rgba(7, 22, 36, 0.9);
+}
+
+.card-block-count {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.card-block-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-lg);
+  padding: 0 var(--pad-lg) var(--pad-lg);
+}
+
+.card-block.collapsed .card-block-body {
+  display: none;
+}
+
+.card-week {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: var(--radius-lg);
+  background: rgba(6, 11, 20, 0.78);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.02),
+    inset 3px 0 0 0 var(--block-accent-color);
+  overflow: hidden;
+}
+
+.card-week-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--pad);
+  padding: var(--pad);
+  width: 100%;
+  text-align: left;
+  background: linear-gradient(120deg, rgba(56, 189, 248, 0.12), rgba(129, 140, 248, 0.12));
+  border: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition: background 0.25s ease;
+}
+
+.card-week-header:hover {
+  background: linear-gradient(120deg, rgba(56, 189, 248, 0.2), rgba(129, 140, 248, 0.18));
+}
+
+.card-week-header::after {
+  content: '▾';
+  font-size: 1rem;
+  color: var(--text-muted);
+  transition: transform 0.25s ease;
+}
+
+.card-week.collapsed .card-week-header::after {
+  transform: rotate(-180deg);
+}
+
+.card-week-title {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.card-week-count {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.card-week-body {
+  padding: var(--pad);
+  padding-top: calc(var(--pad) + 4px);
+}
+
+.card-week.collapsed .card-week-body {
+  display: none;
+}
+
+.card-deck-grid {
+  display: grid;
+  gap: var(--pad);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.card-deck {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  padding: var(--pad-lg);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background:
+    linear-gradient(160deg, rgba(14, 23, 40, 0.92), rgba(6, 12, 24, 0.9));
+  box-shadow: 0 20px 42px rgba(2, 6, 23, 0.45);
+  cursor: pointer;
+  transition: transform 0.35s ease, box-shadow 0.35s ease, border-color 0.35s ease;
+  outline: none;
+  overflow: visible;
+}
+
+.card-deck::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.18), rgba(192, 132, 252, 0.15));
+  opacity: 0.45;
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.card-deck:hover {
+  transform: translateY(-8px) scale(1.01);
+  border-color: rgba(148, 163, 184, 0.45);
+  box-shadow: 0 32px 56px rgba(2, 6, 23, 0.58);
+}
+
+.card-deck:focus-visible {
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.45), 0 24px 48px rgba(2, 6, 23, 0.5);
+}
+
+.card-deck-stack {
+  position: relative;
+  height: 150px;
+  width: 100%;
+  perspective: 1200px;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.card-stack-card {
+  position: absolute;
+  inset: 12px 36px;
+  padding: 12px;
+  border-radius: calc(var(--radius-lg) - 4px);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background:
+    radial-gradient(circle at top left, rgba(255, 255, 255, 0.12), transparent 60%),
+    linear-gradient(160deg, rgba(13, 23, 42, 0.95), var(--stack-accent, rgba(56, 189, 248, 0.35)));
+  color: var(--text);
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  line-height: 1.2;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-start;
+  text-align: left;
+  text-shadow: 0 8px 24px rgba(2, 6, 23, 0.6);
+  box-shadow: 0 18px 38px rgba(2, 6, 23, 0.5);
+  transform-origin: center 120%;
+  transform:
+    translateX(calc(var(--offset) * 18px))
+    rotate(calc(var(--offset) * 4deg))
+    translateY(calc(var(--index) * -6px));
+  transition: transform 0.4s ease, box-shadow 0.4s ease, opacity 0.35s ease;
+  z-index: calc(10 + var(--index));
+  opacity: calc(0.82 + (var(--index) * 0.05));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.card-deck:hover .card-stack-card {
+  transform:
+    translateX(calc(var(--offset) * 28px))
+    rotate(calc(var(--offset) * 6.5deg))
+    translateY(calc(var(--index) * -12px))
+    scale(1.02);
+  box-shadow: 0 32px 56px rgba(2, 6, 23, 0.55);
+}
+
+.card-deck-info {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  position: relative;
+  z-index: 2;
+}
+
+.card-deck-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.card-deck-subtitle {
+  font-size: 0.85rem;
+  color: rgba(248, 250, 252, 0.72);
+}
+
+.card-deck-meta {
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(248, 250, 252, 0.65);
+}
+
+.deck-viewer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-lg);
+  padding: calc(var(--pad-lg) + 8px);
   min-height: 70vh;
 }
+
+.deck-viewer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--pad-lg);
+  background: rgba(10, 16, 28, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: var(--radius-lg);
+  padding: var(--pad) var(--pad-lg);
+  box-shadow: 0 16px 30px rgba(2, 6, 23, 0.4);
+}
+
+.deck-viewer-title h2 {
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.deck-viewer-meta {
+  margin-top: 4px;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.deck-viewer-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.deck-viewer-counter {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  min-width: 64px;
+  text-align: center;
+}
+
+.deck-nav-btn {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(6, 11, 20, 0.75);
+  color: var(--text);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.6rem;
+  transition: background 0.25s ease, border-color 0.25s ease, transform 0.25s ease;
+}
+
+.deck-nav-btn:hover {
+  background: rgba(56, 189, 248, 0.22);
+  border-color: rgba(56, 189, 248, 0.45);
+  transform: translateY(-1px);
+}
+
+.deck-related-toggle {
+  border-radius: 999px;
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  background: rgba(56, 189, 248, 0.16);
+  color: var(--text);
+  padding: 6px 18px;
+  font-size: 0.9rem;
+  transition: background 0.25s ease, border-color 0.25s ease, color 0.25s ease;
+}
+
+.deck-related-toggle:hover {
+  background: rgba(56, 189, 248, 0.24);
+  border-color: rgba(56, 189, 248, 0.45);
+}
+
+.deck-related-toggle.active {
+  background: rgba(56, 189, 248, 0.3);
+  border-color: rgba(56, 189, 248, 0.55);
+}
+
+.deck-close {
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.55);
+  color: rgba(248, 250, 252, 0.76);
+  padding: 6px 18px;
+  font-size: 0.9rem;
+  transition: background 0.25s ease, color 0.25s ease, border-color 0.25s ease;
+}
+
+.deck-close:hover {
+  background: rgba(148, 163, 184, 0.2);
+  color: var(--text);
+  border-color: rgba(148, 163, 184, 0.45);
+}
+
 .deck-card {
-  margin:0 auto;
+  display: flex;
+  justify-content: center;
+  width: 100%;
 }
 
 .deck-card .item-card {
-  width:40vw;
-  height:20vh;
-  overflow:hidden;
-  display:flex;
-  flex-direction:column;
+  width: min(760px, 90vw);
+  max-width: 100%;
+  height: auto;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 .deck-card .item-card.expanded {
-  height:70vh;
+  height: min(70vh, 640px);
 }
 
 .deck-card .item-card .card-body {
-  display:none;
-  flex:1;
-  overflow:auto;
-}
-
-.deck-card .item-card.expanded .card-body {
-  display:block;
+  flex: 1;
+  overflow: auto;
 }
 
 .deck-card .item-card.expanded .section-content {
-  overflow-y:auto;
+  overflow-y: auto;
 }
-.deck-prev, .deck-next {
-  position:absolute;
-  top:50%;
-  transform:translateY(-50%);
-  background:var(--muted);
-  color:var(--text);
-  padding:8px;
-  border-radius:var(--radius);
-  cursor:pointer;
-  border:1px solid var(--border);
-}
-.deck-prev { left:var(--pad); }
-.deck-next { right:var(--pad); }
-.deck-prev:hover, .deck-next:hover {
-  transform:translateY(calc(-50% - 2px));
-}
+
 .deck-related {
-  display:flex;
-  flex-wrap:wrap;
-  gap:var(--pad);
-  justify-content:center;
-  margin-top:var(--pad);
-  opacity:0;
-  transform:translateY(-10px);
-  transition:opacity 0.3s ease, transform 0.3s ease;
+  display: grid;
+  gap: var(--pad);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  opacity: 0;
+  transform: translateY(-10px);
+  transition: opacity 0.35s ease, transform 0.35s ease;
+  margin-top: var(--pad);
 }
+
 .deck-related:not(.hidden) {
-  opacity:1;
-  transform:translateY(0);
+  opacity: 1;
+  transform: translateY(0);
 }
+
 .deck-related .related-card {
-  opacity:0;
-  transform:scale(0.95);
-  transition:opacity 0.3s ease, transform 0.3s ease;
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 0.35s ease, transform 0.35s ease;
 }
+
 .deck-related .related-card.visible {
-  opacity:1;
-  transform:scale(1);
-}
-.deck-close {
-  margin-top:var(--pad);
+  opacity: 1;
+  transform: translateY(0);
 }
 .hidden { display:none !important; }
 


### PR DESCRIPTION
## Summary
- overhaul the Cards tab to group decks by block and week with collapsible sections and a new fan-styled lecture deck tile
- refresh the deck viewer with updated navigation, related toggle, and metadata presentation to match the study/exam aesthetic
- compact the rich-text editor toolbar, remove duplicate highlight actions, enlarge curriculum tagging panels, and widen the editor window for easier tagging

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc444feadc8322a6d27ecfc47327bb