### PR TITLE
Improve study builder selection highlighting

### DIFF
--- a/js/ui/components/builder.js
+++ b/js/ui/components/builder.js
@@ -48,12 +48,13 @@ function renderBlockPanel(block, rerender) {
     return (a.name || '').localeCompare(b.name || '');
   });
   const weeks = groupByWeek(lectures);
-  const hasSelections = hasBlockSelection(blockId);
+  const hasLectureSelection = hasAnyLectureSelected(blockId, lectures);
+  const blockFullySelected = isBlockFullySelected(block, lectures);
   const blockCollapsed = isBlockCollapsed(blockId);
 
   const card = document.createElement('div');
   card.className = 'card builder-block-card';
-  if (hasSelections) card.classList.add('active');
+  if (blockFullySelected) card.classList.add('active');
   if (blockCollapsed) card.classList.add('is-collapsed');
 
   const header = document.createElement('div');
@@ -99,7 +100,7 @@ function renderBlockPanel(block, rerender) {
     actions.appendChild(allBtn);
   }
 
-  if (hasSelections) {
+  if (hasLectureSelection || blockFullySelected) {
     const clearBtn = createAction('Clear block', () => {
       clearBlock(blockId);
       rerender();
@@ -140,6 +141,7 @@ function renderWeek(block, week, lectures, rerender) {
   const weekCollapsed = isWeekCollapsed(blockId, week);
   const row = document.createElement('div');
   row.className = 'builder-week-card';
+  if (hasAnyLectureSelected(blockId, lectures)) row.classList.add('is-active');
   if (weekCollapsed) row.classList.add('is-collapsed');
 
   const header = document.createElement('div');
@@ -265,9 +267,11 @@ function renderSummaryCard(rerender) {
 
   const selectionMeta = document.createElement('div');
   selectionMeta.className = 'builder-selection-meta';
+  const blockCount = countSelectedBlocks();
+  const lectureCount = state.builder.lectures.length;
   selectionMeta.innerHTML = `
-    <span>Blocks: ${state.builder.blocks.length}</span>
-    <span>Lectures: ${state.builder.lectures.length}</span>
+    <span>Blocks: ${blockCount}</span>
+    <span>Lectures: ${lectureCount}</span>
   `;
   card.appendChild(selectionMeta);
 
@@ -355,7 +359,7 @@ function selectEntireBlock(block) {
     (block.lectures || []).forEach(lecture => {
       lectureSet.add(lectureKeyFor(blockId, lecture.id));
     });
-    syncBlockWithLectureSelection(blockSet, lectureSet, blockId);
+    syncBlockWithLectureSelection(blockSet, lectureSet, block);
   } else {
     blockSet.add(blockId);
   }
@@ -390,7 +394,7 @@ function selectWeek(block, week) {
       lectureSet.add(lectureKeyFor(blockId, lecture.id));
     }
   });
-  syncBlockWithLectureSelection(blockSet, lectureSet, blockId);
+  syncBlockWithLectureSelection(blockSet, lectureSet, block);
   setBuilder({
     lectures: Array.from(lectureSet),
     blocks: Array.from(blockSet),
@@ -407,7 +411,7 @@ function clearWeek(block, week) {
       lectureSet.delete(lectureKeyFor(blockId, lecture.id));
     }
   });
-  syncBlockWithLectureSelection(blockSet, lectureSet, blockId);
+  syncBlockWithLectureSelection(blockSet, lectureSet, block);
   setBuilder({
     lectures: Array.from(lectureSet),
     blocks: Array.from(blockSet),
@@ -424,7 +428,7 @@ function toggleLecture(block, lecture) {
   } else {
     lectureSet.add(key);
   }
-  syncBlockWithLectureSelection(blockSet, lectureSet, block.blockId);
+  syncBlockWithLectureSelection(blockSet, lectureSet, block);
   setBuilder({
     lectures: Array.from(lectureSet),
     blocks: Array.from(blockSet),
@@ -467,13 +471,25 @@ function toggleWeekCollapsed(blockId, week) {
   setBuilder({ collapsedWeeks: Array.from(collapsed) });
 }
 
-function hasBlockSelection(blockId) {
-  return state.builder.blocks.includes(blockId)
-    || state.builder.lectures.some(key => key.startsWith(`${blockId}|`));
+function isBlockFullySelected(block, lectures) {
+  if (!block) return false;
+  const blockId = block.blockId;
+  if (!state.builder.blocks.includes(blockId)) return false;
+  if (!lectures?.length) return true;
+  return areAllLecturesSelected(blockId, lectures);
 }
 
 function hasAnySelection() {
   return state.builder.blocks.length || state.builder.lectures.length;
+}
+
+function countSelectedBlocks() {
+  const blockSet = new Set(state.builder.blocks);
+  for (const key of state.builder.lectures) {
+    const [blockId] = key.split('|');
+    if (blockId) blockSet.add(blockId);
+  }
+  return blockSet.size;
 }
 
 function groupByWeek(lectures) {
@@ -513,7 +529,9 @@ function areAllLecturesSelected(blockId, lectures) {
   return lectures.every(lecture => lectureSet.has(lectureKeyFor(blockId, lecture.id)));
 }
 
-function syncBlockWithLectureSelection(blockSet, lectureSet, blockId) {
+function syncBlockWithLectureSelection(blockSet, lectureSet, block) {
+  if (!block) return;
+  const blockId = block.blockId;
   const prefix = `${blockId}|`;
   let hasLecture = false;
   for (const key of lectureSet) {
@@ -522,7 +540,17 @@ function syncBlockWithLectureSelection(blockSet, lectureSet, blockId) {
       break;
     }
   }
-  if (hasLecture) {
+  if (!hasLecture) {
+    blockSet.delete(blockId);
+    return;
+  }
+  const blockLectures = Array.isArray(block.lectures) ? block.lectures : [];
+  if (!blockLectures.length) {
+    blockSet.add(blockId);
+    return;
+  }
+  const allSelected = blockLectures.every(lecture => lectureSet.has(lectureKeyFor(blockId, lecture.id)));
+  if (allSelected) {
     blockSet.add(blockId);
   } else {
     blockSet.delete(blockId);

--- a/style.css
+++ b/style.css
@@ -1517,6 +1517,12 @@ input[type="checkbox"]:checked::after {
   gap: var(--pad-sm);
 }
 
+.builder-week-card.is-active .builder-week-title {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.95), rgba(56, 189, 248, 0.9));
+  color: #041021;
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.45);
+}
+
 .builder-week-card.is-collapsed .builder-lecture-list {
   display: none;
 }
@@ -1632,8 +1638,10 @@ input[type="checkbox"]:checked::after {
 }
 
 .builder-pill-lecture.active {
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.96), rgba(56, 189, 248, 0.92));
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.98), rgba(56, 189, 248, 0.95));
+  border-color: rgba(37, 99, 235, 0.75);
   color: #041021;
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.4);
 }
 
 .builder-pill-small {


### PR DESCRIPTION
## Summary
- adjust study builder logic so lecture selections highlight week headers while full block selections glow the entire card
- ensure block counts include partially selected blocks and only apply block-level glow when the entire block is chosen
- refresh styles for lecture pills and week headers to provide clearer visual feedback when selected

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd911e38fc8322ac34234957d00860