### PR TITLE
Revamp cards tab layout and styling

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -3230,162 +3230,389 @@ var Sevenn = (() => {
   }
 
   // js/ui/components/cards.js
-  function renderCards(container, items, onChange) {
+  var UNASSIGNED_BLOCK_KEY = "__unassigned__";
+  var MISC_LECTURE_KEY = "__misc__";
+  function formatWeekLabel(value) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return `Week ${value}`;
+    }
+    return "Unscheduled";
+  }
+  function titleFromItem(item) {
+    return item?.name || item?.concept || "Untitled Card";
+  }
+  async function renderCards(container, items, onChange) {
     container.innerHTML = "";
-    const decks = /* @__PURE__ */ new Map();
-    items.forEach((it) => {
-      if (it.lectures && it.lectures.length) {
-        it.lectures.forEach((l) => {
-          const key = l.name || `Lecture ${l.id}`;
-          if (!decks.has(key)) decks.set(key, []);
-          decks.get(key).push(it);
+    container.classList.add("cards-tab");
+    const blockDefs = await listBlocks();
+    const blockLookup = new Map(blockDefs.map((def) => [def.blockId, def]));
+    const blockOrder = new Map(blockDefs.map((def, idx) => [def.blockId, idx]));
+    const blockBuckets = /* @__PURE__ */ new Map();
+    function ensureBlock(blockId) {
+      const key = blockId || UNASSIGNED_BLOCK_KEY;
+      if (!blockBuckets.has(key)) {
+        const def = blockLookup.get(blockId);
+        const order = typeof blockId === "string" ? blockOrder.get(blockId) ?? 999 : 1200;
+        blockBuckets.set(key, {
+          key,
+          blockId: blockId || null,
+          title: def?.title || (blockId ? blockId : "Unassigned"),
+          accent: def?.color || null,
+          order,
+          weeks: /* @__PURE__ */ new Map()
         });
-      } else {
-        if (!decks.has("Unassigned")) decks.set("Unassigned", []);
-        decks.get("Unassigned").push(it);
       }
-    });
-    const list = document.createElement("div");
-    list.className = "deck-list";
-    container.appendChild(list);
-    const viewer = document.createElement("div");
-    viewer.className = "deck-viewer hidden";
-    container.appendChild(viewer);
-    decks.forEach((cards, lecture) => {
-      const deck = document.createElement("div");
-      deck.className = "deck";
-      const title = document.createElement("div");
-      title.className = "deck-title";
-      title.textContent = lecture;
-      const meta = document.createElement("div");
-      meta.className = "deck-meta";
-      const blocks = Array.from(new Set(cards.flatMap((c) => c.blocks || []))).join(", ");
-      const weeks = Array.from(new Set(cards.flatMap((c) => c.weeks || []))).join(", ");
-      meta.textContent = `${blocks}${blocks && weeks ? " \u2022 " : ""}${weeks ? "Week " + weeks : ""}`;
-      deck.appendChild(title);
-      deck.appendChild(meta);
-      deck.addEventListener("click", () => {
-        stopPreview(deck);
-        openDeck(lecture, cards);
-      });
-      let hoverTimer;
-      deck.addEventListener("mouseenter", () => {
-        hoverTimer = setTimeout(() => startPreview(deck, cards), 3e3);
-      });
-      deck.addEventListener("mouseleave", () => {
-        clearTimeout(hoverTimer);
-        stopPreview(deck);
-      });
-      list.appendChild(deck);
-    });
-    function startPreview(deckEl, cards) {
-      if (deckEl._preview) return;
-      deckEl.classList.add("pop");
-      const fan = document.createElement("div");
-      fan.className = "deck-fan";
-      deckEl.appendChild(fan);
-      const show = cards.slice(0, 5);
-      const spread = 20;
-      const offset = (show.length - 1) * spread / 2;
-      show.forEach((c, i) => {
-        const mini = document.createElement("div");
-        mini.className = "fan-card";
-        mini.textContent = c.name || c.concept || "";
-        fan.appendChild(mini);
-        const angle = -offset + i * spread;
-        mini.style.transform = `rotate(${angle}deg) translateY(-80px)`;
-        setTimeout(() => {
-          mini.style.opacity = 1;
-        }, i * 100);
-      });
-      deckEl._preview = { fan };
+      return blockBuckets.get(key);
     }
-    function stopPreview(deckEl) {
-      const prev = deckEl._preview;
-      if (prev) {
-        prev.fan.remove();
-        deckEl.classList.remove("pop");
-        deckEl._preview = null;
+    function ensureWeek(blockBucket, weekValue) {
+      const weekKey = weekValue == null ? "none" : String(weekValue);
+      if (!blockBucket.weeks.has(weekKey)) {
+        blockBucket.weeks.set(weekKey, {
+          key: weekKey,
+          value: typeof weekValue === "number" && Number.isFinite(weekValue) ? weekValue : null,
+          label: formatWeekLabel(weekValue),
+          order: typeof weekValue === "number" && Number.isFinite(weekValue) ? weekValue : 999,
+          lectures: /* @__PURE__ */ new Map()
+        });
       }
+      return blockBucket.weeks.get(weekKey);
     }
-    function openDeck(title, cards) {
-      list.classList.add("hidden");
-      viewer.classList.remove("hidden");
-      viewer.innerHTML = "";
-      const header = document.createElement("h2");
-      header.textContent = title;
-      viewer.appendChild(header);
-      const cardHolder = document.createElement("div");
-      cardHolder.className = "deck-card";
-      viewer.appendChild(cardHolder);
-      const prev = document.createElement("button");
-      prev.className = "deck-prev";
-      prev.textContent = "\u25C0";
-      const next = document.createElement("button");
-      next.className = "deck-next";
-      next.textContent = "\u25B6";
-      viewer.appendChild(prev);
-      viewer.appendChild(next);
-      const toggle = document.createElement("button");
-      toggle.className = "deck-related-toggle btn";
-      toggle.textContent = "Show Related";
-      viewer.appendChild(toggle);
-      const relatedWrap = document.createElement("div");
-      relatedWrap.className = "deck-related hidden";
-      viewer.appendChild(relatedWrap);
-      const close = document.createElement("button");
-      close.className = "deck-close btn";
-      close.textContent = "Close";
-      viewer.appendChild(close);
-      let idx = 0;
-      let showRelated = false;
-      function renderCard() {
-        cardHolder.innerHTML = "";
-        cardHolder.appendChild(createItemCard(cards[idx], onChange));
-        renderRelated();
+    function ensureLecture(weekBucket, lectureKey, lectureName) {
+      if (!weekBucket.lectures.has(lectureKey)) {
+        weekBucket.lectures.set(lectureKey, {
+          key: lectureKey,
+          title: lectureName || "Lecture",
+          cards: []
+        });
       }
-      function renderRelated() {
-        relatedWrap.innerHTML = "";
-        if (!showRelated) return;
-        const current = cards[idx];
-        (current.links || []).forEach((l) => {
-          const item = items.find((it) => it.id === l.id);
-          if (item) {
-            const el = createItemCard(item, onChange);
-            el.classList.add("related-card");
-            relatedWrap.appendChild(el);
-            requestAnimationFrame(() => el.classList.add("visible"));
+      return weekBucket.lectures.get(lectureKey);
+    }
+    items.forEach((item) => {
+      const lectureRefs = Array.isArray(item.lectures) ? item.lectures : [];
+      if (lectureRefs.length) {
+        lectureRefs.forEach((ref) => {
+          const blockBucket = ensureBlock(ref.blockId);
+          const weekBucket = ensureWeek(blockBucket, ref.week);
+          const lectureKeyParts = [ref.blockId || blockBucket.key];
+          if (ref.id != null) lectureKeyParts.push(`lec-${ref.id}`);
+          if (ref.name) lectureKeyParts.push(ref.name);
+          const lectureKey = lectureKeyParts.join("::") || `${blockBucket.key}-${titleFromItem(item)}`;
+          const lecture = ensureLecture(weekBucket, lectureKey, ref.name || (ref.id != null ? `Lecture ${ref.id}` : "Lecture"));
+          if (!lecture.cards.includes(item)) {
+            lecture.cards.push(item);
           }
         });
+      } else if (Array.isArray(item.blocks) && item.blocks.length) {
+        item.blocks.forEach((blockId) => {
+          const blockBucket = ensureBlock(blockId);
+          const weeks = Array.isArray(item.weeks) && item.weeks.length ? item.weeks : [null];
+          weeks.forEach((weekVal) => {
+            const weekBucket = ensureWeek(blockBucket, weekVal);
+            const lecture = ensureLecture(weekBucket, `${blockBucket.key}::${MISC_LECTURE_KEY}`, "Ungrouped Items");
+            lecture.cards.push(item);
+          });
+        });
+      } else {
+        const blockBucket = ensureBlock(null);
+        const weekBucket = ensureWeek(blockBucket, null);
+        const lecture = ensureLecture(weekBucket, `${blockBucket.key}::${MISC_LECTURE_KEY}`, "Unassigned Items");
+        lecture.cards.push(item);
+      }
+    });
+    const blockSections = Array.from(blockBuckets.values()).map((block) => {
+      const weeks = Array.from(block.weeks.values()).map((week) => {
+        const lectures = Array.from(week.lectures.values()).map((lec) => ({
+          ...lec,
+          cards: lec.cards.slice().sort((a, b) => titleFromItem(a).localeCompare(titleFromItem(b)))
+        })).filter((lec) => lec.cards.length > 0).sort((a, b) => a.title.localeCompare(b.title));
+        const totalCards2 = lectures.reduce((sum, lec) => sum + lec.cards.length, 0);
+        return {
+          ...week,
+          lectures,
+          totalCards: totalCards2,
+          lectureCount: lectures.length
+        };
+      }).filter((week) => week.totalCards > 0).sort((a, b) => a.order - b.order || a.label.localeCompare(b.label));
+      const totalCards = weeks.reduce((sum, week) => sum + week.totalCards, 0);
+      const lectureCount = weeks.reduce((sum, week) => sum + week.lectureCount, 0);
+      return {
+        ...block,
+        weeks,
+        totalCards,
+        lectureCount
+      };
+    }).filter((block) => block.totalCards > 0).sort((a, b) => a.order - b.order || a.title.localeCompare(b.title));
+    const catalog = document.createElement("div");
+    catalog.className = "card-catalog";
+    container.appendChild(catalog);
+    const overlay = document.createElement("div");
+    overlay.className = "deck-overlay";
+    overlay.dataset.active = "false";
+    overlay.setAttribute("role", "dialog");
+    overlay.setAttribute("aria-modal", "true");
+    const viewer = document.createElement("div");
+    viewer.className = "deck-viewer";
+    overlay.appendChild(viewer);
+    container.appendChild(overlay);
+    let activeKeyHandler = null;
+    function closeDeck() {
+      overlay.dataset.active = "false";
+      viewer.innerHTML = "";
+      if (activeKeyHandler) {
+        document.removeEventListener("keydown", activeKeyHandler);
+        activeKeyHandler = null;
+      }
+    }
+    overlay.addEventListener("click", (evt) => {
+      if (evt.target === overlay) closeDeck();
+    });
+    function openDeck(context) {
+      const { block, week, lecture } = context;
+      overlay.dataset.active = "true";
+      viewer.innerHTML = "";
+      const header = document.createElement("div");
+      header.className = "deck-viewer-header";
+      const crumb = document.createElement("div");
+      crumb.className = "deck-viewer-crumb";
+      const crumbPieces = [];
+      if (block.title) crumbPieces.push(block.title);
+      if (week?.label) crumbPieces.push(week.label);
+      crumb.textContent = crumbPieces.join(" \u2022 ");
+      header.appendChild(crumb);
+      const title = document.createElement("h2");
+      title.className = "deck-viewer-title";
+      title.textContent = lecture.title;
+      header.appendChild(title);
+      const counter = document.createElement("div");
+      counter.className = "deck-counter";
+      header.appendChild(counter);
+      const closeBtn = document.createElement("button");
+      closeBtn.type = "button";
+      closeBtn.className = "deck-close";
+      closeBtn.innerHTML = '<span aria-hidden="true">\xD7</span><span class="sr-only">Close deck</span>';
+      closeBtn.addEventListener("click", closeDeck);
+      header.appendChild(closeBtn);
+      viewer.appendChild(header);
+      const stage = document.createElement("div");
+      stage.className = "deck-stage";
+      const prev = document.createElement("button");
+      prev.type = "button";
+      prev.className = "deck-nav deck-prev";
+      prev.innerHTML = '<span class="sr-only">Previous card</span><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M12.5 15L7.5 10L12.5 5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+      const cardHolder = document.createElement("div");
+      cardHolder.className = "deck-card-stage";
+      const next = document.createElement("button");
+      next.type = "button";
+      next.className = "deck-nav deck-next";
+      next.innerHTML = '<span class="sr-only">Next card</span><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M7.5 5L12.5 10L7.5 15" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+      stage.appendChild(prev);
+      stage.appendChild(cardHolder);
+      stage.appendChild(next);
+      viewer.appendChild(stage);
+      const toolbar = document.createElement("div");
+      toolbar.className = "deck-toolbar";
+      const toggle = document.createElement("button");
+      toggle.type = "button";
+      toggle.className = "deck-related-toggle";
+      toggle.dataset.active = "false";
+      toggle.textContent = "Show related cards";
+      toolbar.appendChild(toggle);
+      viewer.appendChild(toolbar);
+      const relatedWrap = document.createElement("div");
+      relatedWrap.className = "deck-related";
+      relatedWrap.dataset.visible = "false";
+      viewer.appendChild(relatedWrap);
+      let idx = 0;
+      let showRelated = false;
+      function renderRelated() {
+        relatedWrap.innerHTML = "";
+        if (!showRelated) {
+          relatedWrap.dataset.visible = "false";
+          return;
+        }
+        const current = lecture.cards[idx];
+        (current.links || []).forEach((link) => {
+          const related = items.find((it) => it.id === link.id);
+          if (related) {
+            const card = createItemCard(related, onChange);
+            card.classList.add("related-card");
+            relatedWrap.appendChild(card);
+          }
+        });
+        relatedWrap.dataset.visible = relatedWrap.children.length ? "true" : "false";
+      }
+      function renderCard() {
+        cardHolder.innerHTML = "";
+        const card = createItemCard(lecture.cards[idx], onChange);
+        cardHolder.appendChild(card);
+        counter.textContent = `Card ${idx + 1} of ${lecture.cards.length}`;
+        renderRelated();
       }
       prev.addEventListener("click", () => {
-        idx = (idx - 1 + cards.length) % cards.length;
+        idx = (idx - 1 + lecture.cards.length) % lecture.cards.length;
         renderCard();
       });
       next.addEventListener("click", () => {
-        idx = (idx + 1) % cards.length;
+        idx = (idx + 1) % lecture.cards.length;
         renderCard();
       });
       toggle.addEventListener("click", () => {
         showRelated = !showRelated;
-        toggle.textContent = showRelated ? "Hide Related" : "Show Related";
-        relatedWrap.classList.toggle("hidden", !showRelated);
+        toggle.dataset.active = showRelated ? "true" : "false";
+        toggle.textContent = showRelated ? "Hide related cards" : "Show related cards";
         renderRelated();
       });
-      close.addEventListener("click", () => {
-        document.removeEventListener("keydown", keyHandler2);
-        viewer.classList.add("hidden");
-        viewer.innerHTML = "";
-        list.classList.remove("hidden");
-      });
-      function keyHandler2(e) {
-        if (e.key === "ArrowLeft") prev.click();
-        if (e.key === "ArrowRight") next.click();
-        if (e.key === "Escape") close.click();
-      }
+      const keyHandler2 = (event) => {
+        if (event.key === "ArrowLeft") {
+          event.preventDefault();
+          prev.click();
+        } else if (event.key === "ArrowRight") {
+          event.preventDefault();
+          next.click();
+        } else if (event.key === "Escape") {
+          event.preventDefault();
+          closeDeck();
+        }
+      };
       document.addEventListener("keydown", keyHandler2);
+      activeKeyHandler = keyHandler2;
       renderCard();
+      requestAnimationFrame(() => closeBtn.focus());
     }
+    function createCollapseIcon() {
+      const icon = document.createElement("span");
+      icon.className = "card-collapse-icon";
+      icon.innerHTML = '<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 8L10 12L14 8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+      return icon;
+    }
+    function createDeckTile(block, week, lecture) {
+      const tile = document.createElement("button");
+      tile.type = "button";
+      tile.className = "deck-tile";
+      tile.setAttribute("aria-label", `${lecture.title} (${lecture.cards.length} cards)`);
+      const stack = document.createElement("div");
+      stack.className = "deck-stack";
+      const preview = lecture.cards.slice(0, 5);
+      stack.style.setProperty("--spread", preview.length > 0 ? (preview.length - 1) / 2 : 0);
+      if (!preview.length) {
+        const placeholder = document.createElement("div");
+        placeholder.className = "stack-card stack-card-empty";
+        placeholder.style.setProperty("--index", "0");
+        placeholder.textContent = "No cards yet";
+        stack.appendChild(placeholder);
+      } else {
+        preview.forEach((card, idx) => {
+          const mini = document.createElement("div");
+          mini.className = "stack-card";
+          mini.style.setProperty("--index", String(idx));
+          mini.textContent = titleFromItem(card);
+          stack.appendChild(mini);
+        });
+      }
+      tile.appendChild(stack);
+      const info = document.createElement("div");
+      info.className = "deck-info";
+      const count = document.createElement("span");
+      count.className = "deck-count-pill";
+      count.textContent = `${lecture.cards.length} card${lecture.cards.length === 1 ? "" : "s"}`;
+      info.appendChild(count);
+      const label = document.createElement("h3");
+      label.className = "deck-title";
+      label.textContent = lecture.title;
+      info.appendChild(label);
+      const meta = document.createElement("div");
+      meta.className = "deck-meta";
+      const pieces = [];
+      if (block.title) pieces.push(block.title);
+      if (week?.label) pieces.push(week.label);
+      meta.textContent = pieces.join(" \u2022 ");
+      info.appendChild(meta);
+      tile.appendChild(info);
+      const open = () => openDeck({ block, week, lecture });
+      tile.addEventListener("click", open);
+      tile.addEventListener("keydown", (evt) => {
+        if (evt.key === "Enter" || evt.key === " ") {
+          evt.preventDefault();
+          open();
+        }
+      });
+      return tile;
+    }
+    if (!blockSections.length) {
+      const empty = document.createElement("div");
+      empty.className = "cards-empty";
+      const heading = document.createElement("h3");
+      heading.textContent = "No cards match your filters yet";
+      empty.appendChild(heading);
+      const body = document.createElement("p");
+      body.textContent = "Assign lectures, blocks, or create new entries to populate this view.";
+      empty.appendChild(body);
+      catalog.appendChild(empty);
+      return;
+    }
+    blockSections.forEach((block) => {
+      const section = document.createElement("section");
+      section.className = "card-block-section";
+      if (block.accent) section.style.setProperty("--block-accent", block.accent);
+      const header = document.createElement("button");
+      header.type = "button";
+      header.className = "card-block-header";
+      header.setAttribute("aria-expanded", "true");
+      const heading = document.createElement("div");
+      heading.className = "card-block-heading";
+      const swatch = document.createElement("span");
+      swatch.className = "card-block-mark";
+      heading.appendChild(swatch);
+      const title = document.createElement("span");
+      title.className = "card-block-title";
+      title.textContent = block.title;
+      heading.appendChild(title);
+      header.appendChild(heading);
+      const stats = document.createElement("span");
+      stats.className = "card-block-stats";
+      stats.textContent = `${block.lectureCount} lecture${block.lectureCount === 1 ? "" : "s"} \u2022 ${block.totalCards} card${block.totalCards === 1 ? "" : "s"}`;
+      header.appendChild(stats);
+      const icon = createCollapseIcon();
+      header.appendChild(icon);
+      section.appendChild(header);
+      const body = document.createElement("div");
+      body.className = "card-block-body";
+      block.weeks.forEach((week) => {
+        const weekSection = document.createElement("div");
+        weekSection.className = "card-week-section";
+        const weekHeader = document.createElement("button");
+        weekHeader.type = "button";
+        weekHeader.className = "card-week-header";
+        weekHeader.setAttribute("aria-expanded", "true");
+        const weekTitle = document.createElement("span");
+        weekTitle.className = "card-week-title";
+        weekTitle.textContent = week.label;
+        weekHeader.appendChild(weekTitle);
+        const weekStats = document.createElement("span");
+        weekStats.className = "card-week-stats";
+        weekStats.textContent = `${week.lectureCount} lecture${week.lectureCount === 1 ? "" : "s"} \u2022 ${week.totalCards} card${week.totalCards === 1 ? "" : "s"}`;
+        weekHeader.appendChild(weekStats);
+        weekHeader.appendChild(createCollapseIcon());
+        const deckGrid = document.createElement("div");
+        deckGrid.className = "deck-grid";
+        week.lectures.forEach((lecture) => {
+          deckGrid.appendChild(createDeckTile(block, week, lecture));
+        });
+        weekSection.appendChild(weekHeader);
+        weekSection.appendChild(deckGrid);
+        body.appendChild(weekSection);
+        weekHeader.addEventListener("click", () => {
+          const collapsed = weekSection.classList.toggle("is-collapsed");
+          weekHeader.setAttribute("aria-expanded", collapsed ? "false" : "true");
+        });
+      });
+      section.appendChild(body);
+      header.addEventListener("click", () => {
+        const collapsed = section.classList.toggle("is-collapsed");
+        header.setAttribute("aria-expanded", collapsed ? "false" : "true");
+      });
+      catalog.appendChild(section);
+    });
   }
 
   // js/ui/components/builder.js
@@ -3522,7 +3749,7 @@ var Sevenn = (() => {
       }
     });
     header.appendChild(weekCollapseBtn);
-    const label = createPill(selected, formatWeekLabel(week), () => {
+    const label = createPill(selected, formatWeekLabel2(week), () => {
       toggleWeek(block, week);
       rerender();
     }, "week");
@@ -3831,7 +4058,7 @@ var Sevenn = (() => {
   function lectureKeyFor(blockId, lectureId) {
     return `${blockId}|${lectureId}`;
   }
-  function formatWeekLabel(week) {
+  function formatWeekLabel2(week) {
     if (week == null || week < 0) return "No week";
     return `Week ${week}`;
   }
@@ -6069,7 +6296,6 @@ var Sevenn = (() => {
     plus: '<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M10 4v12M4 10h12" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" /></svg>',
     gear: '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M12 8.5a3.5 3.5 0 1 0 0 7 3.5 3.5 0 0 0 0-7z" stroke="currentColor" stroke-width="1.6" /><path d="M4.5 12.5l1.8.52c.26.08.46.28.54.54l.52 1.8a.9.9 0 0 0 1.47.41l1.43-1.08a.9.9 0 0 1 .99-.07l1.63.82a.9.9 0 0 0 1.22-.41l.73-1.66a.9.9 0 0 1 .73-.52l1.88-.2a.9.9 0 0 0 .78-1.07l-.39-1.85a.9.9 0 0 1 .25-.83l1.29-1.29a.9.9 0 0 0-.01-1.27l-1.29-1.29a.9.9 0 0 0-.83-.25l-1.85.39a.9.9 0 0 1-1.07-.78l-.2-1.88A.9.9 0 0 0 13.3 2h-2.6a.9.9 0 0 0-.9.78l-.2 1.88a.9.9 0 0 1-1.07.78l-1.85-.39a.9.9 0 0 0-.83.25L4.56 6.59a.9.9 0 0 0-.01 1.27l1.29 1.29c.22.22.31.54.25.83l-.39 1.85a.9.9 0 0 0 .7 1.07z" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" /></svg>',
     trash: '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 7h12" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" /><path d="M9 7V5a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" /><path d="M18 7v11a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V7" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" /><path d="M10 11v6M14 11v6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" /></svg>'
-
   };
   var DEFAULT_LINK_COLOR = "#888888";
   var DEFAULT_LINE_STYLE = "solid";
@@ -6928,7 +7154,6 @@ var Sevenn = (() => {
       toggle.setAttribute("aria-expanded", open ? "true" : "false");
       toggle.setAttribute("aria-pressed", mapState.menuPinned ? "true" : "false");
       toggle.setAttribute("aria-label", open ? "Hide map controls" : "Open map controls");
-
     };
     const openMenu = ({ pinned = false } = {}) => {
       if (pinned) {
@@ -8633,7 +8858,7 @@ var Sevenn = (() => {
       const filter = { ...state.filters, query: state.query };
       const query = findItemsByFilter(filter);
       const items = await query.toArray();
-      renderCards(content, items, render);
+      await renderCards(content, items, render);
     } else if (state.tab === "Study") {
       main.appendChild(createEntryAddControl(render, "disease"));
       const content = document.createElement("div");

--- a/js/main.js
+++ b/js/main.js
@@ -146,7 +146,7 @@ async function render() {
     const filter = { ...state.filters, query: state.query };
     const query = findItemsByFilter(filter);
     const items = await query.toArray();
-    renderCards(content, items, render);
+    await renderCards(content, items, render);
   } else if (state.tab === 'Study') {
     main.appendChild(createEntryAddControl(render, 'disease'));
     const content = document.createElement('div');

--- a/js/ui/components/cards.js
+++ b/js/ui/components/cards.js
@@ -1,180 +1,477 @@
+import { listBlocks } from '../../storage/storage.js';
 import { createItemCard } from './cardlist.js';
 
+const UNASSIGNED_BLOCK_KEY = '__unassigned__';
+const MISC_LECTURE_KEY = '__misc__';
+
+function formatWeekLabel(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return `Week ${value}`;
+  }
+  return 'Unscheduled';
+}
+
+function titleFromItem(item) {
+  return item?.name || item?.concept || 'Untitled Card';
+}
+
 /**
- * Render lecture-based decks combining all item types.
+ * Render lecture-based decks combining all item types with block/week groupings.
  * @param {HTMLElement} container
  * @param {import('../../types.js').Item[]} items
  * @param {Function} onChange
  */
-export function renderCards(container, items, onChange){
+export async function renderCards(container, items, onChange) {
   container.innerHTML = '';
-  const decks = new Map();
-  items.forEach(it => {
-    if (it.lectures && it.lectures.length){
-      it.lectures.forEach(l => {
-        const key = l.name || `Lecture ${l.id}`;
-        if (!decks.has(key)) decks.set(key, []);
-        decks.get(key).push(it);
+  container.classList.add('cards-tab');
+
+  const blockDefs = await listBlocks();
+  const blockLookup = new Map(blockDefs.map(def => [def.blockId, def]));
+  const blockOrder = new Map(blockDefs.map((def, idx) => [def.blockId, idx]));
+
+  /** @type {Map<string, { key:string, blockId:string|null, title:string, accent?:string|null, order:number, weeks:Map<string, any> }>} */
+  const blockBuckets = new Map();
+
+  function ensureBlock(blockId) {
+    const key = blockId || UNASSIGNED_BLOCK_KEY;
+    if (!blockBuckets.has(key)) {
+      const def = blockLookup.get(blockId);
+      const order = typeof blockId === 'string' ? (blockOrder.get(blockId) ?? 999) : 1200;
+      blockBuckets.set(key, {
+        key,
+        blockId: blockId || null,
+        title: def?.title || (blockId ? blockId : 'Unassigned'),
+        accent: def?.color || null,
+        order,
+        weeks: new Map()
+      });
+    }
+    return blockBuckets.get(key);
+  }
+
+  function ensureWeek(blockBucket, weekValue) {
+    const weekKey = weekValue == null ? 'none' : String(weekValue);
+    if (!blockBucket.weeks.has(weekKey)) {
+      blockBucket.weeks.set(weekKey, {
+        key: weekKey,
+        value: typeof weekValue === 'number' && Number.isFinite(weekValue) ? weekValue : null,
+        label: formatWeekLabel(weekValue),
+        order: typeof weekValue === 'number' && Number.isFinite(weekValue) ? weekValue : 999,
+        lectures: new Map()
+      });
+    }
+    return blockBucket.weeks.get(weekKey);
+  }
+
+  function ensureLecture(weekBucket, lectureKey, lectureName) {
+    if (!weekBucket.lectures.has(lectureKey)) {
+      weekBucket.lectures.set(lectureKey, {
+        key: lectureKey,
+        title: lectureName || 'Lecture',
+        cards: []
+      });
+    }
+    return weekBucket.lectures.get(lectureKey);
+  }
+
+  items.forEach(item => {
+    const lectureRefs = Array.isArray(item.lectures) ? item.lectures : [];
+    if (lectureRefs.length) {
+      lectureRefs.forEach(ref => {
+        const blockBucket = ensureBlock(ref.blockId);
+        const weekBucket = ensureWeek(blockBucket, ref.week);
+        const lectureKeyParts = [ref.blockId || blockBucket.key];
+        if (ref.id != null) lectureKeyParts.push(`lec-${ref.id}`);
+        if (ref.name) lectureKeyParts.push(ref.name);
+        const lectureKey = lectureKeyParts.join('::') || `${blockBucket.key}-${titleFromItem(item)}`;
+        const lecture = ensureLecture(weekBucket, lectureKey, ref.name || (ref.id != null ? `Lecture ${ref.id}` : 'Lecture'));
+        if (!lecture.cards.includes(item)) {
+          lecture.cards.push(item);
+        }
+      });
+    } else if (Array.isArray(item.blocks) && item.blocks.length) {
+      item.blocks.forEach(blockId => {
+        const blockBucket = ensureBlock(blockId);
+        const weeks = Array.isArray(item.weeks) && item.weeks.length ? item.weeks : [null];
+        weeks.forEach(weekVal => {
+          const weekBucket = ensureWeek(blockBucket, weekVal);
+          const lecture = ensureLecture(weekBucket, `${blockBucket.key}::${MISC_LECTURE_KEY}`, 'Ungrouped Items');
+          lecture.cards.push(item);
+        });
       });
     } else {
-      if (!decks.has('Unassigned')) decks.set('Unassigned', []);
-      decks.get('Unassigned').push(it);
+      const blockBucket = ensureBlock(null);
+      const weekBucket = ensureWeek(blockBucket, null);
+      const lecture = ensureLecture(weekBucket, `${blockBucket.key}::${MISC_LECTURE_KEY}`, 'Unassigned Items');
+      lecture.cards.push(item);
     }
   });
 
-  const list = document.createElement('div');
-  list.className = 'deck-list';
-  container.appendChild(list);
+  const blockSections = Array.from(blockBuckets.values())
+    .map(block => {
+      const weeks = Array.from(block.weeks.values())
+        .map(week => {
+          const lectures = Array.from(week.lectures.values())
+            .map(lec => ({
+              ...lec,
+              cards: lec.cards.slice().sort((a, b) => titleFromItem(a).localeCompare(titleFromItem(b)))
+            }))
+            .filter(lec => lec.cards.length > 0)
+            .sort((a, b) => a.title.localeCompare(b.title));
+          const totalCards = lectures.reduce((sum, lec) => sum + lec.cards.length, 0);
+          return {
+            ...week,
+            lectures,
+            totalCards,
+            lectureCount: lectures.length
+          };
+        })
+        .filter(week => week.totalCards > 0)
+        .sort((a, b) => (a.order - b.order) || a.label.localeCompare(b.label));
+      const totalCards = weeks.reduce((sum, week) => sum + week.totalCards, 0);
+      const lectureCount = weeks.reduce((sum, week) => sum + week.lectureCount, 0);
+      return {
+        ...block,
+        weeks,
+        totalCards,
+        lectureCount
+      };
+    })
+    .filter(block => block.totalCards > 0)
+    .sort((a, b) => (a.order - b.order) || a.title.localeCompare(b.title));
 
+  const catalog = document.createElement('div');
+  catalog.className = 'card-catalog';
+  container.appendChild(catalog);
+
+  const overlay = document.createElement('div');
+  overlay.className = 'deck-overlay';
+  overlay.dataset.active = 'false';
+  overlay.setAttribute('role', 'dialog');
+  overlay.setAttribute('aria-modal', 'true');
   const viewer = document.createElement('div');
-  viewer.className = 'deck-viewer hidden';
-  container.appendChild(viewer);
+  viewer.className = 'deck-viewer';
+  overlay.appendChild(viewer);
+  container.appendChild(overlay);
 
-  decks.forEach((cards, lecture) => {
-    const deck = document.createElement('div');
-    deck.className = 'deck';
-    const title = document.createElement('div');
-    title.className = 'deck-title';
-    title.textContent = lecture;
-    const meta = document.createElement('div');
-    meta.className = 'deck-meta';
-    const blocks = Array.from(new Set(cards.flatMap(c => c.blocks || []))).join(', ');
-    const weeks = Array.from(new Set(cards.flatMap(c => c.weeks || []))).join(', ');
-    meta.textContent = `${blocks}${blocks && weeks ? ' • ' : ''}${weeks ? 'Week ' + weeks : ''}`;
-    deck.appendChild(title);
-    deck.appendChild(meta);
-    deck.addEventListener('click', () => { stopPreview(deck); openDeck(lecture, cards); });
-    let hoverTimer;
-    deck.addEventListener('mouseenter', () => {
-      hoverTimer = setTimeout(() => startPreview(deck, cards), 3000);
-    });
-    deck.addEventListener('mouseleave', () => {
-      clearTimeout(hoverTimer);
-      stopPreview(deck);
-    });
-    list.appendChild(deck);
-  });
+  let activeKeyHandler = null;
 
-  function startPreview(deckEl, cards){
-    if (deckEl._preview) return;
-    deckEl.classList.add('pop');
-    const fan = document.createElement('div');
-    fan.className = 'deck-fan';
-    deckEl.appendChild(fan);
-    const show = cards.slice(0,5);
-    const spread = 20;
-    const offset = (show.length - 1) * spread / 2;
-    show.forEach((c,i) => {
-      const mini = document.createElement('div');
-      mini.className = 'fan-card';
-      mini.textContent = c.name || c.concept || '';
-      fan.appendChild(mini);
-      const angle = -offset + i * spread;
-      mini.style.transform = `rotate(${angle}deg) translateY(-80px)`;
-      setTimeout(() => { mini.style.opacity = 1; }, i * 100);
-    });
-    deckEl._preview = { fan };
-  }
-
-  function stopPreview(deckEl){
-    const prev = deckEl._preview;
-    if (prev){
-      prev.fan.remove();
-      deckEl.classList.remove('pop');
-      deckEl._preview = null;
+  function closeDeck() {
+    overlay.dataset.active = 'false';
+    viewer.innerHTML = '';
+    if (activeKeyHandler) {
+      document.removeEventListener('keydown', activeKeyHandler);
+      activeKeyHandler = null;
     }
   }
 
-  function openDeck(title, cards){
-    list.classList.add('hidden');
-    viewer.classList.remove('hidden');
+  overlay.addEventListener('click', evt => {
+    if (evt.target === overlay) closeDeck();
+  });
+
+  function openDeck(context) {
+    const { block, week, lecture } = context;
+    overlay.dataset.active = 'true';
     viewer.innerHTML = '';
 
-    const header = document.createElement('h2');
-    header.textContent = title;
+    const header = document.createElement('div');
+    header.className = 'deck-viewer-header';
+
+    const crumb = document.createElement('div');
+    crumb.className = 'deck-viewer-crumb';
+    const crumbPieces = [];
+    if (block.title) crumbPieces.push(block.title);
+    if (week?.label) crumbPieces.push(week.label);
+    crumb.textContent = crumbPieces.join(' • ');
+    header.appendChild(crumb);
+
+    const title = document.createElement('h2');
+    title.className = 'deck-viewer-title';
+    title.textContent = lecture.title;
+    header.appendChild(title);
+
+    const counter = document.createElement('div');
+    counter.className = 'deck-counter';
+    header.appendChild(counter);
+
+    const closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.className = 'deck-close';
+    closeBtn.innerHTML = '<span aria-hidden="true">×</span><span class="sr-only">Close deck</span>';
+    closeBtn.addEventListener('click', closeDeck);
+    header.appendChild(closeBtn);
+
     viewer.appendChild(header);
 
-    const cardHolder = document.createElement('div');
-    cardHolder.className = 'deck-card';
-    viewer.appendChild(cardHolder);
+    const stage = document.createElement('div');
+    stage.className = 'deck-stage';
 
     const prev = document.createElement('button');
-    prev.className = 'deck-prev';
-    prev.textContent = '◀';
+    prev.type = 'button';
+    prev.className = 'deck-nav deck-prev';
+    prev.innerHTML = '<span class="sr-only">Previous card</span><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M12.5 15L7.5 10L12.5 5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+
+    const cardHolder = document.createElement('div');
+    cardHolder.className = 'deck-card-stage';
+
     const next = document.createElement('button');
-    next.className = 'deck-next';
-    next.textContent = '▶';
-    viewer.appendChild(prev);
-    viewer.appendChild(next);
+    next.type = 'button';
+    next.className = 'deck-nav deck-next';
+    next.innerHTML = '<span class="sr-only">Next card</span><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M7.5 5L12.5 10L7.5 15" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+
+    stage.appendChild(prev);
+    stage.appendChild(cardHolder);
+    stage.appendChild(next);
+    viewer.appendChild(stage);
+
+    const toolbar = document.createElement('div');
+    toolbar.className = 'deck-toolbar';
 
     const toggle = document.createElement('button');
-    toggle.className = 'deck-related-toggle btn';
-    toggle.textContent = 'Show Related';
-    viewer.appendChild(toggle);
+    toggle.type = 'button';
+    toggle.className = 'deck-related-toggle';
+    toggle.dataset.active = 'false';
+    toggle.textContent = 'Show related cards';
+    toolbar.appendChild(toggle);
+
+    viewer.appendChild(toolbar);
 
     const relatedWrap = document.createElement('div');
-    relatedWrap.className = 'deck-related hidden';
+    relatedWrap.className = 'deck-related';
+    relatedWrap.dataset.visible = 'false';
     viewer.appendChild(relatedWrap);
-
-    const close = document.createElement('button');
-    close.className = 'deck-close btn';
-    close.textContent = 'Close';
-    viewer.appendChild(close);
 
     let idx = 0;
     let showRelated = false;
 
-    function renderCard(){
+    function renderRelated() {
+      relatedWrap.innerHTML = '';
+      if (!showRelated) {
+        relatedWrap.dataset.visible = 'false';
+        return;
+      }
+      const current = lecture.cards[idx];
+      (current.links || []).forEach(link => {
+        const related = items.find(it => it.id === link.id);
+        if (related) {
+          const card = createItemCard(related, onChange);
+          card.classList.add('related-card');
+          relatedWrap.appendChild(card);
+        }
+      });
+      relatedWrap.dataset.visible = relatedWrap.children.length ? 'true' : 'false';
+    }
+
+    function renderCard() {
       cardHolder.innerHTML = '';
-      cardHolder.appendChild(createItemCard(cards[idx], onChange));
+      const card = createItemCard(lecture.cards[idx], onChange);
+      cardHolder.appendChild(card);
+      counter.textContent = `Card ${idx + 1} of ${lecture.cards.length}`;
       renderRelated();
     }
 
-    function renderRelated(){
-      relatedWrap.innerHTML = '';
-      if (!showRelated) return;
-      const current = cards[idx];
-      (current.links || []).forEach(l => {
-        const item = items.find(it => it.id === l.id);
-        if (item) {
-          const el = createItemCard(item, onChange);
-          el.classList.add('related-card');
-          relatedWrap.appendChild(el);
-          requestAnimationFrame(() => el.classList.add('visible'));
-        }
-      });
-    }
-
     prev.addEventListener('click', () => {
-      idx = (idx - 1 + cards.length) % cards.length;
+      idx = (idx - 1 + lecture.cards.length) % lecture.cards.length;
       renderCard();
     });
+
     next.addEventListener('click', () => {
-      idx = (idx + 1) % cards.length;
+      idx = (idx + 1) % lecture.cards.length;
       renderCard();
     });
 
     toggle.addEventListener('click', () => {
       showRelated = !showRelated;
-      toggle.textContent = showRelated ? 'Hide Related' : 'Show Related';
-      relatedWrap.classList.toggle('hidden', !showRelated);
+      toggle.dataset.active = showRelated ? 'true' : 'false';
+      toggle.textContent = showRelated ? 'Hide related cards' : 'Show related cards';
       renderRelated();
     });
 
-    close.addEventListener('click', () => {
-      document.removeEventListener('keydown', keyHandler);
-      viewer.classList.add('hidden');
-      viewer.innerHTML = '';
-      list.classList.remove('hidden');
-    });
+    const keyHandler = event => {
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        prev.click();
+      } else if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        next.click();
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+        closeDeck();
+      }
+    };
 
-    function keyHandler(e){
-      if (e.key === 'ArrowLeft') prev.click();
-      if (e.key === 'ArrowRight') next.click();
-      if (e.key === 'Escape') close.click();
-    }
     document.addEventListener('keydown', keyHandler);
+    activeKeyHandler = keyHandler;
 
     renderCard();
+    requestAnimationFrame(() => closeBtn.focus());
   }
+
+  function createCollapseIcon() {
+    const icon = document.createElement('span');
+    icon.className = 'card-collapse-icon';
+    icon.innerHTML = '<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 8L10 12L14 8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+    return icon;
+  }
+
+  function createDeckTile(block, week, lecture) {
+    const tile = document.createElement('button');
+    tile.type = 'button';
+    tile.className = 'deck-tile';
+    tile.setAttribute('aria-label', `${lecture.title} (${lecture.cards.length} cards)`);
+
+    const stack = document.createElement('div');
+    stack.className = 'deck-stack';
+    const preview = lecture.cards.slice(0, 5);
+    stack.style.setProperty('--spread', preview.length > 0 ? (preview.length - 1) / 2 : 0);
+    if (!preview.length) {
+      const placeholder = document.createElement('div');
+      placeholder.className = 'stack-card stack-card-empty';
+      placeholder.style.setProperty('--index', '0');
+      placeholder.textContent = 'No cards yet';
+      stack.appendChild(placeholder);
+    } else {
+      preview.forEach((card, idx) => {
+        const mini = document.createElement('div');
+        mini.className = 'stack-card';
+        mini.style.setProperty('--index', String(idx));
+        mini.textContent = titleFromItem(card);
+        stack.appendChild(mini);
+      });
+    }
+    tile.appendChild(stack);
+
+    const info = document.createElement('div');
+    info.className = 'deck-info';
+
+    const count = document.createElement('span');
+    count.className = 'deck-count-pill';
+    count.textContent = `${lecture.cards.length} card${lecture.cards.length === 1 ? '' : 's'}`;
+    info.appendChild(count);
+
+    const label = document.createElement('h3');
+    label.className = 'deck-title';
+    label.textContent = lecture.title;
+    info.appendChild(label);
+
+    const meta = document.createElement('div');
+    meta.className = 'deck-meta';
+    const pieces = [];
+    if (block.title) pieces.push(block.title);
+    if (week?.label) pieces.push(week.label);
+    meta.textContent = pieces.join(' • ');
+    info.appendChild(meta);
+
+    tile.appendChild(info);
+
+    const open = () => openDeck({ block, week, lecture });
+    tile.addEventListener('click', open);
+    tile.addEventListener('keydown', evt => {
+      if (evt.key === 'Enter' || evt.key === ' ') {
+        evt.preventDefault();
+        open();
+      }
+    });
+
+    return tile;
+  }
+
+  if (!blockSections.length) {
+    const empty = document.createElement('div');
+    empty.className = 'cards-empty';
+    const heading = document.createElement('h3');
+    heading.textContent = 'No cards match your filters yet';
+    empty.appendChild(heading);
+    const body = document.createElement('p');
+    body.textContent = 'Assign lectures, blocks, or create new entries to populate this view.';
+    empty.appendChild(body);
+    catalog.appendChild(empty);
+    return;
+  }
+
+  blockSections.forEach(block => {
+    const section = document.createElement('section');
+    section.className = 'card-block-section';
+    if (block.accent) section.style.setProperty('--block-accent', block.accent);
+
+    const header = document.createElement('button');
+    header.type = 'button';
+    header.className = 'card-block-header';
+    header.setAttribute('aria-expanded', 'true');
+
+    const heading = document.createElement('div');
+    heading.className = 'card-block-heading';
+
+    const swatch = document.createElement('span');
+    swatch.className = 'card-block-mark';
+    heading.appendChild(swatch);
+
+    const title = document.createElement('span');
+    title.className = 'card-block-title';
+    title.textContent = block.title;
+    heading.appendChild(title);
+
+    header.appendChild(heading);
+
+    const stats = document.createElement('span');
+    stats.className = 'card-block-stats';
+    stats.textContent = `${block.lectureCount} lecture${block.lectureCount === 1 ? '' : 's'} • ${block.totalCards} card${block.totalCards === 1 ? '' : 's'}`;
+    header.appendChild(stats);
+
+    const icon = createCollapseIcon();
+    header.appendChild(icon);
+
+    section.appendChild(header);
+
+    const body = document.createElement('div');
+    body.className = 'card-block-body';
+
+    block.weeks.forEach(week => {
+      const weekSection = document.createElement('div');
+      weekSection.className = 'card-week-section';
+
+      const weekHeader = document.createElement('button');
+      weekHeader.type = 'button';
+      weekHeader.className = 'card-week-header';
+      weekHeader.setAttribute('aria-expanded', 'true');
+
+      const weekTitle = document.createElement('span');
+      weekTitle.className = 'card-week-title';
+      weekTitle.textContent = week.label;
+      weekHeader.appendChild(weekTitle);
+
+      const weekStats = document.createElement('span');
+      weekStats.className = 'card-week-stats';
+      weekStats.textContent = `${week.lectureCount} lecture${week.lectureCount === 1 ? '' : 's'} • ${week.totalCards} card${week.totalCards === 1 ? '' : 's'}`;
+      weekHeader.appendChild(weekStats);
+
+      weekHeader.appendChild(createCollapseIcon());
+
+      const deckGrid = document.createElement('div');
+      deckGrid.className = 'deck-grid';
+
+      week.lectures.forEach(lecture => {
+        deckGrid.appendChild(createDeckTile(block, week, lecture));
+      });
+
+      weekSection.appendChild(weekHeader);
+      weekSection.appendChild(deckGrid);
+
+      body.appendChild(weekSection);
+
+      weekHeader.addEventListener('click', () => {
+        const collapsed = weekSection.classList.toggle('is-collapsed');
+        weekHeader.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+      });
+    });
+
+    section.appendChild(body);
+
+    header.addEventListener('click', () => {
+      const collapsed = section.classList.toggle('is-collapsed');
+      header.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+    });
+
+    catalog.appendChild(section);
+  });
 }

--- a/js/ui/components/map.js
+++ b/js/ui/components/map.js
@@ -1073,9 +1073,6 @@ export async function renderMap(root) {
 
   applyMenuState();
 
-  const openMenu = () => setMenuOpen(true);
-  const closeMenu = () => setMenuOpen(false);
-
   toggle.addEventListener('click', evt => {
     evt.preventDefault();
     if (mapState.menuPinned) {

--- a/style.css
+++ b/style.css
@@ -2211,137 +2211,490 @@ input[type="checkbox"]:checked::after {
   display: block;
 }
 
-/* Decks */
-.deck-list {
-  display:flex;
-  flex-wrap:wrap;
-  gap:var(--pad);
-  padding:var(--pad);
+/* Cards */
+.cards-tab {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-lg);
+  padding: var(--pad-lg);
 }
-.deck {
-  background:var(--panel);
-  border:1px solid var(--border);
-  border-radius:var(--radius);
-  padding:var(--pad-lg);
-  cursor:pointer;
-  box-shadow:0 2px 4px rgba(0,0,0,0.2);
-  position:relative;
-  width:200px;
-  display:flex;
-  flex-direction:column;
-  align-items:center;
-  text-align:center;
-  transition:transform 0.3s ease;
+
+.card-catalog {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-lg);
 }
-.deck-title { font-weight:600; margin-bottom:4px; }
-.deck-meta { font-size:0.85rem; color:var(--gray); }
-.deck.pop { transform:scale(1.05); z-index:2; }
-.deck-fan {
-  position:absolute;
-  top:50%;
-  left:50%;
-  transform:translate(-50%,-50%);
-  pointer-events:none;
-}
-.deck-fan .fan-card {
-  position:absolute;
-  width:70px;
-  height:90px;
-  background:var(--panel);
-  border:1px solid var(--border);
-  border-radius:var(--radius);
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  font-size:0.65rem;
-  color:var(--text);
-  opacity:0;
-  transform-origin:bottom center;
-  transition:opacity 0.3s ease, transform 0.3s ease;
-  white-space:nowrap;
-  overflow:hidden;
-  text-overflow:ellipsis;
-}
-.deck-viewer {
-  position: relative;
+
+.cards-empty {
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.72), rgba(2, 6, 23, 0.88));
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: var(--radius-lg);
+  padding: clamp(28px, 5vw, 48px);
   text-align: center;
+  box-shadow: 0 28px 62px rgba(2, 6, 23, 0.45);
+}
+
+.cards-empty h3 {
+  margin: 0 0 8px;
+  font-size: clamp(1.35rem, 1.1vw + 1rem, 1.8rem);
+}
+
+.cards-empty p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.card-block-section {
+  --block-accent: rgba(56, 189, 248, 0.55);
+  position: relative;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  background: linear-gradient(160deg, rgba(10, 16, 30, 0.92), rgba(3, 6, 20, 0.88));
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  box-shadow: 0 24px 50px rgba(2, 6, 23, 0.4);
+}
+
+.card-block-section::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top left, color-mix(in srgb, var(--block-accent) 35%, transparent), transparent 60%);
+  opacity: 0.9;
+  pointer-events: none;
+}
+
+.card-block-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  width: 100%;
+  padding: 26px clamp(20px, 4vw, 36px);
+  background: transparent;
+  border: none;
+  text-align: left;
+  position: relative;
+  z-index: 1;
+}
+
+.card-block-header:hover {
+  background: linear-gradient(90deg, rgba(56, 189, 248, 0.08), transparent 70%);
+}
+
+.card-block-heading {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex: 1;
+  min-width: 0;
+}
+
+.card-block-mark {
+  width: 14px;
+  height: 14px;
+  border-radius: 4px;
+  background: var(--block-accent);
+  box-shadow: 0 6px 18px color-mix(in srgb, var(--block-accent) 40%, transparent);
+}
+
+.card-block-title {
+  font-size: clamp(1.15rem, 1.2vw + 0.8rem, 1.8rem);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.card-block-stats {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  white-space: nowrap;
+}
+
+.card-collapse-icon {
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.15);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  transition: transform 0.3s ease, background 0.3s ease, border-color 0.3s ease;
+}
+
+.card-collapse-icon svg {
+  width: 18px;
+  height: 18px;
+}
+
+.card-block-header:hover .card-collapse-icon {
+  background: rgba(56, 189, 248, 0.16);
+  border-color: rgba(56, 189, 248, 0.35);
+}
+
+.card-block-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  padding: 0 clamp(20px, 4vw, 36px) clamp(28px, 4vw, 40px);
+  position: relative;
+  z-index: 1;
+}
+
+.card-week-section {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: var(--radius);
   padding: var(--pad);
   display: flex;
   flex-direction: column;
+  gap: var(--pad);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.35);
+}
+
+.card-week-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  padding: 6px;
+  background: transparent;
+  border: none;
+  color: inherit;
+  text-align: left;
+}
+
+.card-week-header .card-collapse-icon {
+  width: 28px;
+  height: 28px;
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.card-week-header:hover .card-collapse-icon {
+  background: rgba(56, 189, 248, 0.18);
+  border-color: rgba(56, 189, 248, 0.32);
+}
+
+.card-week-title {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.card-week-stats {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+.deck-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: clamp(16px, 2vw, 28px);
+}
+
+.deck-tile {
+  position: relative;
+  border-radius: var(--radius-lg);
+  padding: clamp(20px, 3vw, 32px);
+  background: radial-gradient(circle at top, rgba(148, 163, 184, 0.08), transparent 65%), rgba(10, 16, 32, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  color: inherit;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(18px, 2vw, 26px);
+  box-shadow: 0 22px 48px rgba(2, 6, 23, 0.38);
+  transition: transform 0.4s cubic-bezier(0.19, 1, 0.22, 1), box-shadow 0.4s ease, border-color 0.4s ease, background 0.4s ease;
+  cursor: pointer;
+}
+
+.deck-tile:hover {
+  transform: translateY(-6px) scale(1.015);
+  border-color: rgba(56, 189, 248, 0.45);
+  background: radial-gradient(circle at top, rgba(56, 189, 248, 0.16), transparent 68%), rgba(10, 16, 32, 0.96);
+  box-shadow: 0 32px 70px rgba(2, 6, 23, 0.5);
+}
+
+.deck-stack {
+  position: relative;
+  width: 100%;
+  height: clamp(120px, 18vw, 180px);
+  perspective: 1100px;
+  transform-style: preserve-3d;
+}
+
+.stack-card {
+  --index: 0;
+  position: absolute;
+  inset: 0;
+  padding: clamp(16px, 2vw, 22px);
+  border-radius: 20px;
+  background: linear-gradient(140deg, rgba(30, 58, 138, 0.9), rgba(56, 189, 248, 0.18));
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  display: flex;
+  align-items: flex-end;
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(248, 250, 252, 0.9);
+  backdrop-filter: blur(4px);
+  transform-origin: center 120%;
+  transform: rotate(calc((var(--index) - var(--spread, 0)) * 1deg)) translateY(calc(var(--index) * -10px)) translateZ(calc(var(--index) * -10px));
+  box-shadow: 0 18px 34px rgba(2, 6, 23, 0.32);
+  opacity: calc(1 - (var(--index) * 0.1));
+  transition: transform 0.45s cubic-bezier(0.16, 1, 0.3, 1), box-shadow 0.45s ease, filter 0.45s ease, opacity 0.45s ease;
+  overflow: hidden;
+}
+
+.stack-card:nth-child(odd) {
+  background: linear-gradient(140deg, rgba(124, 58, 237, 0.85), rgba(56, 189, 248, 0.2));
+}
+
+.stack-card-empty {
+  justify-content: center;
+  align-items: center;
+  text-transform: none;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.deck-tile:hover .stack-card {
+  transform: rotate(calc((var(--index) - var(--spread, 0)) * 7deg)) translateX(calc((var(--index) - var(--spread, 0)) * 26px)) translateY(calc(var(--index) * -4px)) translateZ(calc(var(--index) * 36px));
+  box-shadow: 0 26px 52px rgba(2, 6, 23, 0.45);
+  filter: brightness(1.05) saturate(1.1);
+}
+
+.deck-info {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.deck-count-pill {
+  align-self: flex-start;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(56, 189, 248, 0.15);
+  border: 1px solid rgba(56, 189, 248, 0.3);
+  color: rgba(244, 244, 255, 0.85);
+}
+
+.deck-title {
+  margin: 0;
+  font-size: clamp(1.1rem, 1vw + 1rem, 1.55rem);
+  font-weight: 600;
+}
+
+.deck-meta {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.card-block-section.is-collapsed > .card-block-body {
+  display: none;
+}
+
+.card-block-section.is-collapsed > .card-block-header .card-collapse-icon {
+  transform: rotate(-90deg);
+}
+
+.card-week-section.is-collapsed > .deck-grid {
+  display: none;
+}
+
+.card-week-section.is-collapsed > .card-week-header .card-collapse-icon {
+  transform: rotate(-90deg);
+}
+
+.deck-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 70vh;
-}
-.deck-card {
-  margin:0 auto;
-}
-
-.deck-card .item-card {
-  width:40vw;
-  height:20vh;
-  overflow:hidden;
-  display:flex;
-  flex-direction:column;
+  padding: clamp(16px, 4vw, 48px);
+  background: color-mix(in srgb, rgba(3, 7, 18, 0.9) 82%, transparent);
+  backdrop-filter: blur(24px);
+  z-index: 2000;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.35s ease;
 }
 
-.deck-card .item-card.expanded {
-  height:70vh;
+.deck-overlay[data-active="true"] {
+  opacity: 1;
+  pointer-events: auto;
 }
 
-.deck-card .item-card .card-body {
-  display:none;
-  flex:1;
-  overflow:auto;
+.deck-viewer {
+  width: min(900px, 90vw);
+  max-height: 90vh;
+  background: linear-gradient(150deg, rgba(9, 13, 24, 0.95), rgba(18, 29, 48, 0.92));
+  border-radius: 28px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 36px 80px rgba(2, 6, 23, 0.55);
+  padding: clamp(28px, 4vw, 48px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(18px, 3vw, 32px);
+  position: relative;
 }
 
-.deck-card .item-card.expanded .card-body {
-  display:block;
+.deck-viewer-header {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: flex-start;
 }
 
-.deck-card .item-card.expanded .section-content {
-  overflow-y:auto;
+.deck-viewer-crumb {
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-muted);
 }
-.deck-prev, .deck-next {
-  position:absolute;
-  top:50%;
-  transform:translateY(-50%);
-  background:var(--muted);
-  color:var(--text);
-  padding:8px;
-  border-radius:var(--radius);
-  cursor:pointer;
-  border:1px solid var(--border);
+
+.deck-viewer-title {
+  margin: 0;
+  font-size: clamp(1.6rem, 1.2vw + 1.3rem, 2.4rem);
 }
-.deck-prev { left:var(--pad); }
-.deck-next { right:var(--pad); }
-.deck-prev:hover, .deck-next:hover {
-  transform:translateY(calc(-50% - 2px));
+
+.deck-counter {
+  margin-left: auto;
+  font-size: 0.95rem;
+  color: var(--text-muted);
 }
-.deck-related {
-  display:flex;
-  flex-wrap:wrap;
-  gap:var(--pad);
-  justify-content:center;
-  margin-top:var(--pad);
-  opacity:0;
-  transform:translateY(-10px);
-  transition:opacity 0.3s ease, transform 0.3s ease;
-}
-.deck-related:not(.hidden) {
-  opacity:1;
-  transform:translateY(0);
-}
-.deck-related .related-card {
-  opacity:0;
-  transform:scale(0.95);
-  transition:opacity 0.3s ease, transform 0.3s ease;
-}
-.deck-related .related-card.visible {
-  opacity:1;
-  transform:scale(1);
-}
+
 .deck-close {
-  margin-top:var(--pad);
+  position: absolute;
+  top: clamp(18px, 2vw, 26px);
+  right: clamp(18px, 2vw, 26px);
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(2, 6, 23, 0.65);
+  color: var(--text-muted);
+  font-size: 24px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.3s ease, color 0.3s ease, border-color 0.3s ease, transform 0.3s ease;
+}
+
+.deck-close:hover {
+  background: rgba(56, 189, 248, 0.18);
+  color: var(--text);
+  border-color: rgba(56, 189, 248, 0.4);
+  transform: translateY(-1px);
+}
+
+.deck-stage {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: clamp(16px, 2vw, 28px);
+  align-items: center;
+}
+
+.deck-nav {
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(148, 163, 184, 0.14);
+  color: inherit;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.3s ease, background 0.3s ease, border-color 0.3s ease, color 0.3s ease;
+}
+
+.deck-nav svg {
+  width: 22px;
+  height: 22px;
+}
+
+.deck-nav:hover {
+  transform: translateY(-2px);
+  background: rgba(56, 189, 248, 0.18);
+  border-color: rgba(56, 189, 248, 0.38);
+  color: var(--accent);
+}
+
+.deck-card-stage {
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  max-height: min(65vh, 560px);
+  overflow: hidden;
+}
+
+.deck-card-stage .item-card {
+  width: min(560px, 70vw);
+  max-height: min(65vh, 560px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.deck-card-stage .item-card .card-body {
+  display: block;
+  overflow-y: auto;
+}
+
+.deck-card-stage .item-card .section-content {
+  overflow-y: auto;
+}
+
+.deck-toolbar {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.deck-related-toggle {
+  padding: 8px 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  transition: background 0.3s ease, border-color 0.3s ease, color 0.3s ease;
+}
+
+.deck-related-toggle[data-active="true"] {
+  background: rgba(56, 189, 248, 0.2);
+  border-color: rgba(56, 189, 248, 0.45);
+  color: var(--text);
+  box-shadow: 0 10px 24px rgba(56, 189, 248, 0.25);
+}
+
+.deck-related {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: var(--pad);
+  max-height: 260px;
+  overflow-y: auto;
+  padding-right: 6px;
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.deck-related[data-visible="true"] {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.deck-related .item-card {
+  width: 100%;
+  max-height: 240px;
 }
 .hidden { display:none !important; }
 


### PR DESCRIPTION
## Summary
- reorganize cards tab by block and week with collapsible sections, fanned deck tiles, and an immersive deck viewer overlay
- refresh cards styling to match the study/exam design language and surface counts, meta data, and related card previews
- remove duplicate map menu helpers so the bundle rebuild succeeds with the updated cards module

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68cc9ea352f88322abee3201e13cb363