### PR TITLE
Revamp card detail overlay UI

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -1,4 +1,4 @@
-var Sevenn = (() => {
+(() => {
   // js/state.js
   var state = {
     tab: "Diseases",
@@ -3232,7 +3232,6 @@ var Sevenn = (() => {
   // js/ui/components/cards.js
   var UNASSIGNED_BLOCK_KEY = "__unassigned__";
   var MISC_LECTURE_KEY = "__misc__";
-
   var KIND_COLORS = {
     disease: "var(--pink)",
     drug: "var(--blue)",
@@ -3266,7 +3265,6 @@ var Sevenn = (() => {
       ["mnemonic", "Mnemonic", "\u{1F9E0}"]
     ]
   };
-
   function formatWeekLabel(value) {
     if (typeof value === "number" && Number.isFinite(value)) {
       return `Week ${value}`;
@@ -3276,7 +3274,6 @@ var Sevenn = (() => {
   function titleFromItem(item) {
     return item?.name || item?.concept || "Untitled Card";
   }
-
   function escapeHtml5(str = "") {
     return String(str).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
   }
@@ -3298,24 +3295,53 @@ var Sevenn = (() => {
     if (item?.kind && KIND_COLORS[item.kind]) return KIND_COLORS[item.kind];
     return "var(--accent)";
   }
-  function getLectureAccent(cards) {
-    if (!Array.isArray(cards) || !cards.length) return "var(--accent)";
-    const colored = cards.find((card) => card?.color);
-    if (colored?.color) return colored.color;
-    const kindMatch = cards.find((card) => card?.kind && KIND_COLORS[card.kind]);
-    if (kindMatch?.kind) return KIND_COLORS[kindMatch.kind];
-    return "var(--accent)";
+  function collectLectureColors(cards, limit = 5) {
+    if (!Array.isArray(cards) || !cards.length) {
+      return ["var(--accent)"];
+    }
+    const seen = /* @__PURE__ */ new Set();
+    const colors = [];
+    cards.forEach((card) => {
+      const accent = getItemAccent(card);
+      if (!seen.has(accent)) {
+        seen.add(accent);
+        colors.push(accent);
+      }
+    });
+    if (!colors.length) colors.push("var(--accent)");
+    return colors.slice(0, Math.max(1, limit));
   }
-
+  function buildGradient(colors) {
+    const palette = colors && colors.length ? colors : ["var(--accent)"];
+    if (palette.length === 1) {
+      const single = palette[0];
+      return `linear-gradient(135deg, ${single} 0%, color-mix(in srgb, ${single} 38%, transparent) 100%)`;
+    }
+    const stops = palette.map((color, idx) => {
+      const pct = palette.length === 1 ? 0 : Math.round(idx / (palette.length - 1) * 100);
+      return `${color} ${pct}%`;
+    });
+    return `linear-gradient(135deg, ${stops.join(", ")})`;
+  }
+  function getLecturePalette(cards) {
+    const colors = collectLectureColors(cards);
+    return {
+      accent: colors[0] || "var(--accent)",
+      colors,
+      gradient: buildGradient(colors)
+    };
+  }
+  function getLectureAccent(cards) {
+    return getLecturePalette(cards).accent;
+  }
   async function renderCards(container, items, onChange) {
     container.innerHTML = "";
     container.classList.add("cards-tab");
     const blockDefs = await listBlocks();
     const blockLookup = new Map(blockDefs.map((def) => [def.blockId, def]));
     const blockOrder = new Map(blockDefs.map((def, idx) => [def.blockId, idx]));
-
     const itemLookup = new Map(items.map((item) => [item.id, item]));
-
+    const deckContextLookup = /* @__PURE__ */ new Map();
     const blockBuckets = /* @__PURE__ */ new Map();
     function ensureBlock(blockId) {
       const key = blockId || UNASSIGNED_BLOCK_KEY;
@@ -3411,6 +3437,105 @@ var Sevenn = (() => {
         lectureCount
       };
     }).filter((block) => block.totalCards > 0).sort((a, b) => a.order - b.order || a.title.localeCompare(b.title));
+    blockSections.forEach((block) => {
+      block.weeks.forEach((week) => {
+        week.lectures.forEach((lecture) => {
+          lecture.cards.forEach((card) => {
+            if (!deckContextLookup.has(card.id)) {
+              deckContextLookup.set(card.id, []);
+            }
+            deckContextLookup.get(card.id).push({ block, week, lecture });
+          });
+        });
+      });
+    });
+    const gridPayload = /* @__PURE__ */ new WeakMap();
+    const activeGrids = /* @__PURE__ */ new Set();
+    let gridPumpHandle = 0;
+    const getTime = typeof performance === "object" && typeof performance.now === "function" ? () => performance.now() : () => Date.now();
+    const deckTileObserver = typeof IntersectionObserver === "function" ? new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          deckTileObserver.unobserve(entry.target);
+          startGridRender(entry.target);
+        }
+      });
+    }, { rootMargin: "200px 0px" }) : null;
+    function scheduleGridPump() {
+      if (gridPumpHandle) return;
+      gridPumpHandle = requestAnimationFrame(() => {
+        gridPumpHandle = 0;
+        pumpGridRenders();
+      });
+    }
+    function startGridRender(grid) {
+      if (!grid || grid.dataset.rendered === "true") return;
+      activeGrids.add(grid);
+      scheduleGridPump();
+    }
+    function renderGridChunk(grid) {
+      const payload = gridPayload.get(grid);
+      if (!payload) {
+        grid.dataset.rendered = "true";
+        grid.classList.remove("is-loading");
+        return;
+      }
+      const { entries } = payload;
+      let { index = 0 } = payload;
+      const frag = document.createDocumentFragment();
+      const chunkStart = getTime();
+      let elapsed = 0;
+      while (index < entries.length && elapsed < 6) {
+        const { block, week, lecture } = entries[index++];
+        frag.appendChild(createDeckTile(block, week, lecture));
+        elapsed = getTime() - chunkStart;
+      }
+      payload.index = index;
+      grid.appendChild(frag);
+      if (index > 0) {
+        grid.classList.remove("is-loading");
+      }
+      if (index >= entries.length) {
+        grid.dataset.rendered = "true";
+        grid.classList.remove("is-loading");
+        gridPayload.delete(grid);
+      }
+    }
+    function pumpGridRenders() {
+      if (!activeGrids.size) return;
+      const iterator = Array.from(activeGrids);
+      const frameStart = getTime();
+      for (const grid of iterator) {
+        renderGridChunk(grid);
+        if (grid.dataset.rendered === "true") {
+          activeGrids.delete(grid);
+        }
+        if (getTime() - frameStart > 14) break;
+      }
+      if (activeGrids.size) {
+        scheduleGridPump();
+      }
+    }
+    function registerGrid(grid, entries) {
+      grid.dataset.rendered = "false";
+      grid.classList.add("is-loading");
+      gridPayload.set(grid, { entries, index: 0 });
+      if (deckTileObserver) {
+        requestAnimationFrame(() => {
+          if (grid.dataset.rendered === "true") return;
+          deckTileObserver.observe(grid);
+        });
+      } else {
+        startGridRender(grid);
+      }
+    }
+    function ensureGridRendered(grid) {
+      if (!grid || grid.dataset.rendered === "true") return;
+      if (deckTileObserver) {
+        deckTileObserver.unobserve(grid);
+      }
+      startGridRender(grid);
+    }
     const catalog = document.createElement("div");
     catalog.className = "card-catalog";
     container.appendChild(catalog);
@@ -3424,127 +3549,140 @@ var Sevenn = (() => {
     overlay.appendChild(viewer);
     container.appendChild(overlay);
     let activeKeyHandler = null;
+    let persistRelatedVisibility = false;
     function closeDeck() {
       overlay.dataset.active = "false";
+      viewer.innerHTML = "";
+      viewer.className = "deck-viewer";
+      if (activeKeyHandler) {
+        document.removeEventListener("keydown", activeKeyHandler);
+        activeKeyHandler = null;
+      }
+      persistRelatedVisibility = false;
+    }
+    overlay.addEventListener("click", (evt) => {
+      if (evt.target === overlay) closeDeck();
+    });
+    function openDeck(context, targetCardId = null) {
+      const { block, week, lecture } = context;
+      overlay.dataset.active = "true";
       viewer.innerHTML = "";
       if (activeKeyHandler) {
         document.removeEventListener("keydown", activeKeyHandler);
         activeKeyHandler = null;
       }
-    }
-    overlay.addEventListener("click", (evt) => {
-      if (evt.target === overlay) closeDeck();
-    });
-    function openDeck(context) {
-      const { block, week, lecture } = context;
-      overlay.dataset.active = "true";
-      viewer.innerHTML = "";
-      const header = document.createElement("div");
-      header.className = "deck-viewer-header";
-      const crumb = document.createElement("div");
-      crumb.className = "deck-viewer-crumb";
-      const crumbPieces = [];
-      if (block.title) crumbPieces.push(block.title);
-      if (week?.label) crumbPieces.push(week.label);
-      crumb.textContent = crumbPieces.join(" \u2022 ");
-      header.appendChild(crumb);
-      const title = document.createElement("h2");
-      title.className = "deck-viewer-title";
-      title.textContent = lecture.title;
-      header.appendChild(title);
-      const counter = document.createElement("div");
-      counter.className = "deck-counter";
-      header.appendChild(counter);
-
-      const progress = document.createElement("div");
-      progress.className = "deck-progress";
-      const progressFill = document.createElement("span");
-      progressFill.className = "deck-progress-fill";
-      progress.appendChild(progressFill);
-      header.appendChild(progress);
-
+      const baseContext = { block, week, lecture };
+      viewer.className = "deck-viewer deck-viewer-card";
       const closeBtn = document.createElement("button");
       closeBtn.type = "button";
       closeBtn.className = "deck-close";
       closeBtn.innerHTML = '<span aria-hidden="true">\xD7</span><span class="sr-only">Close deck</span>';
       closeBtn.addEventListener("click", closeDeck);
-      header.appendChild(closeBtn);
-      viewer.appendChild(header);
+      viewer.appendChild(closeBtn);
+      const summary = document.createElement("div");
+      summary.className = "deck-card-summary";
+      const crumb = document.createElement("span");
+      crumb.className = "deck-card-summary-crumb";
+      const crumbPieces = [];
+      if (block.title) crumbPieces.push(block.title);
+      if (week?.label) crumbPieces.push(week.label);
+      crumb.textContent = crumbPieces.join(" \u2022 ");
+      summary.appendChild(crumb);
+      const title = document.createElement("h2");
+      title.className = "deck-card-summary-title";
+      title.textContent = lecture.title;
+      summary.appendChild(title);
+      const counter = document.createElement("span");
+      counter.className = "deck-card-summary-counter";
+      counter.textContent = `Card 1 of ${lecture.cards.length}`;
+      summary.appendChild(counter);
+      viewer.appendChild(summary);
       const stage = document.createElement("div");
-      stage.className = "deck-stage";
+      stage.className = "deck-card-stage-full";
       const prev = document.createElement("button");
       prev.type = "button";
-      prev.className = "deck-nav deck-prev";
-      prev.innerHTML = '<span class="sr-only">Previous card</span><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M12.5 15L7.5 10L12.5 5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>';
-
+      prev.className = "deck-card-nav deck-card-nav-prev";
+      prev.innerHTML = '<span class="sr-only">Previous card</span><svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M14 18L8 12L14 6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>';
       const slideHolder = document.createElement("div");
-      slideHolder.className = "deck-card-stage";
-
+      slideHolder.className = "deck-card-holder";
       const next = document.createElement("button");
       next.type = "button";
-      next.className = "deck-nav deck-next";
-      next.innerHTML = '<span class="sr-only">Next card</span><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M7.5 5L12.5 10L7.5 15" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+      next.className = "deck-card-nav deck-card-nav-next";
+      next.innerHTML = '<span class="sr-only">Next card</span><svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M10 6L16 12L10 18" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>';
       stage.appendChild(prev);
-
       stage.appendChild(slideHolder);
       stage.appendChild(next);
       viewer.appendChild(stage);
-      const footer = document.createElement("div");
-      footer.className = "deck-footer";
-
+      const relatedPanel = document.createElement("div");
+      relatedPanel.className = "deck-related-panel";
       const toggle = document.createElement("button");
       toggle.type = "button";
       toggle.className = "deck-related-toggle";
       toggle.dataset.active = "false";
       toggle.textContent = "Show related cards";
-
-      footer.appendChild(toggle);
-      viewer.appendChild(footer);
-
+      toggle.setAttribute("aria-expanded", "false");
+      relatedPanel.appendChild(toggle);
+      const relatedWrapId = `deck-related-${Math.random().toString(36).slice(2)}`;
       const relatedWrap = document.createElement("div");
       relatedWrap.className = "deck-related";
       relatedWrap.dataset.visible = "false";
-      viewer.appendChild(relatedWrap);
+      relatedWrap.id = relatedWrapId;
+      relatedWrap.setAttribute("aria-hidden", "true");
+      toggle.setAttribute("aria-controls", relatedWrapId);
+      relatedPanel.appendChild(relatedWrap);
+      viewer.appendChild(relatedPanel);
       let idx = 0;
-      let showRelated = false;
-
+      if (targetCardId != null) {
+        const initialIdx = lecture.cards.findIndex((card) => card.id === targetCardId);
+        if (initialIdx >= 0) idx = initialIdx;
+      }
+      let showRelated = persistRelatedVisibility;
       function updateToggle(current) {
         const linkCount = Array.isArray(current?.links) ? current.links.length : 0;
-        toggle.disabled = linkCount === 0;
-        toggle.dataset.active = showRelated && linkCount ? "true" : "false";
-        toggle.textContent = linkCount ? `${showRelated ? "Hide" : "Show"} related (${linkCount})` : "No related cards";
+        const hasLinks = linkCount > 0;
+        toggle.disabled = !hasLinks;
+        toggle.dataset.active = showRelated && hasLinks ? "true" : "false";
+        toggle.setAttribute("aria-expanded", showRelated && hasLinks ? "true" : "false");
+        toggle.textContent = hasLinks ? `${showRelated ? "Hide" : "Show"} related (${linkCount})` : "No related cards";
       }
       function renderRelated(current) {
-
         relatedWrap.innerHTML = "";
         if (!showRelated) {
           relatedWrap.dataset.visible = "false";
+          relatedWrap.setAttribute("aria-hidden", "true");
+          toggle.dataset.active = "false";
+          toggle.setAttribute("aria-expanded", "false");
           return;
         }
-
         const links = Array.isArray(current?.links) ? current.links : [];
         links.forEach((link) => {
           const related = itemLookup.get(link.id);
           if (related) {
-            relatedWrap.appendChild(createRelatedCard(related));
-
+            relatedWrap.appendChild(createRelatedCard(related, baseContext));
           }
         });
-        relatedWrap.dataset.visible = relatedWrap.children.length ? "true" : "false";
+        const visible = relatedWrap.children.length > 0;
+        relatedWrap.dataset.visible = visible ? "true" : "false";
+        relatedWrap.setAttribute("aria-hidden", visible ? "false" : "true");
+        if (!visible) {
+          toggle.dataset.active = "false";
+          toggle.setAttribute("aria-expanded", "false");
+        }
       }
       function renderCard() {
-
         const current = lecture.cards[idx];
         slideHolder.innerHTML = "";
-        slideHolder.appendChild(createDeckSlide(current, { block, week, lecture }));
+        const slide = createDeckSlide(current, baseContext);
+        slide.classList.add("deck-slide-full");
+        slideHolder.appendChild(slide);
         const accent = getItemAccent(current);
-        viewer.style.setProperty("--viewer-accent", accent);
+        viewer.style.setProperty("--deck-current-accent", accent);
         counter.textContent = `Card ${idx + 1} of ${lecture.cards.length}`;
-        const progressValue = (idx + 1) / lecture.cards.length * 100;
-        progressFill.style.width = `${progressValue}%`;
+        const multiple = lecture.cards.length > 1;
+        prev.disabled = !multiple;
+        next.disabled = !multiple;
         updateToggle(current);
         renderRelated(current);
-
       }
       prev.addEventListener("click", () => {
         idx = (idx - 1 + lecture.cards.length) % lecture.cards.length;
@@ -3557,10 +3695,9 @@ var Sevenn = (() => {
       toggle.addEventListener("click", () => {
         if (toggle.disabled) return;
         showRelated = !showRelated;
-
+        persistRelatedVisibility = showRelated;
         updateToggle(lecture.cards[idx]);
         renderRelated(lecture.cards[idx]);
-
       });
       const keyHandler2 = (event) => {
         if (event.key === "ArrowLeft") {
@@ -3585,19 +3722,46 @@ var Sevenn = (() => {
       icon.innerHTML = '<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 8L10 12L14 8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>';
       return icon;
     }
+    const FAN_DELAY_MS = 1e3;
+    function enableDelayedFan(tile) {
+      let fanTimer = 0;
+      const cancel = () => {
+        if (fanTimer) {
+          clearTimeout(fanTimer);
+          fanTimer = 0;
+        }
+        tile.classList.remove("is-fanned");
+      };
+      const arm = () => {
+        if (fanTimer) return;
+        fanTimer = setTimeout(() => {
+          tile.classList.add("is-fanned");
+          fanTimer = 0;
+        }, FAN_DELAY_MS);
+      };
+      tile.addEventListener("pointerenter", arm);
+      tile.addEventListener("pointerleave", cancel);
+      tile.addEventListener("pointercancel", cancel);
+      tile.addEventListener("mouseenter", arm);
+      tile.addEventListener("mouseleave", cancel);
+      tile.addEventListener("touchstart", arm, { passive: true });
+      tile.addEventListener("touchend", cancel);
+      tile.addEventListener("touchcancel", cancel);
+      tile.addEventListener("focus", arm);
+      tile.addEventListener("blur", cancel);
+    }
     function createDeckTile(block, week, lecture) {
       const tile = document.createElement("button");
       tile.type = "button";
       tile.className = "deck-tile";
       tile.setAttribute("aria-label", `${lecture.title} (${lecture.cards.length} cards)`);
-
-      const accent = getLectureAccent(lecture.cards);
-      tile.style.setProperty("--deck-accent", accent);
+      const palette = getLecturePalette(lecture.cards);
+      const accent = palette.accent;
       const stack = document.createElement("div");
       stack.className = "deck-stack";
       stack.style.setProperty("--deck-accent", accent);
+      stack.style.setProperty("--deck-gradient", palette.gradient);
       const preview = lecture.cards.slice(0, 4);
-
       stack.style.setProperty("--spread", preview.length > 0 ? (preview.length - 1) / 2 : 0);
       if (!preview.length) {
         const placeholder = document.createElement("div");
@@ -3614,15 +3778,14 @@ var Sevenn = (() => {
           stack.appendChild(mini);
         });
       }
+      tile.style.setProperty("--deck-accent", accent);
+      tile.style.setProperty("--deck-gradient", palette.gradient);
       tile.appendChild(stack);
       const info = document.createElement("div");
       info.className = "deck-info";
       const count = document.createElement("span");
       count.className = "deck-count-pill";
       count.textContent = `${lecture.cards.length} card${lecture.cards.length === 1 ? "" : "s"}`;
-
-      count.style.setProperty("--deck-accent", accent);
-
       info.appendChild(count);
       const label = document.createElement("h3");
       label.className = "deck-title";
@@ -3644,9 +3807,9 @@ var Sevenn = (() => {
           open();
         }
       });
+      enableDelayedFan(tile);
       return tile;
     }
-
     function createMetaChip(text, icon) {
       const chip = document.createElement("span");
       chip.className = "deck-chip";
@@ -3755,8 +3918,22 @@ var Sevenn = (() => {
       slide.appendChild(sections);
       return slide;
     }
-    function createRelatedCard(item) {
-      const entry = document.createElement("div");
+    function resolveDeckContext(item, origin) {
+      const contexts = deckContextLookup.get(item.id);
+      if (!contexts || !contexts.length) return null;
+      if (origin?.lecture?.key) {
+        const lectureMatch = contexts.find((ctx) => ctx.lecture.key === origin.lecture.key);
+        if (lectureMatch) return lectureMatch;
+      }
+      if (origin?.block?.key) {
+        const blockMatch = contexts.find((ctx) => ctx.block.key === origin.block.key);
+        if (blockMatch) return blockMatch;
+      }
+      return contexts[0];
+    }
+    function createRelatedCard(item, originContext) {
+      const entry = document.createElement("button");
+      entry.type = "button";
       entry.className = "related-card-chip";
       const accent = getItemAccent(item);
       entry.style.setProperty("--related-accent", accent);
@@ -3769,6 +3946,15 @@ var Sevenn = (() => {
       kind.className = "related-card-kind";
       kind.textContent = item.kind ? item.kind.toUpperCase() : "";
       entry.appendChild(kind);
+      const target = resolveDeckContext(item, originContext);
+      if (!target) {
+        entry.disabled = true;
+        entry.classList.add("is-disabled");
+      } else {
+        entry.addEventListener("click", () => {
+          openDeck(target, item.id);
+        });
+      }
       return entry;
     }
     function buildBlockSection(block) {
@@ -3777,7 +3963,6 @@ var Sevenn = (() => {
       const firstLecture = block.weeks.find((week) => week.lectures.length)?.lectures.find((lec) => lec.cards.length);
       const blockAccent = block.accent || getLectureAccent(firstLecture?.cards || []);
       if (blockAccent) section.style.setProperty("--block-accent", blockAccent);
-
       const header = document.createElement("button");
       header.type = "button";
       header.className = "card-block-header";
@@ -3804,10 +3989,8 @@ var Sevenn = (() => {
       block.weeks.forEach((week) => {
         const weekSection = document.createElement("div");
         weekSection.className = "card-week-section";
-
         const weekAccent = getLectureAccent(week.lectures.find((lec) => lec.cards.length)?.cards || []);
         if (weekAccent) weekSection.style.setProperty("--week-accent", weekAccent);
-
         const weekHeader = document.createElement("button");
         weekHeader.type = "button";
         weekHeader.className = "card-week-header";
@@ -3823,15 +4006,16 @@ var Sevenn = (() => {
         weekHeader.appendChild(createCollapseIcon());
         const deckGrid = document.createElement("div");
         deckGrid.className = "deck-grid";
-        week.lectures.forEach((lecture) => {
-          deckGrid.appendChild(createDeckTile(block, week, lecture));
-        });
+        registerGrid(deckGrid, week.lectures.map((lecture) => ({ block, week, lecture })));
         weekSection.appendChild(weekHeader);
         weekSection.appendChild(deckGrid);
         body.appendChild(weekSection);
         weekHeader.addEventListener("click", () => {
           const collapsed = weekSection.classList.toggle("is-collapsed");
           weekHeader.setAttribute("aria-expanded", collapsed ? "false" : "true");
+          if (!collapsed) {
+            ensureGridRendered(deckGrid);
+          }
         });
       });
       section.appendChild(body);
@@ -3839,7 +4023,6 @@ var Sevenn = (() => {
         const collapsed = section.classList.toggle("is-collapsed");
         header.setAttribute("aria-expanded", collapsed ? "false" : "true");
       });
-
       return section;
     }
     if (!blockSections.length) {
@@ -3855,7 +4038,6 @@ var Sevenn = (() => {
       return;
     }
     const renderQueue = blockSections.slice();
-    const getTime = typeof performance === "object" && typeof performance.now === "function" ? () => performance.now() : () => Date.now();
     function pump() {
       const start = getTime();
       while (renderQueue.length && getTime() - start < 12) {
@@ -3866,7 +4048,6 @@ var Sevenn = (() => {
       }
     }
     pump();
-
   }
 
   // js/ui/components/builder.js

--- a/style.css
+++ b/style.css
@@ -2616,7 +2616,7 @@ input[type="checkbox"]:checked::after {
   position: fixed;
   inset: 0;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
   padding: clamp(18px, 4vw, 48px);
   background: rgba(2, 6, 18, 0.78);
@@ -2624,6 +2624,7 @@ input[type="checkbox"]:checked::after {
   z-index: 2000;
   opacity: 0;
   pointer-events: none;
+  overflow-y: auto;
   transition: opacity 0.3s ease;
 }
 
@@ -2634,68 +2635,74 @@ input[type="checkbox"]:checked::after {
 
 .deck-viewer {
   --deck-current-accent: var(--accent);
-
-  width: min(920px, 92vw);
-
-  max-height: 90vh;
-  background: linear-gradient(165deg, rgba(8, 13, 25, 0.96), rgba(5, 9, 20, 0.88));
-  border-radius: 26px;
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  box-shadow: 0 32px 68px rgba(2, 6, 23, 0.5);
-  padding: clamp(24px, 3.5vw, 40px);
+  width: min(980px, 94vw);
+  margin: clamp(24px, 5vh, 56px) auto;
+  padding: clamp(24px, 3.5vw, 40px) clamp(18px, 3vw, 32px) clamp(32px, 4vw, 48px);
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: clamp(16px, 2.5vw, 28px);
-  position: relative;
-  overflow: visible;
-
+  gap: clamp(18px, 2.5vw, 28px);
+  background: linear-gradient(165deg, rgba(8, 13, 25, 0.96), rgba(5, 9, 20, 0.88));
+  border-radius: 28px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  box-shadow: 0 36px 72px rgba(2, 6, 23, 0.55);
 }
 
-.deck-viewer-header {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 12px;
-  align-items: start;
+.deck-viewer-card {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  padding: clamp(18px, 2.5vw, 32px) clamp(12px, 2vw, 26px) clamp(28px, 3vw, 40px);
+  border-radius: 0;
+  gap: clamp(18px, 2.5vw, 28px);
+}
+
+.deck-card-summary {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(8px, 1.8vw, 16px);
+  padding-right: clamp(54px, 8vw, 72px);
   position: relative;
   z-index: 1;
 }
 
-.deck-viewer-crumb {
-  grid-column: 1 / -1;
+.deck-card-summary-crumb {
   font-size: 0.82rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: rgba(248, 250, 252, 0.6);
+  color: rgba(248, 250, 252, 0.58);
 }
 
-.deck-viewer-title {
+.deck-card-summary-crumb:empty {
+  display: none;
+}
+
+.deck-card-summary-title {
   margin: 0;
   font-size: clamp(1.6rem, 1.2vw + 1.3rem, 2.4rem);
+  color: var(--text);
 }
 
-.deck-counter {
+.deck-card-summary-counter {
   font-size: 0.95rem;
-  color: rgba(248, 250, 252, 0.65);
-  align-self: center;
+  color: rgba(248, 250, 252, 0.68);
 }
 
-.deck-progress {
-  grid-column: 1 / -1;
-  height: 6px;
-  background: rgba(148, 163, 184, 0.2);
-  border-radius: 999px;
-  overflow: hidden;
-  position: relative;
-}
+@media (min-width: 640px) {
+  .deck-card-summary {
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: clamp(10px, 1.8vw, 18px);
+  }
 
-.deck-progress-fill {
-  position: absolute;
-  inset: 0;
-  width: 0%;
-  background: var(--deck-current-accent, var(--accent));
-  border-radius: inherit;
-  box-shadow: 0 10px 24px color-mix(in srgb, var(--deck-current-accent, var(--accent)) 35%, transparent);
-  transition: width 0.35s ease;
+  .deck-card-summary-crumb {
+    flex-basis: 100%;
+  }
+
+  .deck-card-summary-counter {
+    margin-left: auto;
+  }
 }
 
 .deck-close {
@@ -2703,8 +2710,8 @@ input[type="checkbox"]:checked::after {
   top: clamp(18px, 2vw, 26px);
   right: clamp(18px, 2vw, 26px);
 
-  width: 42px;
-  height: 42px;
+  width: 44px;
+  height: 44px;
 
   border-radius: 50%;
   border: 1px solid rgba(148, 163, 184, 0.28);
@@ -2729,71 +2736,75 @@ input[type="checkbox"]:checked::after {
 }
 
 
-.deck-stage {
+.deck-card-stage-full {
   display: grid;
-  grid-template-columns: auto 1fr auto;
-
-  gap: clamp(16px, 2vw, 28px);
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: stretch;
+  gap: clamp(16px, 2.5vw, 32px);
   position: relative;
-  z-index: 1;
 }
 
+.deck-card-holder {
+  display: flex;
+  justify-content: center;
+  padding: 0 clamp(12px, 2.5vw, 24px);
+  min-width: 0;
+}
 
-.deck-nav {
-  width: 46px;
-  height: 46px;
-
+.deck-card-nav {
+  width: clamp(42px, 5vw, 56px);
+  height: clamp(42px, 5vw, 56px);
   border-radius: 50%;
-
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  background: rgba(148, 163, 184, 0.12);
-
-  color: var(--deck-current-accent, var(--accent));
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  background: rgba(8, 13, 25, 0.82);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: transform 0.25s ease, background 0.25s ease, border-color 0.25s ease, color 0.25s ease;
-}
-
-.deck-nav svg {
-  width: 22px;
-  height: 22px;
-}
-
-.deck-nav:hover {
-  transform: translateY(-2px);
-  background: rgba(56, 189, 248, 0.2);
-  border-color: rgba(56, 189, 248, 0.38);
+  align-self: center;
   color: var(--deck-current-accent, var(--accent));
-
+  transition: background 0.3s ease, border-color 0.3s ease, transform 0.3s ease, color 0.3s ease;
+  box-shadow: 0 18px 32px rgba(2, 6, 23, 0.35);
+  backdrop-filter: blur(6px);
 }
 
+.deck-card-nav svg {
+  width: clamp(18px, 2vw, 24px);
+  height: clamp(18px, 2vw, 24px);
+}
 
-.deck-card-stage {
-  display: flex;
-  align-items: stretch;
-  justify-content: center;
-  padding: clamp(12px, 2vw, 18px);
-  max-height: none;
-  overflow: visible;
+.deck-card-nav:hover {
+  background: color-mix(in srgb, var(--deck-current-accent, var(--accent)) 18%, rgba(8, 13, 25, 0.82));
+  border-color: color-mix(in srgb, var(--deck-current-accent, var(--accent)) 45%, transparent);
+  transform: translateY(-1px);
+}
+
+.deck-card-nav:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--deck-current-accent, var(--accent)) 45%, transparent);
+  outline-offset: 2px;
+}
+
+.deck-card-nav:disabled {
+  opacity: 0.35;
+  pointer-events: none;
 }
 
 .deck-slide {
-  width: min(640px, 82vw);
-  max-height: min(72vh, 640px);
-  background: linear-gradient(175deg, rgba(11, 18, 32, 0.95), rgba(7, 12, 24, 0.9));
+  width: 100%;
+  background: linear-gradient(175deg, rgba(11, 18, 32, 0.96), rgba(7, 12, 24, 0.92));
   border: 1px solid rgba(148, 163, 184, 0.18);
-  border-radius: 22px;
+  border-radius: 24px;
   padding: clamp(22px, 3vw, 34px);
   display: flex;
   flex-direction: column;
-  gap: 20px;
-  overflow-y: auto;
+  gap: clamp(18px, 2vw, 26px);
   position: relative;
-  box-shadow: 0 28px 60px rgba(2, 6, 23, 0.35), inset 4px 0 0 color-mix(in srgb, var(--slide-accent, var(--accent)) 55%, transparent);
-  scrollbar-gutter: stable both-edges;
+  box-shadow: 0 28px 60px rgba(2, 6, 23, 0.38), inset 4px 0 0 color-mix(in srgb, var(--slide-accent, var(--accent)) 55%, transparent);
 }
+
+.deck-slide-full {
+  max-width: min(780px, 90vw);
+}
+
 
 .deck-slide-header {
   display: flex;
@@ -2850,7 +2861,11 @@ input[type="checkbox"]:checked::after {
 }
 
 .deck-chip-icon {
-  font-size: 0.78rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.9rem;
+  line-height: 1;
 }
 
 .deck-chip-label {
@@ -2877,9 +2892,9 @@ input[type="checkbox"]:checked::after {
 }
 
 .deck-section-title {
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
   font-size: 0.95rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -2888,7 +2903,15 @@ input[type="checkbox"]:checked::after {
 }
 
 .deck-section-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.9rem;
+  height: 1.9rem;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--section-accent, var(--accent)) 18%, rgba(15, 23, 42, 0.6));
   font-size: 1rem;
+  line-height: 1;
 }
 
 .deck-section-content {
@@ -2907,62 +2930,68 @@ input[type="checkbox"]:checked::after {
   color: rgba(248, 250, 252, 0.6);
 }
 
-.deck-footer {
-  display: flex;
-  justify-content: flex-end;
+.deck-related-panel {
+  align-self: flex-end;
   position: relative;
-  z-index: 1;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 12px;
+  z-index: 2;
 }
 
 .deck-related-toggle {
-  padding: 8px 18px;
-
+  padding: 10px 22px;
   border-radius: 999px;
-  border: 1px solid rgba(148, 163, 184, 0.24);
-  background: rgba(148, 163, 184, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(148, 163, 184, 0.16);
   color: var(--text-muted);
-  font-size: 0.9rem;
-  letter-spacing: 0.04em;
+  font-size: 0.88rem;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
-
   transition: background 0.3s ease, border-color 0.3s ease, color 0.3s ease, transform 0.3s ease;
 }
 
 .deck-related-toggle[data-active="true"] {
-  background: rgba(56, 189, 248, 0.18);
-  border-color: rgba(56, 189, 248, 0.42);
+  background: color-mix(in srgb, var(--deck-current-accent, var(--accent)) 22%, rgba(148, 163, 184, 0.16));
+  border-color: color-mix(in srgb, var(--deck-current-accent, var(--accent)) 45%, transparent);
   color: var(--text);
-  box-shadow: 0 10px 24px rgba(56, 189, 248, 0.2);
+  box-shadow: 0 14px 32px rgba(56, 189, 248, 0.22);
   transform: translateY(-1px);
 }
 
 .deck-related-toggle:disabled {
-  opacity: 0.5;
+  opacity: 0.55;
   cursor: not-allowed;
-
 }
 
 .deck-related {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 12px;
+  width: min(420px, 80vw);
+  max-height: min(52vh, 420px);
+  padding: clamp(16px, 2vw, 22px) clamp(14px, 2vw, 20px);
   display: grid;
-
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: var(--pad);
-  max-height: 240px;
-
+  gap: 14px;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: linear-gradient(165deg, rgba(11, 18, 32, 0.96), rgba(7, 12, 24, 0.9));
+  box-shadow: 0 26px 48px rgba(2, 6, 23, 0.45);
   overflow-y: auto;
-  padding-right: 6px;
   opacity: 0;
-  transform: translateY(12px);
+  z-index: 3;
+  transform: translateY(12px) scale(0.96);
+  transform-origin: 90% 0;
   transition: opacity 0.3s ease, transform 0.3s ease;
-
-  position: relative;
-  z-index: 1;
-
+  pointer-events: none;
 }
 
 .deck-related[data-visible="true"] {
   opacity: 1;
-  transform: translateY(0);
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
 }
 
 


### PR DESCRIPTION
## Summary
- simplify the card viewer so opening a deck shows a full card with a compact header, navigation arrows, and a popover for related cards
- refresh the related cards UI, spacing, and icon styling while making the overlay scrollable so long cards are readable
- fix the delayed fan animation on deck tiles by using a 1s hover delay with additional pointer and touch listeners

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cce7705a2c832283073da6f2797cd5