### PR TITLE
Improve cards performance and persist collapse state

### DIFF
--- a/js/state.js
+++ b/js/state.js
@@ -23,6 +23,10 @@ export const state = {
     collapsedBlocks:[],
     collapsedWeeks:[]
   },
+  cards: {
+    collapsedBlocks: [],
+    collapsedWeeks: []
+  },
   cohort: [],
   review: { count:20, format:"flashcards" },
   quizSession: null,
@@ -38,6 +42,21 @@ export function setSubtab(tab, sub){ state.subtab[tab] = sub; }
 export function setQuery(q){ state.query = q; }
 export function setFilters(patch){ Object.assign(state.filters, patch); }
 export function setBuilder(patch){ Object.assign(state.builder, patch); }
+export function setCardsState(patch){
+  if (!patch) return;
+  if (!state.cards) {
+    state.cards = { collapsedBlocks: [], collapsedWeeks: [] };
+  }
+  const { collapsedBlocks, collapsedWeeks } = patch;
+  if (Array.isArray(collapsedBlocks)) {
+    const unique = Array.from(new Set(collapsedBlocks.filter(Boolean)));
+    state.cards.collapsedBlocks = unique;
+  }
+  if (Array.isArray(collapsedWeeks)) {
+    const unique = Array.from(new Set(collapsedWeeks.filter(Boolean)));
+    state.cards.collapsedWeeks = unique;
+  }
+}
 export function setCohort(items){ state.cohort = items; }
 export function resetTransientSessions(){ state.quizSession = null; state.flashSession = null; state.examSession = null; }
 export function setFlashSession(sess){ state.flashSession = sess; }

--- a/js/ui/components/cards.js
+++ b/js/ui/components/cards.js
@@ -1,4 +1,5 @@
 import { listBlocks } from '../../storage/storage.js';
+import { state, setCardsState } from '../../state.js';
 import { renderRichText } from './rich-text.js';
 
 const UNASSIGNED_BLOCK_KEY = '__unassigned__';
