### PR TITLE
Guard synthetic input dispatch in rich text editor

### DIFF
--- a/js/ui/components/rich-text.js
+++ b/js/ui/components/rich-text.js
@@ -227,9 +227,20 @@ export function createRichTextEditor({ value = '', onChange, ariaLabel, ariaLabe
     if (!getSavedRange({ requireSelection })) return false;
     focusEditor();
     if (!restoreSavedRange({ requireSelection })) return false;
+
+    let inputFired = false;
+    const handleInput = () => {
+      inputFired = true;
+    };
+    editable.addEventListener('input', handleInput, { once: true });
+
     const result = action();
+
+    editable.removeEventListener('input', handleInput);
     captureSelectionRange();
-    editable.dispatchEvent(new Event('input'));
+    if (!inputFired) {
+      editable.dispatchEvent(new Event('input', { bubbles: true }));
+    }
     updateInlineState();
     return result;
   }


### PR DESCRIPTION
## Summary
- detect whether execCommand triggered a native input event before firing a synthetic fallback
- ensure fallback synthetic input continues to bubble so onChange handlers run when needed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc75fc565c83228f010fe55373cd60