### PR TITLE
Refine editor toolbar and save flow

### DIFF
--- a/js/ui/components/window-manager.js
+++ b/js/ui/components/window-manager.js
@@ -60,7 +60,7 @@ function setupDragging(win, header){
   }
 }
 
-export function createFloatingWindow({ title, width = 520, onClose } = {}){
+export function createFloatingWindow({ title, width = 520, onClose, onBeforeClose } = {}){
   ensureDock();
   const win = document.createElement('div');
   win.className = 'floating-window';
@@ -141,14 +141,24 @@ export function createFloatingWindow({ title, width = 520, onClose } = {}){
 
   minimizeBtn.addEventListener('click', handleMinimize);
 
-  function close(reason){
+  async function close(reason){
+    if (typeof onBeforeClose === 'function') {
+      try {
+        const shouldClose = await onBeforeClose(reason);
+        if (shouldClose === false) return false;
+      } catch (err) {
+        console.error(err);
+        return false;
+      }
+    }
     destroyDockButton();
     windows.delete(win);
     if (win.parentElement) win.parentElement.removeChild(win);
     if (typeof onClose === 'function') onClose(reason);
+    return true;
   }
 
-  closeBtn.addEventListener('click', () => close('close'));
+  closeBtn.addEventListener('click', () => { void close('close'); });
 
   win.addEventListener('mousedown', () => bringToFront(win));
 

--- a/style.css
+++ b/style.css
@@ -686,7 +686,7 @@ input[type="checkbox"]:checked::after {
 
 .floating-actions {
   display: flex;
-  gap: 4px;
+  gap: 6px;
 }
 
 .floating-action {
@@ -698,6 +698,10 @@ input[type="checkbox"]:checked::after {
   border-radius: 8px;
   font-size: 18px;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
 }
 
 .floating-action:hover {
@@ -744,9 +748,10 @@ input[type="checkbox"]:checked::after {
   display: flex;
   flex-direction: column;
   gap: var(--pad);
-  min-height: 220px;
-  max-height: clamp(280px, 46vh, 420px);
+  min-height: 320px;
+  max-height: clamp(420px, 62vh, 680px);
   overflow: hidden;
+  flex: 1 1 auto;
 }
 
 .editor-tags-title {
@@ -947,51 +952,58 @@ input[type="checkbox"]:checked::after {
 .rich-editor {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  background: rgba(15, 23, 42, 0.4);
-  border: 1px solid var(--border);
+  gap: 8px;
+  background: rgba(15, 23, 42, 0.32);
+  border: 1px solid rgba(148, 163, 184, 0.22);
   border-radius: var(--radius);
-  padding: var(--pad-sm);
+  padding: 12px;
 }
 
 .rich-editor-toolbar {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 6px;
   align-items: center;
 }
 
 .rich-editor-group {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
   padding: 4px 6px;
   border-radius: var(--radius-sm);
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  background: rgba(8, 13, 23, 0.6);
-  backdrop-filter: blur(6px);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(8, 13, 23, 0.5);
+  backdrop-filter: blur(8px);
 }
 
-.rich-editor-label {
-  font-size: 0.75rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--text-muted);
+.rich-editor-color-group {
+  gap: 6px;
+  flex-wrap: wrap;
+  align-items: center;
+  row-gap: 4px;
+}
+
+.rich-editor-highlight-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
 }
 
 .rich-editor-btn {
   background: transparent;
   border: none;
   color: var(--text-muted);
-  padding: 6px 8px;
-  font-size: 0.9rem;
+  padding: 4px 6px;
+  font-size: 0.85rem;
   cursor: pointer;
   border-radius: var(--radius-sm);
 }
 
 .rich-editor-btn:hover,
 .rich-editor-btn:focus {
-  background: var(--muted);
+  background: rgba(148, 163, 184, 0.18);
   color: var(--text);
   outline: none;
 }
@@ -1002,39 +1014,35 @@ input[type="checkbox"]:checked::after {
 }
 
 .rich-editor-color input {
-  width: 34px;
-  height: 30px;
+  width: 28px;
+  height: 26px;
   border: 1px solid rgba(148, 163, 184, 0.25);
   border-radius: var(--radius-sm);
-  background: rgba(15, 23, 42, 0.4);
+  background: rgba(15, 23, 42, 0.45);
   padding: 0;
   cursor: pointer;
 }
 
-.rich-editor-highlight-group {
-  gap: 8px;
-}
-
 .rich-editor-swatch {
-  width: 26px;
-  height: 26px;
+  width: 22px;
+  height: 22px;
   border-radius: 50%;
-  border: 2px solid rgba(8, 13, 23, 0.7);
+  border: 2px solid rgba(8, 13, 23, 0.65);
   background: var(--swatch-color, transparent);
-  box-shadow: 0 0 0 2px rgba(148, 163, 184, 0.25);
+  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.35);
   cursor: pointer;
 }
 
 .rich-editor-swatch:hover,
 .rich-editor-swatch:focus {
-  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.45);
+  box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.55);
   outline: none;
 }
 
 .rich-editor-swatch--clear {
-  background: rgba(15, 23, 42, 0.6);
+  background: rgba(15, 23, 42, 0.65);
   color: var(--text-muted);
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   line-height: 1;
 }
 
@@ -1043,16 +1051,15 @@ input[type="checkbox"]:checked::after {
   color: var(--text);
 }
 
-.rich-editor-select,
 .rich-editor-size {
-  background: rgba(15, 23, 42, 0.6);
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.5);
+  border: 1px solid rgba(148, 163, 184, 0.22);
   border-radius: var(--radius-sm);
   color: var(--text);
-  padding: 6px 10px;
+  padding: 4px 8px;
   cursor: pointer;
-  font-size: 0.9rem;
-  min-width: 120px;
+  font-size: 0.85rem;
+  min-width: 0;
 }
 
 .rich-editor-area {
@@ -1064,6 +1071,9 @@ input[type="checkbox"]:checked::after {
   overflow: auto;
   word-break: break-word;
   backdrop-filter: blur(4px);
+  font-size: 0.95rem;
+  line-height: 1.55;
+  font-weight: 400;
 }
 
 .rich-editor-area:focus {
@@ -1092,25 +1102,6 @@ input[type="checkbox"]:checked::after {
   margin-left: auto;
   font-size: 0.85rem;
   opacity: 0.8;
-}
-
-.editor-tags {
-  margin-top: var(--pad);
-  padding: var(--pad);
-  background: rgba(15, 23, 42, 0.45);
-  border-radius: var(--radius);
-  border: 1px solid var(--border);
-  max-height: min(420px, 50vh);
-  overflow: auto;
-  display: flex;
-  flex-direction: column;
-  gap: var(--pad-sm);
-}
-
-.editor-tags-title {
-  font-weight: 600;
-  margin: 0;
-  font-size: 1rem;
 }
 
 .editor-tag-block {


### PR DESCRIPTION
## Summary
- redesign the rich text editor toolbar with a compact layout, selection-aware formatting commands, and a single highlight removal control
- streamline the item editor with dirty-state tracking, a single save-and-close action, and a confirmation prompt when closing with unsaved work
- expand curriculum tagging space and align floating window controls for a cleaner presentation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc4ebdf0b083228b85dff12e2c6734