### PR TITLE
Move deck tile fan effect to CSS and add containment hints

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -3802,34 +3802,6 @@
       icon.innerHTML = '<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 8L10 12L14 8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>';
       return icon;
     }
-    const FAN_DELAY_MS = 1e3;
-    function enableDelayedFan(tile) {
-      let fanTimer = 0;
-      const cancel = () => {
-        if (fanTimer) {
-          clearTimeout(fanTimer);
-          fanTimer = 0;
-        }
-        tile.classList.remove("is-fanned");
-      };
-      const arm = () => {
-        if (fanTimer) return;
-        fanTimer = setTimeout(() => {
-          tile.classList.add("is-fanned");
-          fanTimer = 0;
-        }, FAN_DELAY_MS);
-      };
-      tile.addEventListener("pointerenter", arm);
-      tile.addEventListener("pointerleave", cancel);
-      tile.addEventListener("pointercancel", cancel);
-      tile.addEventListener("mouseenter", arm);
-      tile.addEventListener("mouseleave", cancel);
-      tile.addEventListener("touchstart", arm, { passive: true });
-      tile.addEventListener("touchend", cancel);
-      tile.addEventListener("touchcancel", cancel);
-      tile.addEventListener("focus", arm);
-      tile.addEventListener("blur", cancel);
-    }
     function createDeckTile(block, week, lecture) {
       const tile = document.createElement("button");
       tile.type = "button";
@@ -3887,7 +3859,6 @@
           open();
         }
       });
-      enableDelayedFan(tile);
       return tile;
     }
     function createMetaChip(text, icon) {

--- a/js/ui/components/cards.js
+++ b/js/ui/components/cards.js
@@ -663,36 +663,6 @@ export async function renderCards(container, items, onChange) {
     return icon;
   }
 
-  const FAN_DELAY_MS = 1000;
-
-  function enableDelayedFan(tile) {
-    let fanTimer = 0;
-    const cancel = () => {
-      if (fanTimer) {
-        clearTimeout(fanTimer);
-        fanTimer = 0;
-      }
-      tile.classList.remove('is-fanned');
-    };
-    const arm = () => {
-      if (fanTimer) return;
-      fanTimer = setTimeout(() => {
-        tile.classList.add('is-fanned');
-        fanTimer = 0;
-      }, FAN_DELAY_MS);
-    };
-    tile.addEventListener('pointerenter', arm);
-    tile.addEventListener('pointerleave', cancel);
-    tile.addEventListener('pointercancel', cancel);
-    tile.addEventListener('mouseenter', arm);
-    tile.addEventListener('mouseleave', cancel);
-    tile.addEventListener('touchstart', arm, { passive: true });
-    tile.addEventListener('touchend', cancel);
-    tile.addEventListener('touchcancel', cancel);
-    tile.addEventListener('focus', arm);
-    tile.addEventListener('blur', cancel);
-  }
-
   function createDeckTile(block, week, lecture) {
     const tile = document.createElement('button');
     tile.type = 'button';
@@ -762,8 +732,6 @@ export async function renderCards(container, items, onChange) {
         open();
       }
     });
-
-    enableDelayedFan(tile);
 
     return tile;
   }

--- a/style.css
+++ b/style.css
@@ -2457,6 +2457,9 @@ input[type="checkbox"]:checked::after {
   overflow: hidden;
   min-height: clamp(260px, 30vw, 330px);
   transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1), box-shadow 0.3s ease, border-color 0.3s ease;
+  content-visibility: auto;
+  contain: layout paint style;
+  contain-intrinsic-size: auto 320px;
 }
 
 .deck-tile::before {
@@ -2520,6 +2523,7 @@ input[type="checkbox"]:checked::after {
   box-shadow: 0 16px 32px rgba(2, 6, 23, 0.28);
   opacity: calc(1 - (var(--index) * 0.12));
   transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1), box-shadow 0.4s ease, opacity 0.4s ease, filter 0.4s ease;
+  transition-delay: 0s, 0s, 0s, 0s;
   overflow: hidden;
 }
 
@@ -2541,12 +2545,13 @@ input[type="checkbox"]:checked::after {
   color: var(--text-muted);
 }
 
-.deck-tile.is-fanned .stack-card {
+.deck-tile:is(:hover, :focus-visible) .stack-card {
 
   transform: rotate(calc((var(--index) - var(--spread, 0)) * 6deg)) translateX(calc((var(--index) - var(--spread, 0)) * 24px)) translateY(calc(var(--index) * -6px)) translateZ(calc(var(--index) * 32px));
   box-shadow: 0 26px 52px rgba(2, 6, 23, 0.46);
   filter: saturate(1.1) brightness(1.05);
 
+  transition-delay: 1s, 1s, 1s, 1s;
 }
 
 .deck-info {


### PR DESCRIPTION
## Summary
- remove per-tile timer/event handlers for the deck fan-out effect
- recreate the delayed fan animation purely with CSS hover/focus rules
- add content-visibility containment hints so offscreen tiles avoid layout/paint work

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ccf6bc88c083228d226bc67e14e88f