### PR TITLE
Fix rich text toolbar toggling and modal stacking order

### DIFF
--- a/js/ui/components/rich-text.js
+++ b/js/ui/components/rich-text.js
@@ -230,15 +230,19 @@ export function createRichTextEditor({ value = '', onChange, ariaLabel, ariaLabe
       if (tag === 'i' || tag === 'em') state.italic = true;
       if (tag === 'u') state.underline = true;
       if (tag === 's' || tag === 'strike' || tag === 'del') state.strike = true;
-      if (typeof window !== 'undefined' && el instanceof Element) {
-        const style = window.getComputedStyle(el);
-        if (style) {
+      if (el instanceof Element) {
+        const inlineStyle = el.style;
+        if (inlineStyle) {
           if (!state.bold) {
-            const weight = parseInt(style.fontWeight, 10);
-            if (style.fontWeight === 'bold' || Number.isFinite(weight) && weight >= 600) state.bold = true;
+            const weightRaw = inlineStyle.fontWeight || '';
+            const weightText = typeof weightRaw === 'string' ? weightRaw.toLowerCase() : `${weightRaw}`.toLowerCase();
+            const weightValue = Number.parseInt(weightText, 10);
+            if (weightText === 'bold' || weightText === 'bolder' || Number.isFinite(weightValue) && weightValue >= 600) {
+              state.bold = true;
+            }
           }
-          if (!state.italic && style.fontStyle === 'italic') state.italic = true;
-          const deco = `${style.textDecorationLine || style.textDecoration || ''}`.toLowerCase();
+          if (!state.italic && inlineStyle.fontStyle === 'italic') state.italic = true;
+          const deco = `${inlineStyle.textDecorationLine || inlineStyle.textDecoration || ''}`.toLowerCase();
           if (!state.underline && deco.includes('underline')) state.underline = true;
           if (!state.strike && (deco.includes('line-through') || deco.includes('strikethrough'))) state.strike = true;
         }

--- a/style.css
+++ b/style.css
@@ -1077,11 +1077,16 @@ input[type="checkbox"]:checked::after {
   outline: none;
 }
 
+
+.rich-editor-btn:active {
+  color: #000;
+}
+
 .rich-editor-btn.is-active,
 .rich-editor-btn[data-active="true"] {
   background: linear-gradient(135deg, rgba(56, 189, 248, 0.96), rgba(192, 132, 252, 0.92));
   border-color: transparent;
-  color: #031327;
+  color: #000;
   box-shadow: 0 18px 32px rgba(2, 6, 23, 0.42);
   transform: translateY(-1px);
 }
@@ -1091,7 +1096,7 @@ input[type="checkbox"]:checked::after {
 .rich-editor-btn[data-active="true"]:hover,
 .rich-editor-btn[data-active="true"]:focus {
   background: linear-gradient(135deg, rgba(56, 189, 248, 0.98), rgba(192, 132, 252, 0.96));
-  color: #020a16;
+  color: #000;
 }
 
 .rich-editor-color {
@@ -1289,6 +1294,7 @@ input[type="checkbox"]:checked::after {
   justify-content: center;
   overflow-y: auto;
   padding: 40px 0;
+  z-index: 12000;
 }
 
 .modal .card {


### PR DESCRIPTION
## Summary
- adjust the rich text editor's collapsed state detection to rely on inline styles so focusing the editor no longer flips the bold command on and off
- make the formatting buttons turn their glyphs black when pressed/active and raise the modal overlay z-index so confirmations appear above floating windows

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc6f4c5c888322be4f607c79d93644