### PR TITLE
Revamp concept map layout with overlay controls

### DIFF
--- a/js/ui/components/map.js
+++ b/js/ui/components/map.js
@@ -284,13 +284,15 @@ function setSearchInputState({ notFound = false } = {}) {
   input.classList.toggle('not-found', Boolean(notFound));
 }
 
-function buildMapHeader(wrapper, activeTab) {
+function createMapTabsPanel(activeTab) {
   const config = mapState.mapConfig || { tabs: [] };
-  const header = document.createElement('div');
-  header.className = 'map-header';
-
   const tabsWrap = document.createElement('div');
   tabsWrap.className = 'map-tabs';
+
+  const heading = document.createElement('div');
+  heading.className = 'map-tabs-heading';
+  heading.textContent = 'Concept maps';
+  tabsWrap.appendChild(heading);
 
   const tabList = document.createElement('div');
   tabList.className = 'map-tab-list';
@@ -308,6 +310,9 @@ function buildMapHeader(wrapper, activeTab) {
   });
   tabsWrap.appendChild(tabList);
 
+  const actions = document.createElement('div');
+  actions.className = 'map-tab-actions';
+
   const addBtn = document.createElement('button');
   addBtn.type = 'button';
   addBtn.className = 'map-tab-add';
@@ -316,12 +321,28 @@ function buildMapHeader(wrapper, activeTab) {
   addBtn.addEventListener('click', () => {
     createMapTab();
   });
-  tabsWrap.appendChild(addBtn);
+  actions.appendChild(addBtn);
 
-  header.appendChild(tabsWrap);
+  const settingsBtn = document.createElement('button');
+  settingsBtn.type = 'button';
+  settingsBtn.className = 'map-tab-settings';
+  settingsBtn.textContent = 'Settings';
+  settingsBtn.addEventListener('click', () => {
+    const headerSettings = document.querySelector('.header-settings-btn');
+    if (headerSettings) {
+      headerSettings.click();
+    }
+  });
+  actions.appendChild(settingsBtn);
 
+  tabsWrap.appendChild(actions);
+
+  return tabsWrap;
+}
+
+function createSearchOverlay() {
   const searchWrap = document.createElement('div');
-  searchWrap.className = 'map-search-container';
+  searchWrap.className = 'map-search-container map-search-overlay';
 
   const form = document.createElement('form');
   form.className = 'map-search';
@@ -356,21 +377,18 @@ function buildMapHeader(wrapper, activeTab) {
   feedback.className = 'map-search-feedback';
   searchWrap.appendChild(feedback);
 
-  header.appendChild(searchWrap);
-
-  wrapper.appendChild(header);
-
   mapState.searchInput = input;
   mapState.searchFeedbackEl = feedback;
   applyStoredSearchFeedback();
+
+  return searchWrap;
 }
 
-function buildMapControls(wrapper, activeTab) {
+function createMapControlsPanel(activeTab) {
   const controls = document.createElement('div');
   controls.className = 'map-controls';
   if (!activeTab) {
-    wrapper.appendChild(controls);
-    return;
+    return controls;
   }
 
   const titleRow = document.createElement('div');
@@ -416,6 +434,14 @@ function buildMapControls(wrapper, activeTab) {
   manualInput.checked = Boolean(activeTab.manualMode);
   manualInput.addEventListener('change', async () => {
     activeTab.manualMode = manualInput.checked;
+    if (manualInput.checked) {
+      activeTab.filter.blockId = '';
+      activeTab.filter.week = '';
+      activeTab.filter.lectureKey = '';
+      activeTab.includeLinked = false;
+    } else {
+      activeTab.includeLinked = true;
+    }
     await persistMapConfig();
     await renderMap(mapState.root);
   });
@@ -429,7 +455,7 @@ function buildMapControls(wrapper, activeTab) {
   linkedToggle.className = 'map-toggle';
   const linkedInput = document.createElement('input');
   linkedInput.type = 'checkbox';
-  linkedInput.checked = activeTab.includeLinked !== false;
+  linkedInput.checked = activeTab.manualMode ? false : activeTab.includeLinked !== false;
   linkedInput.addEventListener('change', async () => {
     activeTab.includeLinked = linkedInput.checked;
     await persistMapConfig();
@@ -569,10 +595,10 @@ function buildMapControls(wrapper, activeTab) {
 
   controls.appendChild(filterRow);
 
-  wrapper.appendChild(controls);
+  return controls;
 }
 
-function buildMapPalette(items, activeTab) {
+function createMapPalettePanel(items, activeTab) {
   if (!activeTab || !activeTab.manualMode) {
     return null;
   }
@@ -884,26 +910,88 @@ export async function renderMap(root) {
   wrapper.className = 'map-wrapper';
   root.appendChild(wrapper);
 
-  buildMapHeader(wrapper, activeTab);
-  buildMapControls(wrapper, activeTab);
-
-  const content = document.createElement('div');
-  content.className = 'map-content';
-  wrapper.appendChild(content);
-
-  const palette = buildMapPalette(items, activeTab);
-  if (palette) {
-    content.appendChild(palette);
-  }
-
   const stage = document.createElement('div');
   stage.className = 'map-stage';
-  content.appendChild(stage);
+  wrapper.appendChild(stage);
 
   const container = document.createElement('div');
   container.className = 'map-container';
   stage.appendChild(container);
   mapState.container = container;
+
+  const overlay = document.createElement('div');
+  overlay.className = 'map-overlay';
+  stage.appendChild(overlay);
+
+  const menu = document.createElement('div');
+  menu.className = 'map-menu';
+  overlay.appendChild(menu);
+
+  const toggle = document.createElement('button');
+  toggle.type = 'button';
+  toggle.className = 'map-menu-toggle';
+  toggle.setAttribute('aria-haspopup', 'true');
+  toggle.setAttribute('aria-expanded', 'false');
+  toggle.setAttribute('aria-label', 'Open map controls');
+  toggle.innerHTML = '<span class="map-menu-icon">☰</span>';
+  menu.appendChild(toggle);
+
+  const panel = document.createElement('div');
+  panel.className = 'map-menu-panel';
+  menu.appendChild(panel);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.type = 'button';
+  closeBtn.className = 'map-menu-close';
+  closeBtn.textContent = 'Close menu';
+  closeBtn.setAttribute('aria-label', 'Hide map controls');
+  panel.appendChild(closeBtn);
+
+  const tabsPanel = createMapTabsPanel(activeTab);
+  panel.appendChild(tabsPanel);
+
+  const controlsPanel = createMapControlsPanel(activeTab);
+  if (controlsPanel) {
+    panel.appendChild(controlsPanel);
+  }
+
+  const palettePanel = createMapPalettePanel(items, activeTab);
+  if (palettePanel) {
+    panel.appendChild(palettePanel);
+  }
+
+  const searchOverlay = createSearchOverlay();
+  overlay.appendChild(searchOverlay);
+
+  function setMenuOpen(open) {
+    menu.classList.toggle('open', open);
+    toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+    toggle.setAttribute('aria-label', open ? 'Hide map controls' : 'Open map controls');
+  }
+
+  toggle.addEventListener('click', evt => {
+    evt.preventDefault();
+    const next = !menu.classList.contains('open');
+    setMenuOpen(next);
+  });
+
+  menu.addEventListener('mouseenter', () => {
+    setMenuOpen(true);
+  });
+  menu.addEventListener('mouseleave', () => {
+    setMenuOpen(false);
+  });
+  menu.addEventListener('focusin', () => {
+    setMenuOpen(true);
+  });
+  menu.addEventListener('focusout', evt => {
+    if (!menu.contains(evt.relatedTarget)) {
+      setMenuOpen(false);
+    }
+  });
+  closeBtn.addEventListener('click', () => {
+    setMenuOpen(false);
+  });
 
   const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
   svg.classList.add('map-svg');

--- a/style.css
+++ b/style.css
@@ -2441,78 +2441,79 @@ input[type="checkbox"]:checked::after {
 }
 
 .map-wrapper {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  padding: var(--pad);
-  padding-top: 16px;
   height: 100%;
-}
-
-.map-header {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
+  padding: 0;
+  overflow: hidden;
 }
 
 .map-tabs {
   display: flex;
-  align-items: center;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 12px;
+}
+
+.map-tabs-heading {
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.72);
 }
 
 .map-tab-list {
   display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .map-tab {
-  padding: 6px 14px;
-  border-radius: 999px;
-  background: rgba(148, 163, 184, 0.16);
-  border: 1px solid rgba(148, 163, 184, 0.32);
+  text-align: left;
+  padding: 8px 14px;
+  border-radius: var(--radius);
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.28);
   color: var(--text);
   transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .map-tab:hover {
-  background: rgba(148, 163, 184, 0.28);
-  border-color: rgba(203, 213, 225, 0.4);
+  background: rgba(148, 163, 184, 0.24);
+  border-color: rgba(203, 213, 225, 0.42);
 }
 
 .map-tab.active {
-  background: #ffffff;
-  color: #0f172a;
-  border-color: #ffffff;
-  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.2);
-}
-
-.map-tab-add {
-  width: 32px;
-  height: 32px;
-  border-radius: 999px;
-  display: grid;
-  place-items: center;
-  background: rgba(148, 163, 184, 0.16);
-  border: 1px solid rgba(148, 163, 184, 0.32);
-  font-size: 20px;
-  line-height: 1;
-}
-
-.map-tab-add:hover {
   background: rgba(148, 163, 184, 0.26);
+  color: #f8fafc;
+  border-color: rgba(148, 163, 184, 0.45);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.45);
+}
+
+.map-tab-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.map-tab-add,
+.map-tab-settings {
+  padding: 8px 12px;
+  border-radius: var(--radius-sm);
+  background: rgba(148, 163, 184, 0.14);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+}
+
+.map-tab-add:hover,
+.map-tab-settings:hover {
+  background: rgba(148, 163, 184, 0.24);
   border-color: rgba(203, 213, 225, 0.42);
 }
 
 .map-search-container {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  gap: 4px;
+  align-items: center;
+  gap: 6px;
 }
 
 .map-search {
@@ -2523,11 +2524,19 @@ input[type="checkbox"]:checked::after {
 
 .map-search-input {
   min-width: 220px;
+  background: rgba(15, 23, 42, 0.6);
+  color: #f8fafc;
+  border-color: rgba(148, 163, 184, 0.5);
+  backdrop-filter: blur(6px);
 }
 
 .map-search-input.not-found {
   border-color: rgba(248, 113, 113, 0.85);
   box-shadow: 0 0 0 2px rgba(248, 113, 113, 0.25);
+}
+
+.map-search-input::placeholder {
+  color: rgba(226, 232, 240, 0.7);
 }
 
 .map-search-btn {
@@ -2548,11 +2557,32 @@ input[type="checkbox"]:checked::after {
   color: #f87171;
 }
 
+.map-search-overlay {
+  position: absolute;
+  top: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 14px 18px;
+  min-width: 260px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 24px 60px rgba(2, 6, 23, 0.6);
+  backdrop-filter: blur(10px);
+  pointer-events: auto;
+  z-index: 2;
+}
+
+.map-search-overlay .map-search-feedback {
+  color: rgba(226, 232, 240, 0.8);
+}
+
 .map-controls {
+  width: 100%;
   display: flex;
   flex-direction: column;
   gap: 14px;
-  background: rgba(15, 23, 42, 0.32);
+  background: rgba(15, 23, 42, 0.3);
   border: 1px solid rgba(148, 163, 184, 0.35);
   border-radius: var(--radius);
   padding: 16px;
@@ -2621,6 +2651,88 @@ input[type="checkbox"]:checked::after {
   gap: 16px;
 }
 
+.map-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.map-menu {
+  position: absolute;
+  top: 24px;
+  left: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  pointer-events: auto;
+}
+
+.map-menu-toggle {
+  width: 48px;
+  height: 48px;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  background: rgba(15, 23, 42, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  color: #e2e8f0;
+  box-shadow: 0 20px 44px rgba(2, 6, 23, 0.55);
+  backdrop-filter: blur(10px);
+}
+
+.map-menu-toggle:hover,
+.map-menu.open .map-menu-toggle {
+  background: rgba(30, 41, 59, 0.92);
+  border-color: rgba(148, 163, 184, 0.65);
+  color: #ffffff;
+}
+
+.map-menu-icon {
+  font-size: 20px;
+  line-height: 1;
+}
+
+.map-menu-panel {
+  width: 320px;
+  max-height: 70vh;
+  padding: 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  border-radius: 24px;
+  background: rgba(15, 23, 42, 0.88);
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  box-shadow: 0 32px 80px rgba(2, 6, 23, 0.7);
+  backdrop-filter: blur(18px);
+  opacity: 0;
+  transform: translateY(12px);
+  pointer-events: none;
+  transition: opacity 0.25s ease, transform 0.25s ease;
+  overflow-y: auto;
+}
+
+.map-menu.open .map-menu-panel {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.map-menu-close {
+  align-self: flex-end;
+  padding: 0;
+  background: none;
+  border: none;
+  color: rgba(226, 232, 240, 0.72);
+  font-size: 13px;
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+
+.map-menu-close:hover {
+  color: rgba(255, 255, 255, 0.92);
+}
+
 .map-stage {
   flex: 1;
   min-height: 0;
@@ -2628,11 +2740,11 @@ input[type="checkbox"]:checked::after {
 }
 
 .map-palette {
-  width: 260px;
+  width: 100%;
   display: flex;
   flex-direction: column;
   gap: 12px;
-  background: rgba(15, 23, 42, 0.26);
+  background: rgba(15, 23, 42, 0.28);
   border: 1px solid rgba(148, 163, 184, 0.32);
   border-radius: var(--radius);
   padding: 14px;


### PR DESCRIPTION
## Summary
- replace the map header/controls layout with a floating overlay menu that reveals tabs, filters, and manual mode options on hover or focus
- add a translucent floating search bar atop the concept map and tweak styling for a full-screen canvas look
- refine manual mode logic so toggling it resets filters and linked concepts for a cleaner experience

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc8d2bea908322a5c35b9fc5e8002d