@@ -142,6 +143,49 @@ export async function renderCards(container, items, onChange) {
   /** @type {Map<string, Array<{ block: any, week: any, lecture: any }>>} */
   const deckContextLookup = new Map();
 
+  const cardsState = state.cards || {};
+  const collapsedBlockSet = new Set(Array.isArray(cardsState.collapsedBlocks) ? cardsState.collapsedBlocks : []);
+  const collapsedWeekSet = new Set(Array.isArray(cardsState.collapsedWeeks) ? cardsState.collapsedWeeks : []);
+  const scheduleFrame = typeof requestAnimationFrame === 'function'
+    ? (cb => requestAnimationFrame(cb))
+    : (cb => setTimeout(cb, 16));
+  let persistHandle = 0;
+
+  function schedulePersist() {
+    if (persistHandle) return;
+    persistHandle = scheduleFrame(() => {
+      persistHandle = 0;
+      setCardsState({
+        collapsedBlocks: Array.from(collapsedBlockSet),
+        collapsedWeeks: Array.from(collapsedWeekSet)
+      });
+    });
+  }
+
+  function setBlockCollapsedState(key, collapsed) {
+    if (!key) return;
+    if (collapsed) {
+      if (!collapsedBlockSet.has(key)) {
+        collapsedBlockSet.add(key);
+        schedulePersist();
+      }
+    } else if (collapsedBlockSet.delete(key)) {
+      schedulePersist();
+    }
+  }
+
+  function setWeekCollapsedState(key, collapsed) {
+    if (!key) return;
+    if (collapsed) {
+      if (!collapsedWeekSet.has(key)) {
+        collapsedWeekSet.add(key);
+        schedulePersist();
+      }
+    } else if (collapsedWeekSet.delete(key)) {
+      schedulePersist();
+    }
+  }
+
 
   /** @type {Map<string, { key:string, blockId:string|null, title:string, accent?:string|null, order:number, weeks:Map<string, any> }>} */
   const blockBuckets = new Map();
@@ -274,6 +318,28 @@ export async function renderCards(container, items, onChange) {
     ? () => performance.now()
     : () => Date.now();
 
+  const eagerGridQueue = [];
+  const eagerGridSet = new Set();
+  let eagerGridFlushHandle = 0;
+
+  function requestEagerGrid(grid) {
+    if (!grid || eagerGridSet.has(grid)) return;
+    if (eagerGridQueue.length >= 6) return;
+    eagerGridQueue.push(grid);
+    eagerGridSet.add(grid);
+    if (eagerGridFlushHandle) return;
+    eagerGridFlushHandle = scheduleFrame(() => {
+      eagerGridFlushHandle = 0;
+      while (eagerGridQueue.length) {
+        const nextGrid = eagerGridQueue.shift();
+        eagerGridSet.delete(nextGrid);
+        if (!nextGrid || nextGrid.dataset.rendered === 'true') continue;
+        if (!nextGrid.isConnected) continue;
+        ensureGridRendered(nextGrid);
+      }
+    });
+  }
+
   const deckTileObserver = typeof IntersectionObserver === 'function'
     ? new IntersectionObserver(entries => {
       entries.forEach(entry => {
@@ -344,16 +410,20 @@ export async function renderCards(container, items, onChange) {
     }
   }
 
-  function registerGrid(grid, entries) {
+  function registerGrid(grid, entries, options = {}) {
     grid.dataset.rendered = 'false';
     grid.classList.add('is-loading');
     gridPayload.set(grid, { entries, index: 0 });
+    const deferInitialRender = Boolean(options?.deferInitialRender);
+    if (!deferInitialRender) {
+      requestEagerGrid(grid);
+    }
     if (deckTileObserver) {
       requestAnimationFrame(() => {
         if (grid.dataset.rendered === 'true') return;
         deckTileObserver.observe(grid);
       });
-    } else {
+    } else if (!deferInitialRender) {
       startGridRender(grid);
     }
   }
@@ -867,6 +937,7 @@ export async function renderCards(container, items, onChange) {
   function buildBlockSection(block) {
     const section = document.createElement('section');
     section.className = 'card-block-section';
+    const blockKey = block.key;
     const firstLecture = block.weeks.find(week => week.lectures.length)?.lectures.find(lec => lec.cards.length);
     const blockAccent = block.accent || getLectureAccent(firstLecture?.cards || []);
     if (blockAccent) section.style.setProperty('--block-accent', blockAccent);
@@ -875,7 +946,8 @@ export async function renderCards(container, items, onChange) {
     const header = document.createElement('button');
     header.type = 'button';
     header.className = 'card-block-header';
-    header.setAttribute('aria-expanded', 'true');
+    const blockInitiallyCollapsed = collapsedBlockSet.has(blockKey);
+    header.setAttribute('aria-expanded', blockInitiallyCollapsed ? 'false' : 'true');
 
     const heading = document.createElement('div');
     heading.className = 'card-block-heading';
@@ -904,6 +976,12 @@ export async function renderCards(container, items, onChange) {
     const body = document.createElement('div');
     body.className = 'card-block-body';
 
+    if (blockInitiallyCollapsed) {
+      section.classList.add('is-collapsed');
+    }
+
+    const blockWeekGrids = [];
+
     block.weeks.forEach(week => {
       const weekSection = document.createElement('div');
       weekSection.className = 'card-week-section';
@@ -915,7 +993,9 @@ export async function renderCards(container, items, onChange) {
       const weekHeader = document.createElement('button');
       weekHeader.type = 'button';
       weekHeader.className = 'card-week-header';
-      weekHeader.setAttribute('aria-expanded', 'true');
+      const weekStateKey = `${blockKey}::${week.key}`;
+      const weekInitiallyCollapsed = collapsedWeekSet.has(weekStateKey);
+      weekHeader.setAttribute('aria-expanded', weekInitiallyCollapsed ? 'false' : 'true');
 
       const weekTitle = document.createElement('span');
       weekTitle.className = 'card-week-title';
@@ -931,7 +1011,15 @@ export async function renderCards(container, items, onChange) {
 
       const deckGrid = document.createElement('div');
       deckGrid.className = 'deck-grid';
-      registerGrid(deckGrid, week.lectures.map(lecture => ({ block, week, lecture })));
+      registerGrid(deckGrid, week.lectures.map(lecture => ({ block, week, lecture })), {
+        deferInitialRender: weekInitiallyCollapsed || blockInitiallyCollapsed
+      });
+
+      if (weekInitiallyCollapsed) {
+        weekSection.classList.add('is-collapsed');
+      }
+
+      blockWeekGrids.push({ grid: deckGrid, key: weekStateKey });
 
       weekSection.appendChild(weekHeader);
       weekSection.appendChild(deckGrid);
@@ -941,6 +1029,7 @@ export async function renderCards(container, items, onChange) {
       weekHeader.addEventListener('click', () => {
         const collapsed = weekSection.classList.toggle('is-collapsed');
         weekHeader.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+        setWeekCollapsedState(weekStateKey, collapsed);
         if (!collapsed) {
           ensureGridRendered(deckGrid);
         }
@@ -952,6 +1041,14 @@ export async function renderCards(container, items, onChange) {
     header.addEventListener('click', () => {
       const collapsed = section.classList.toggle('is-collapsed');
       header.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+      setBlockCollapsedState(blockKey, collapsed);
+      if (!collapsed) {
+        blockWeekGrids.forEach(({ grid, key }) => {
+          if (!collapsedWeekSet.has(key)) {
+            ensureGridRendered(grid);
+          }
+        });
+      }
     });
 
     return section;
@@ -974,8 +1071,16 @@ export async function renderCards(container, items, onChange) {
 
   function pump() {
     const start = getTime();
-    while (renderQueue.length && getTime() - start < 12) {
-      catalog.appendChild(buildBlockSection(renderQueue.shift()));
+    const frag = document.createDocumentFragment();
+    let appended = 0;
+    let elapsed = 0;
+    while (renderQueue.length && elapsed < 12) {
+      frag.appendChild(buildBlockSection(renderQueue.shift()));
+      appended += 1;
+      elapsed = getTime() - start;
+    }
+    if (appended) {
+      catalog.appendChild(frag);
     }
     if (renderQueue.length) {
       requestAnimationFrame(pump);


### PR DESCRIPTION
## Summary
- store persistent collapse metadata for the cards tab and expose a setter on the shared state
- have the cards view remember block/week collapse toggles, avoid eager work for collapsed sections, and eagerly render visible grids for faster interaction
- batch block section mounting via document fragments to smooth initial rendering

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ccef5186788322af225bf5ae61e7ee