### PR TITLE
Fix editor rich text labeling and bold toggle

### DIFF
--- a/js/ui/components/editor.js
+++ b/js/ui/components/editor.js
@@ -85,17 +85,25 @@ export async function openEditor(kind, onSave, existing = null) {
 
   const fieldInputs = {};
   fieldMap[kind].forEach(([field, label]) => {
-    const lbl = document.createElement('label');
-    lbl.className = 'editor-field';
-    lbl.textContent = label;
+    const fieldWrap = document.createElement('div');
+    fieldWrap.className = 'editor-field';
+
+    const labelEl = document.createElement('label');
+    labelEl.className = 'editor-field-label';
+    labelEl.textContent = label;
+    const labelId = `field-${field}-${uid()}`;
+    labelEl.id = labelId;
+    fieldWrap.appendChild(labelEl);
+
     const editor = createRichTextEditor({
       value: existing ? existing[field] || '' : '',
-      onChange: markDirty
+      onChange: markDirty,
+      ariaLabelledBy: labelId
     });
     const inp = editor.element;
     fieldInputs[field] = editor;
-    lbl.appendChild(inp);
-    form.appendChild(lbl);
+    fieldWrap.appendChild(inp);
+    form.appendChild(fieldWrap);
   });
 
   const extrasWrap = document.createElement('section');

--- a/js/ui/components/rich-text.js
+++ b/js/ui/components/rich-text.js
@@ -163,7 +163,7 @@ function createToolbarButton(label, title, onClick){
   return btn;
 }
 
-export function createRichTextEditor({ value = '', onChange } = {}){
+export function createRichTextEditor({ value = '', onChange, ariaLabel, ariaLabelledBy } = {}){
   const wrapper = document.createElement('div');
   wrapper.className = 'rich-editor';
 
@@ -178,6 +178,8 @@ export function createRichTextEditor({ value = '', onChange } = {}){
   editable.contentEditable = 'true';
   editable.spellcheck = true;
   editable.innerHTML = normalizeInput(value);
+  if (ariaLabel) editable.setAttribute('aria-label', ariaLabel);
+  if (ariaLabelledBy) editable.setAttribute('aria-labelledby', ariaLabelledBy);
   wrapper.appendChild(editable);
 
   const commandButtons = [];

--- a/style.css
+++ b/style.css
@@ -793,6 +793,11 @@ input[type="checkbox"]:checked::after {
   font-size: 0.95rem;
 }
 
+.editor-field-label {
+  font-weight: 600;
+  color: var(--text);
+}
+
 .editor-tags {
   margin-top: var(--pad);
   padding: var(--pad);


### PR DESCRIPTION
## Summary
- stop using a wrapping label around rich text editors to prevent accidental bold toggles when clicking the field
- connect each editor to its label via aria-labelledby options and expose optional aria labelling in the rich text helper
- style the new field label element to keep the popup form layout unchanged

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc6d8de9cc8322af138fd758869660