### PR TITLE
Refresh builder toggles with pastel gradients

### DIFF
--- a/js/ui/components/builder.js
+++ b/js/ui/components/builder.js
@@ -104,7 +104,7 @@ function renderBlockPanel(block, rerender) {
     const clearBtn = createAction('Clear block', () => {
       clearBlock(blockId);
       rerender();
-    });
+    }, 'danger');
     actions.appendChild(clearBtn);
   }
 
@@ -176,7 +176,7 @@ function renderWeek(block, week, lectures, rerender) {
   const clearBtn = createAction('Clear', () => {
     clearWeek(block, week);
     rerender();
-  });
+  }, 'danger');
 
   if (areAllLecturesSelected(blockId, lectures)) {
     allBtn.disabled = true;
@@ -294,7 +294,7 @@ function renderSummaryCard(rerender) {
 
   const clearBtn = document.createElement('button');
   clearBtn.type = 'button';
-  clearBtn.className = 'btn secondary';
+  clearBtn.className = 'btn secondary builder-clear-btn';
   clearBtn.textContent = 'Clear selection';
   clearBtn.disabled = !hasAnySelection();
   clearBtn.addEventListener('click', () => {
@@ -571,10 +571,14 @@ function createPill(active, label, onClick, variant = '') {
   return btn;
 }
 
-function createAction(label, onClick) {
+function createAction(label, onClick, variant = '') {
   const btn = document.createElement('button');
   btn.type = 'button';
   btn.className = 'builder-action';
+  if (variant) {
+    const variants = Array.isArray(variant) ? variant : variant.split(' ');
+    variants.filter(Boolean).forEach(name => btn.classList.add(`builder-action-${name}`));
+  }
   btn.textContent = label;
   btn.addEventListener('click', onClick);
   return btn;

--- a/style.css
+++ b/style.css
@@ -690,6 +690,30 @@ input[type="checkbox"]:checked::after {
   border: 1px solid var(--border-strong);
   box-shadow: none;
 }
+
+.btn.secondary.builder-clear-btn {
+  background: linear-gradient(135deg, rgba(254, 226, 226, 0.94), rgba(252, 165, 165, 0.82));
+  color: #2e0d14;
+  border-color: transparent;
+  box-shadow: 0 16px 32px rgba(120, 10, 32, 0.28);
+}
+
+.btn.secondary.builder-clear-btn:hover {
+  background: linear-gradient(135deg, rgba(255, 241, 241, 0.96), rgba(252, 165, 165, 0.86));
+  color: #1f050b;
+  box-shadow: 0 20px 36px rgba(120, 10, 32, 0.32);
+}
+
+.btn.secondary.builder-clear-btn:active {
+  box-shadow: 0 12px 24px rgba(120, 10, 32, 0.26);
+}
+
+.btn.secondary.builder-clear-btn:disabled {
+  background: rgba(252, 165, 165, 0.18);
+  color: rgba(252, 165, 165, 0.55);
+  box-shadow: none;
+  border-color: rgba(252, 165, 165, 0.28);
+}
 .btn.subtle {
   background: var(--muted);
   color: var(--text);
@@ -951,15 +975,21 @@ input[type="checkbox"]:checked::after {
 }
 
 .tag-chip-lecture {
-  background: rgba(134, 239, 172, 0.18);
-  border-color: rgba(134, 239, 172, 0.35);
+  background: rgba(191, 219, 254, 0.18);
+  border-color: rgba(191, 219, 254, 0.35);
   font-size: 0.85rem;
 }
 
 .tag-chip-lecture.active {
-  background: linear-gradient(135deg, rgba(134, 239, 172, 0.96), rgba(59, 130, 246, 0.9));
-  color: #041021;
+  background: linear-gradient(135deg, rgba(191, 219, 254, 0.98), rgba(221, 214, 254, 0.96));
+  color: #0b162d;
   font-weight: 700;
+}
+
+.tag-chip-lecture.active:hover,
+.tag-chip-lecture.active:focus-visible {
+  background: linear-gradient(135deg, rgba(224, 231, 255, 0.98), rgba(199, 210, 254, 0.96));
+  color: #071023;
 }
 
 .editor-extras {
@@ -1625,23 +1655,35 @@ input[type="checkbox"]:checked::after {
 }
 
 .builder-pill.active {
-  background: linear-gradient(135deg, rgba(56, 189, 248, 0.92), rgba(14, 165, 233, 0.9));
-  color: #041021;
+  background: linear-gradient(135deg, rgba(125, 211, 252, 0.95), rgba(199, 210, 254, 0.92));
+  color: #0b162d;
   border-color: transparent;
-  box-shadow: 0 12px 24px rgba(2, 6, 23, 0.3);
+  box-shadow: 0 14px 26px rgba(2, 6, 23, 0.32);
+}
+
+.builder-pill.active:hover,
+.builder-pill.active:focus-visible {
+  background: linear-gradient(135deg, rgba(148, 226, 255, 0.98), rgba(221, 214, 254, 0.96));
+  color: #061024;
 }
 
 .builder-pill-lecture {
-  background: rgba(59, 130, 246, 0.12);
-  border-color: rgba(59, 130, 246, 0.28);
+  background: rgba(165, 180, 252, 0.16);
+  border-color: rgba(165, 180, 252, 0.32);
   font-size: 0.9rem;
 }
 
 .builder-pill-lecture.active {
-  background: linear-gradient(135deg, rgba(37, 99, 235, 0.98), rgba(56, 189, 248, 0.95));
-  border-color: rgba(37, 99, 235, 0.75);
-  color: #041021;
-  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.4);
+  background: linear-gradient(135deg, rgba(191, 219, 254, 0.98), rgba(224, 231, 255, 0.96));
+  border-color: transparent;
+  color: #0a1530;
+  box-shadow: 0 10px 22px rgba(15, 23, 42, 0.38);
+}
+
+.builder-pill-lecture.active:hover,
+.builder-pill-lecture.active:focus-visible {
+  background: linear-gradient(135deg, rgba(221, 231, 255, 0.99), rgba(210, 221, 255, 0.97));
+  color: #050d1f;
 }
 
 .builder-pill-small {
@@ -1669,12 +1711,33 @@ input[type="checkbox"]:checked::after {
   color: #fff;
 }
 
+.builder-action-danger {
+  background: linear-gradient(135deg, rgba(254, 226, 226, 0.92), rgba(252, 165, 165, 0.85));
+  border: 1px solid rgba(252, 165, 165, 0.45);
+  color: #2e0d14;
+  padding: 4px 10px;
+  box-shadow: 0 10px 20px rgba(120, 10, 32, 0.26);
+}
+
+.builder-action-danger:hover,
+.builder-action-danger:focus-visible {
+  background: linear-gradient(135deg, rgba(255, 241, 241, 0.95), rgba(252, 165, 165, 0.88));
+  color: #1f050b;
+}
+
 .builder-action[disabled] {
   opacity: 0.5;
   cursor: not-allowed;
   background: none;
   color: var(--gray);
   pointer-events: none;
+}
+
+.builder-action-danger[disabled] {
+  background: rgba(252, 165, 165, 0.12);
+  border-color: rgba(252, 165, 165, 0.22);
+  color: rgba(252, 165, 165, 0.55);
+  box-shadow: none;
 }
 
 .builder-week-title {


### PR DESCRIPTION
## Summary
- restyle builder filter pills to use a blue-purple gradient when active, matching the study subtabs
- update lecture chips and pills with a lighter pastel gradient and hover cues so selections stand out
- give builder clear actions a pastel red treatment, including the clear selection button and clear links

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd939854d48322b8478742fcb86c14