### PR TITLE
Refine concept map layout with fullscreen UI

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -16,6 +16,23 @@ const tabs = ["Diseases","Drugs","Concepts","Cards","Study","Exams","Map"];
 
 async function render() {
   const root = document.getElementById('app');
+
+  if (state.tab === 'Map') {
+    root.innerHTML = '';
+    root.classList.add('map-shell');
+    const navTabs = [...tabs.filter(t => t !== 'Map'), 'Settings'];
+    await renderMap(root, {
+      navigate: tab => {
+        setTab(tab);
+        render();
+      },
+      tabs: navTabs
+    });
+    return;
+  }
+
+  root.classList.remove('map-shell');
+
   const activeEl = document.activeElement;
   const shouldRestoreSearch = activeEl && activeEl.dataset && activeEl.dataset.role === 'global-search';
   const selectionStart = shouldRestoreSearch && typeof activeEl.selectionStart === 'number' ? activeEl.selectionStart : null;

--- a/style.css
+++ b/style.css
@@ -51,6 +51,12 @@ html, body, #app {
   flex-direction: column;
 }
 
+#app.map-shell {
+  display: block;
+  position: relative;
+  overflow: hidden;
+}
+
 main {
   flex: 1;
   overflow: auto;
@@ -2441,27 +2447,177 @@ input[type="checkbox"]:checked::after {
 }
 
 .map-wrapper {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.map-stage {
+  position: absolute;
+  inset: 0;
+}
+
+.map-container {
+  position: absolute;
+  inset: 0;
+}
+
+.map-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.map-drawer {
+  position: absolute;
+  top: 24px;
+  left: 0;
+  height: calc(100% - 48px);
+  display: flex;
+  align-items: flex-start;
+  gap: 0;
+  pointer-events: auto;
+  z-index: 6;
+}
+
+.map-drawer-handle {
+  pointer-events: auto;
+  margin-top: 12px;
+  width: 48px;
+  height: 48px;
+  border-radius: 0 var(--radius) var(--radius) 0;
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  color: rgba(226, 232, 240, 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.map-drawer-handle:hover {
+  background: rgba(15, 23, 42, 0.85);
+  color: var(--text);
+}
+
+.map-drawer.open .map-drawer-handle,
+.map-drawer:focus-within .map-drawer-handle,
+.map-drawer:hover .map-drawer-handle {
+  background: rgba(15, 23, 42, 0.85);
+  color: var(--text);
+}
+
+.map-menu {
+  pointer-events: auto;
+  width: min(340px, calc(100vw - 80px));
+  max-height: 100%;
+  background: rgba(2, 6, 23, 0.86);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-left: none;
+  border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
+  padding: 24px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  padding: var(--pad);
-  padding-top: 16px;
-  height: 100%;
+  gap: 20px;
+  transform: translateX(calc(-100% + 52px));
+  transition: transform 0.28s ease;
+  box-shadow: 0 30px 50px rgba(2, 6, 23, 0.55);
+  overflow-y: auto;
+}
+
+.map-drawer.open .map-menu,
+.map-drawer:hover .map-menu,
+.map-drawer:focus-within .map-menu {
+  transform: translateX(0);
+}
+
+.map-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.map-nav-title {
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.6);
+}
+
+.map-nav-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.map-nav-btn {
+  flex: 1 1 45%;
+  min-width: 120px;
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  color: rgba(226, 232, 240, 0.88);
+  border-radius: var(--radius-sm);
+  padding: 8px 12px;
+  text-align: left;
+}
+
+.map-nav-btn:hover {
+  background: rgba(148, 163, 184, 0.24);
+  border-color: rgba(203, 213, 225, 0.35);
 }
 
 .map-header {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.map-header-top {
+  display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
 }
 
-.map-tabs {
+.map-header-title {
+  margin: 0;
+  font-size: 18px;
+}
+
+.map-header-actions {
   display: flex;
   align-items: center;
+  gap: 8px;
+}
+
+.map-header-btn {
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  background: rgba(148, 163, 184, 0.16);
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  font-size: 18px;
+}
+
+.map-header-btn:hover {
+  background: rgba(148, 163, 184, 0.26);
+  border-color: rgba(203, 213, 225, 0.42);
+}
+
+.map-header-btn.active {
+  background: rgba(56, 189, 248, 0.28);
+  border-color: rgba(125, 211, 252, 0.45);
+  color: var(--text);
+}
+
+.map-tabs {
+  display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: 8px;
 }
 
 .map-tab-list {
@@ -2474,14 +2630,14 @@ input[type="checkbox"]:checked::after {
   padding: 6px 14px;
   border-radius: 999px;
   background: rgba(148, 163, 184, 0.16);
-  border: 1px solid rgba(148, 163, 184, 0.32);
+  border: 1px solid rgba(148, 163, 184, 0.28);
   color: var(--text);
   transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .map-tab:hover {
-  background: rgba(148, 163, 184, 0.28);
-  border-color: rgba(203, 213, 225, 0.4);
+  background: rgba(148, 163, 184, 0.26);
+  border-color: rgba(203, 213, 225, 0.36);
 }
 
 .map-tab.active {
@@ -2491,38 +2647,51 @@ input[type="checkbox"]:checked::after {
   box-shadow: 0 12px 28px rgba(15, 23, 42, 0.2);
 }
 
-.map-tab-add {
-  width: 32px;
-  height: 32px;
-  border-radius: 999px;
-  display: grid;
-  place-items: center;
-  background: rgba(148, 163, 184, 0.16);
-  border: 1px solid rgba(148, 163, 184, 0.32);
-  font-size: 20px;
-  line-height: 1;
-}
-
-.map-tab-add:hover {
-  background: rgba(148, 163, 184, 0.26);
-  border-color: rgba(203, 213, 225, 0.42);
-}
-
 .map-search-container {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  gap: 4px;
+  align-items: flex-end;
+  gap: 6px;
+}
+
+.map-search-container.floating {
+  position: absolute;
+  top: 24px;
+  right: 24px;
+  padding: 14px 18px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.62);
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  backdrop-filter: blur(18px);
+  pointer-events: auto;
+  width: min(320px, calc(100vw - 96px));
+  box-shadow: 0 20px 40px rgba(2, 6, 23, 0.45);
 }
 
 .map-search {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
+  width: 100%;
 }
 
 .map-search-input {
-  min-width: 220px;
+  flex: 1;
+  min-width: 0;
+  padding: 10px 16px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.42);
+  color: var(--text);
+  font-size: 15px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.map-search-input:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.8);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.18);
+  background: rgba(15, 23, 42, 0.6);
 }
 
 .map-search-input.not-found {
@@ -2531,13 +2700,23 @@ input[type="checkbox"]:checked::after {
 }
 
 .map-search-btn {
-  padding: 8px 14px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.22);
+  border: 1px solid rgba(56, 189, 248, 0.3);
+  color: rgba(240, 249, 255, 0.92);
+}
+
+.map-search-btn:hover {
+  background: rgba(56, 189, 248, 0.32);
+  border-color: rgba(125, 211, 252, 0.42);
 }
 
 .map-search-feedback {
   font-size: 13px;
   color: var(--text-muted);
   min-height: 18px;
+  text-align: right;
 }
 
 .map-search-feedback.success {
@@ -2552,10 +2731,28 @@ input[type="checkbox"]:checked::after {
   display: flex;
   flex-direction: column;
   gap: 14px;
-  background: rgba(15, 23, 42, 0.32);
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  border-radius: var(--radius);
-  padding: 16px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-lg);
+  padding: 0;
+  box-shadow: none;
+  opacity: 0;
+  pointer-events: none;
+  max-height: 0;
+  overflow: hidden;
+  transform: translateY(-8px);
+  transition: opacity 0.25s ease, transform 0.25s ease, max-height 0.28s ease, padding 0.2s ease, background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.map-controls.expanded {
+  background: rgba(15, 23, 42, 0.58);
+  border-color: rgba(148, 163, 184, 0.38);
+  padding: 20px;
+  box-shadow: 0 20px 40px rgba(2, 6, 23, 0.42);
+  opacity: 1;
+  pointer-events: auto;
+  max-height: 1200px;
+  transform: translateY(0);
 }
 
 .map-controls-row {
@@ -2563,6 +2760,11 @@ input[type="checkbox"]:checked::after {
   flex-wrap: wrap;
   gap: 12px;
   align-items: center;
+}
+
+.map-controls.manual-active .map-control,
+.map-controls.manual-active .map-reset-filters {
+  opacity: 0.6;
 }
 
 .map-control {
@@ -2614,28 +2816,16 @@ input[type="checkbox"]:checked::after {
   align-self: flex-start;
 }
 
-.map-content {
-  flex: 1;
-  min-height: 0;
-  display: flex;
-  gap: 16px;
-}
-
-.map-stage {
-  flex: 1;
-  min-height: 0;
-  position: relative;
-}
-
 .map-palette {
-  width: 260px;
+  width: 100%;
   display: flex;
   flex-direction: column;
   gap: 12px;
-  background: rgba(15, 23, 42, 0.26);
+  background: rgba(15, 23, 42, 0.45);
   border: 1px solid rgba(148, 163, 184, 0.32);
-  border-radius: var(--radius);
-  padding: 14px;
+  border-radius: var(--radius-lg);
+  padding: 16px;
+  box-shadow: 0 16px 32px rgba(2, 6, 23, 0.35);
 }
 
 .map-palette h3 {
@@ -2647,6 +2837,20 @@ input[type="checkbox"]:checked::after {
   margin: 0;
   font-size: 13px;
   color: var(--text-muted);
+}
+
+.map-palette-search {
+  padding: 8px 12px;
+  border-radius: var(--radius-sm);
+  background: rgba(15, 23, 42, 0.38);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  color: var(--text);
+}
+
+.map-palette-search:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.6);
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.18);
 }
 
 .map-palette-list,
@@ -2830,8 +3034,8 @@ input[type="checkbox"]:checked::after {
 
 .map-hidden-panel {
   position: absolute;
-  top: 16px;
-  right: 16px;
+  top: 120px;
+  right: 24px;
   width: 260px;
   max-height: calc(100% - 32px);
   background: var(--panel);


### PR DESCRIPTION
## Summary
- render the map tab in a dedicated fullscreen shell with navigation callbacks
- rebuild the map component with a hoverable drawer that contains tabs, settings, and manual-mode tools
- restyle the concept map to expose a floating translucent search bar and hidden controls for a cleaner canvas

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc8d2bea908322a5c35b9fc5e8002d