### PR TITLE
Redesign concept map controls and per-tab layouts

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -1,4 +1,4 @@
-(() => {
+var Sevenn = (() => {
   // js/state.js
   var state = {
     tab: "Diseases",
@@ -668,6 +668,8 @@
         includeLinked: true,
         manualMode: false,
         manualIds: [],
+        layout: {},
+        layoutSeeded: true,
         filter: { blockId: "", week: "", lectureKey: "" }
       }
     ]
@@ -6061,6 +6063,13 @@
       23
     )
   };
+  var ICONS = {
+    sliders: '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 7h12" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" /><path d="M6 12h8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" /><path d="M6 17h14" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" /><circle cx="16" cy="7" r="2.5" stroke="currentColor" stroke-width="1.6" /><circle cx="11" cy="12" r="2.5" stroke="currentColor" stroke-width="1.6" /><circle cx="19" cy="17" r="2.5" stroke="currentColor" stroke-width="1.6" /></svg>',
+    close: '<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M5 5l10 10M15 5L5 15" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" /></svg>',
+    plus: '<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M10 4v12M4 10h12" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" /></svg>',
+    gear: '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M12 8.5a3.5 3.5 0 1 0 0 7 3.5 3.5 0 0 0 0-7z" stroke="currentColor" stroke-width="1.6" /><path d="M4.5 12.5l1.8.52c.26.08.46.28.54.54l.52 1.8a.9.9 0 0 0 1.47.41l1.43-1.08a.9.9 0 0 1 .99-.07l1.63.82a.9.9 0 0 0 1.22-.41l.73-1.66a.9.9 0 0 1 .73-.52l1.88-.2a.9.9 0 0 0 .78-1.07l-.39-1.85a.9.9 0 0 1 .25-.83l1.29-1.29a.9.9 0 0 0-.01-1.27l-1.29-1.29a.9.9 0 0 0-.83-.25l-1.85.39a.9.9 0 0 1-1.07-.78l-.2-1.88A.9.9 0 0 0 13.3 2h-2.6a.9.9 0 0 0-.9.78l-.2 1.88a.9.9 0 0 1-1.07.78l-1.85-.39a.9.9 0 0 0-.83.25L4.56 6.59a.9.9 0 0 0-.01 1.27l1.29 1.29c.22.22.31.54.25.83l-.39 1.85a.9.9 0 0 0 .7 1.07z" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" /></svg>',
+    trash: '<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M5 6.5h10" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" /><path d="M8.5 6.5V5.2A1.2 1.2 0 0 1 9.7 4h0.6a1.2 1.2 0 0 1 1.2 1.2v1.3" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" /><path d="M7.2 9v5.4a1.2 1.2 0 0 0 1.2 1.2h3.2a1.2 1.2 0 0 0 1.2-1.2V9" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" /></svg>'
+  };
   var DEFAULT_LINK_COLOR = "#888888";
   var DEFAULT_LINE_STYLE = "solid";
   var DEFAULT_LINE_THICKNESS = "regular";
@@ -6140,12 +6149,24 @@
   };
   function normalizeMapTab(tab = {}) {
     const filter = tab.filter && typeof tab.filter === "object" ? tab.filter : {};
+    const layout = {};
+    if (tab.layout && typeof tab.layout === "object") {
+      Object.entries(tab.layout).forEach(([id, pos]) => {
+        if (!id || !pos || typeof pos !== "object") return;
+        const x = Number(pos.x);
+        const y = Number(pos.y);
+        if (!Number.isFinite(x) || !Number.isFinite(y)) return;
+        layout[id] = { x, y };
+      });
+    }
     const normalized2 = {
       id: tab.id || uid(),
       name: tab.name || "Untitled map",
       includeLinked: tab.includeLinked !== false,
       manualMode: Boolean(tab.manualMode),
       manualIds: Array.isArray(tab.manualIds) ? Array.from(new Set(tab.manualIds.filter(Boolean))) : [],
+      layout,
+      layoutSeeded: tab.layoutSeeded === true,
       filter: {
         blockId: filter.blockId || "",
         week: Number.isFinite(filter.week) ? filter.week : typeof filter.week === "string" && filter.week.trim() ? Number(filter.week) : "",
@@ -6159,7 +6180,7 @@
   }
   function normalizeMapConfig(config = null) {
     const base = config && typeof config === "object" ? { ...config } : {};
-    const tabs2 = Array.isArray(base.tabs) ? base.tabs.map(normalizeMapTab) : [normalizeMapTab({ id: "default", name: "All concepts", includeLinked: true })];
+    const tabs2 = Array.isArray(base.tabs) ? base.tabs.map(normalizeMapTab) : [normalizeMapTab({ id: "default", name: "All concepts", includeLinked: true, layoutSeeded: true })];
     const ids = /* @__PURE__ */ new Set();
     const deduped = [];
     tabs2.forEach((tab) => {
@@ -6177,6 +6198,13 @@
       activeTabId: active.id,
       tabs: deduped
     };
+  }
+  function ensureTabLayout(tab) {
+    if (!tab) return {};
+    if (!tab.layout || typeof tab.layout !== "object") {
+      tab.layout = {};
+    }
+    return tab.layout;
   }
   async function ensureMapConfig() {
     if (mapState.mapConfigLoaded && mapState.mapConfig) {
@@ -6225,6 +6253,7 @@
       includeLinked: true,
       manualMode: false,
       manualIds: [],
+      layoutSeeded: true,
       filter: { blockId: "", week: "", lectureKey: "" }
     });
     config.tabs.push(tab);
@@ -6305,17 +6334,18 @@
     actions.className = "map-tab-actions";
     const addBtn = document.createElement("button");
     addBtn.type = "button";
-    addBtn.className = "map-tab-add";
+    addBtn.className = "map-icon-btn map-tab-add";
     addBtn.setAttribute("aria-label", "Create new map tab");
-    addBtn.textContent = "+";
+    addBtn.innerHTML = `${ICONS.plus}`;
     addBtn.addEventListener("click", () => {
       createMapTab();
     });
     actions.appendChild(addBtn);
     const settingsBtn = document.createElement("button");
     settingsBtn.type = "button";
-    settingsBtn.className = "map-tab-settings";
-    settingsBtn.textContent = "Settings";
+    settingsBtn.className = "map-icon-btn map-tab-settings";
+    settingsBtn.setAttribute("aria-label", "Open settings");
+    settingsBtn.innerHTML = `${ICONS.gear}`;
     settingsBtn.addEventListener("click", () => {
       const headerSettings = document.querySelector(".header-settings-btn");
       if (headerSettings) {
@@ -6387,8 +6417,9 @@
     titleRow.appendChild(nameLabel);
     const deleteBtn = document.createElement("button");
     deleteBtn.type = "button";
-    deleteBtn.className = "btn danger map-delete-tab";
-    deleteBtn.textContent = "Delete map";
+    deleteBtn.className = "map-icon-btn danger map-delete-tab";
+    deleteBtn.setAttribute("aria-label", "Delete map");
+    deleteBtn.innerHTML = `${ICONS.trash}<span class="sr-only">Delete map</span>`;
     if ((mapState.mapConfig?.tabs || []).length <= 1) {
       deleteBtn.disabled = true;
     }
@@ -6856,16 +6887,17 @@
     toggle.setAttribute("aria-haspopup", "true");
     toggle.setAttribute("aria-expanded", "false");
     toggle.setAttribute("aria-label", "Open map controls");
-    toggle.innerHTML = '<span class="map-menu-icon">\u2630</span>';
+    toggle.innerHTML = `<span class="map-menu-icon" aria-hidden="true">${ICONS.sliders}</span><span class="sr-only">Open map controls</span>`;
     menu.appendChild(toggle);
     const panel = document.createElement("div");
     panel.className = "map-menu-panel";
+    panel.setAttribute("aria-label", "Map controls");
     menu.appendChild(panel);
     const closeBtn = document.createElement("button");
     closeBtn.type = "button";
     closeBtn.className = "map-menu-close";
-    closeBtn.textContent = "Close menu";
     closeBtn.setAttribute("aria-label", "Hide map controls");
+    closeBtn.innerHTML = `<span class="sr-only">Hide map controls</span>${ICONS.close}`;
     panel.appendChild(closeBtn);
     const tabsPanel = createMapTabsPanel(activeTab);
     panel.appendChild(tabsPanel);
@@ -6884,28 +6916,24 @@
       toggle.setAttribute("aria-expanded", open ? "true" : "false");
       toggle.setAttribute("aria-label", open ? "Hide map controls" : "Open map controls");
     }
+    const openMenu = () => setMenuOpen(true);
+    const closeMenu = () => setMenuOpen(false);
     toggle.addEventListener("click", (evt) => {
       evt.preventDefault();
       const next = !menu.classList.contains("open");
       setMenuOpen(next);
     });
-    menu.addEventListener("mouseenter", () => {
-      setMenuOpen(true);
-    });
-    menu.addEventListener("mouseleave", () => {
-      setMenuOpen(false);
-    });
-    menu.addEventListener("focusin", () => {
-      setMenuOpen(true);
-    });
+    toggle.addEventListener("mouseenter", openMenu);
+    panel.addEventListener("mouseenter", openMenu);
+    toggle.addEventListener("focusin", openMenu);
+    panel.addEventListener("focusin", openMenu);
+    menu.addEventListener("mouseleave", closeMenu);
     menu.addEventListener("focusout", (evt) => {
       if (!menu.contains(evt.relatedTarget)) {
-        setMenuOpen(false);
+        closeMenu();
       }
     });
-    closeBtn.addEventListener("click", () => {
-      setMenuOpen(false);
-    });
+    closeBtn.addEventListener("click", closeMenu);
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     svg.classList.add("map-svg");
     const defaultView = {
@@ -6967,9 +6995,28 @@
     const maxRadius = 60;
     const center = size / 2;
     const newItems = [];
+    const layout = activeTab ? ensureTabLayout(activeTab) : null;
+    const allowLegacyPositions = Boolean(activeTab && activeTab.layoutSeeded !== true);
+    let layoutDirty = false;
+    let legacyImported = false;
     visibleItems.forEach((it) => {
-      if (it.mapPos) positions[it.id] = { ...it.mapPos };
-      else newItems.push(it);
+      if (layout && layout[it.id]) {
+        positions[it.id] = { ...layout[it.id] };
+        return;
+      }
+      const legacy = it.mapPos;
+      if (allowLegacyPositions && legacy && typeof legacy === "object" && Number.isFinite(Number(legacy.x)) && Number.isFinite(Number(legacy.y))) {
+        const x = Number(legacy.x);
+        const y = Number(legacy.y);
+        positions[it.id] = { x, y };
+        if (layout) {
+          layout[it.id] = { x, y };
+          layoutDirty = true;
+          legacyImported = true;
+        }
+        return;
+      }
+      newItems.push(it);
     });
     newItems.sort((a, b) => (linkCounts[b.id] || 0) - (linkCounts[a.id] || 0));
     const step = 2 * Math.PI / Math.max(newItems.length, 1);
@@ -6980,9 +7027,18 @@
       const x = center + dist * Math.cos(angle);
       const y = center + dist * Math.sin(angle);
       positions[it.id] = { x, y };
-      it.mapPos = positions[it.id];
+      if (layout) {
+        layout[it.id] = { x, y };
+        layoutDirty = true;
+      }
     });
-    for (const it of newItems) await upsertItem(it);
+    if (activeTab && legacyImported && activeTab.layoutSeeded !== true) {
+      activeTab.layoutSeeded = true;
+      layoutDirty = true;
+    }
+    if (layoutDirty) {
+      await persistMapConfig();
+    }
     mapState.selectionIds = mapState.selectionIds.filter((id) => positions[id]);
     const hiddenLinks = gatherHiddenLinks(items, itemMap);
     buildToolbox(container, hiddenNodes.length, hiddenLinks.length);
@@ -7328,7 +7384,10 @@
       mapState.areaDrag = null;
       cursorNeedsRefresh = true;
       if (moved) {
-        await Promise.all(ids.map((id) => persistNodePosition(id)));
+        for (const id of ids) {
+          await persistNodePosition(id, { persist: false });
+        }
+        await persistMapConfig();
         mapState.suppressNextClick = true;
       } else {
         mapState.suppressNextClick = false;
@@ -7730,25 +7789,42 @@
     const item = await getItem(drag.id);
     if (!item) return;
     if (drag.source === "palette") {
-      const tab = getActiveTab();
-      if (!tab || !tab.manualMode) return;
-      if (drag.tabId && tab.id !== drag.tabId) return;
-      if (!Array.isArray(tab.manualIds)) {
-        tab.manualIds = [];
+      const tab2 = getActiveTab();
+      if (!tab2 || !tab2.manualMode) return;
+      if (drag.tabId && tab2.id !== drag.tabId) return;
+      if (!Array.isArray(tab2.manualIds)) {
+        tab2.manualIds = [];
       }
-      if (!tab.manualIds.includes(item.id)) {
-        tab.manualIds.push(item.id);
-        await persistMapConfig();
+      let shouldPersist = false;
+      if (!tab2.manualIds.includes(item.id)) {
+        tab2.manualIds.push(item.id);
+        shouldPersist = true;
       }
       item.mapHidden = false;
-      item.mapPos = { x, y };
       await upsertItem(item);
+      const layout = ensureTabLayout(tab2);
+      const prev = layout[item.id];
+      layout[item.id] = { x, y };
+      if (!prev || prev.x !== x || prev.y !== y) {
+        shouldPersist = true;
+      }
+      if (shouldPersist) {
+        await persistMapConfig();
+      }
       await renderMap(mapState.root);
       return;
     }
     item.mapHidden = false;
-    item.mapPos = { x, y };
     await upsertItem(item);
+    const tab = getActiveTab();
+    if (tab) {
+      const layout = ensureTabLayout(tab);
+      const prev = layout[item.id];
+      layout[item.id] = { x, y };
+      if (!prev || prev.x !== x || prev.y !== y) {
+        await persistMapConfig();
+      }
+    }
     await renderMap(mapState.root);
   }
   function updateMenuDragPosition(clientX, clientY) {
@@ -7862,12 +7938,16 @@
     mapState.cursorOverride = null;
     refreshCursor();
   }
-  async function persistNodePosition(id) {
-    const item = mapState.itemMap[id];
-    if (!item) return;
-    const next = { ...item, mapPos: { ...mapState.positions[id] } };
-    mapState.itemMap[id] = next;
-    await upsertItem(next);
+  async function persistNodePosition(id, options = {}) {
+    const tab = getActiveTab();
+    if (!tab) return;
+    const pos = mapState.positions[id];
+    if (!pos) return;
+    const layout = ensureTabLayout(tab);
+    layout[id] = { x: pos.x, y: pos.y };
+    if (options.persist !== false) {
+      await persistMapConfig();
+    }
   }
   function gatherHiddenLinks(items, itemMap) {
     const hidden = [];

--- a/js/storage/storage.js
+++ b/js/storage/storage.js
@@ -16,6 +16,8 @@ const DEFAULT_MAP_CONFIG = {
       includeLinked: true,
       manualMode: false,
       manualIds: [],
+      layout: {},
+      layoutSeeded: true,
       filter: { blockId: '', week: '', lectureKey: '' }
     }
   ]

--- a/style.css
+++ b/style.css
@@ -2452,61 +2452,111 @@ input[type="checkbox"]:checked::after {
 .map-tabs {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 14px;
 }
 
 .map-tabs-heading {
-  font-size: 13px;
-  letter-spacing: 0.08em;
+  font-size: 12px;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: rgba(226, 232, 240, 0.72);
+  color: rgba(226, 232, 240, 0.58);
+  font-weight: 600;
 }
 
 .map-tab-list {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
 }
 
 .map-tab {
   text-align: left;
-  padding: 8px 14px;
-  border-radius: var(--radius);
-  background: rgba(148, 163, 184, 0.12);
+  padding: 10px 18px;
+  border-radius: 18px;
+  background: linear-gradient(150deg, rgba(148, 163, 184, 0.14) 0%, rgba(148, 163, 184, 0.08) 100%);
   border: 1px solid rgba(148, 163, 184, 0.28);
-  color: var(--text);
-  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  color: rgba(226, 232, 240, 0.85);
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  transition: transform 0.18s ease, background 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease, color 0.18s ease;
 }
 
-.map-tab:hover {
-  background: rgba(148, 163, 184, 0.24);
-  border-color: rgba(203, 213, 225, 0.42);
+.map-tab:hover,
+.map-tab:focus-visible {
+  background: linear-gradient(150deg, rgba(148, 163, 184, 0.22) 0%, rgba(148, 163, 184, 0.12) 100%);
+  border-color: rgba(203, 213, 225, 0.45);
+  color: #f8fafc;
+  transform: translateX(-2px);
+  box-shadow: 0 14px 32px rgba(2, 6, 23, 0.35);
+}
+
+.map-tab:focus-visible {
+  outline: 2px solid rgba(56, 189, 248, 0.45);
+  outline-offset: 2px;
 }
 
 .map-tab.active {
-  background: rgba(148, 163, 184, 0.26);
+  background: linear-gradient(160deg, rgba(56, 189, 248, 0.24) 0%, rgba(56, 189, 248, 0.12) 100%);
+  border-color: rgba(56, 189, 248, 0.45);
   color: #f8fafc;
-  border-color: rgba(148, 163, 184, 0.45);
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.45);
+  box-shadow: 0 18px 40px rgba(56, 189, 248, 0.28);
+  transform: translateX(-2px);
 }
 
 .map-tab-actions {
   display: flex;
-  gap: 8px;
+  gap: 12px;
 }
 
-.map-tab-add,
-.map-tab-settings {
-  padding: 8px 12px;
-  border-radius: var(--radius-sm);
-  background: rgba(148, 163, 184, 0.14);
-  border: 1px solid rgba(148, 163, 184, 0.28);
+.map-icon-btn {
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  background: rgba(15, 23, 42, 0.65);
+  color: rgba(226, 232, 240, 0.82);
+  transition: transform 0.18s ease, background 0.18s ease, border-color 0.18s ease, color 0.18s ease;
+  backdrop-filter: blur(12px);
 }
 
-.map-tab-add:hover,
-.map-tab-settings:hover {
-  background: rgba(148, 163, 184, 0.24);
-  border-color: rgba(203, 213, 225, 0.42);
+.map-icon-btn svg {
+  width: 18px;
+  height: 18px;
+}
+
+.map-icon-btn:hover,
+.map-icon-btn:focus-visible {
+  transform: translateY(-1px);
+  background: rgba(30, 41, 59, 0.92);
+  border-color: rgba(148, 163, 184, 0.55);
+  color: #ffffff;
+}
+
+.map-icon-btn:focus-visible {
+  outline: 2px solid rgba(56, 189, 248, 0.5);
+  outline-offset: 2px;
+}
+
+.map-icon-btn.danger {
+  color: rgba(248, 113, 113, 0.88);
+  border-color: rgba(248, 113, 113, 0.35);
+  background: rgba(127, 29, 29, 0.18);
+}
+
+.map-icon-btn.danger:hover,
+.map-icon-btn.danger:focus-visible {
+  background: rgba(248, 113, 113, 0.24);
+  border-color: rgba(248, 113, 113, 0.58);
+  color: #fecaca;
+}
+
+.map-icon-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+  background: rgba(15, 23, 42, 0.42);
 }
 
 .map-search-container {
@@ -2660,77 +2710,110 @@ input[type="checkbox"]:checked::after {
 
 .map-menu {
   position: absolute;
-  top: 24px;
-  left: 24px;
+  top: 50%;
+  right: 0;
+  transform: translateY(-50%);
   display: flex;
-  flex-direction: column;
-  gap: 12px;
+  align-items: center;
   pointer-events: auto;
+  z-index: 2;
 }
 
 .map-menu-toggle {
   width: 48px;
-  height: 48px;
-  border-radius: 999px;
-  display: grid;
-  place-items: center;
-  background: rgba(15, 23, 42, 0.78);
-  border: 1px solid rgba(148, 163, 184, 0.45);
-  color: #e2e8f0;
-  box-shadow: 0 20px 44px rgba(2, 6, 23, 0.55);
-  backdrop-filter: blur(10px);
+  height: 140px;
+  border-radius: 999px 0 0 999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.82) 0%, rgba(30, 41, 59, 0.9) 100%);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  color: rgba(226, 232, 240, 0.85);
+  box-shadow: 0 20px 44px rgba(2, 6, 23, 0.45);
+  backdrop-filter: blur(14px);
+  transition: background 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease, transform 0.3s ease, color 0.3s ease;
 }
 
 .map-menu-toggle:hover,
+.map-menu-toggle:focus-visible,
 .map-menu.open .map-menu-toggle {
-  background: rgba(30, 41, 59, 0.92);
-  border-color: rgba(148, 163, 184, 0.65);
+  background: linear-gradient(180deg, rgba(30, 41, 59, 0.98) 0%, rgba(15, 23, 42, 0.94) 100%);
+  border-color: rgba(148, 163, 184, 0.6);
   color: #ffffff;
+  box-shadow: 0 28px 60px rgba(2, 6, 23, 0.6);
+  transform: translateX(-4px);
+}
+
+.map-menu-toggle:focus-visible {
+  outline: 2px solid rgba(56, 189, 248, 0.6);
+  outline-offset: 2px;
 }
 
 .map-menu-icon {
-  font-size: 20px;
-  line-height: 1;
+  display: block;
+  width: 22px;
+  height: 22px;
+  color: inherit;
+}
+
+.map-menu-icon svg {
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 .map-menu-panel {
-  width: 320px;
-  max-height: 70vh;
-  padding: 22px;
+  position: absolute;
+  top: 50%;
+  right: 64px;
+  transform: translateY(-50%) translateX(24px);
+  width: 340px;
+  max-height: 78vh;
+  padding: 48px 26px 26px;
   display: flex;
   flex-direction: column;
-  gap: 20px;
-  border-radius: 24px;
-  background: rgba(15, 23, 42, 0.88);
-  border: 1px solid rgba(148, 163, 184, 0.45);
-  box-shadow: 0 32px 80px rgba(2, 6, 23, 0.7);
-  backdrop-filter: blur(18px);
+  gap: 24px;
+  border-radius: 28px;
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.94) 0%, rgba(30, 41, 59, 0.95) 100%);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  box-shadow: 0 40px 120px rgba(2, 6, 23, 0.72);
+  backdrop-filter: blur(22px);
   opacity: 0;
-  transform: translateY(12px);
   pointer-events: none;
-  transition: opacity 0.25s ease, transform 0.25s ease;
+  transition: opacity 0.28s ease, transform 0.28s ease;
   overflow-y: auto;
 }
 
 .map-menu.open .map-menu-panel {
   opacity: 1;
-  transform: translateY(0);
   pointer-events: auto;
+  transform: translateY(-50%) translateX(0);
 }
 
 .map-menu-close {
-  align-self: flex-end;
-  padding: 0;
+  position: absolute;
+  top: 18px;
+  right: 18px;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
   background: none;
   border: none;
-  color: rgba(226, 232, 240, 0.72);
-  font-size: 13px;
-  text-decoration: underline;
-  text-underline-offset: 4px;
+  color: rgba(226, 232, 240, 0.7);
+  transition: color 0.2s ease, background 0.2s ease;
 }
 
-.map-menu-close:hover {
-  color: rgba(255, 255, 255, 0.92);
+.map-menu-close:hover,
+.map-menu-close:focus-visible {
+  color: #ffffff;
+  background: rgba(148, 163, 184, 0.2);
+}
+
+.map-menu-close svg {
+  width: 16px;
+  height: 16px;
 }
 
 .map-stage {


### PR DESCRIPTION
## Summary
- restyle the concept map controls into a right-hand flyout with icon-based actions
- update concept map tab buttons and delete action to use compact icon treatments
- persist node positions per map tab so layouts are independent and seed defaults for new configs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc96c025648322831e06d24cdd5f87