### PR TITLE
Implement spaced review scheduling and flashcard ratings

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -186,12 +186,12 @@ async function render() {
           startBtn.className = 'btn';
           startBtn.textContent = 'Start Flashcards';
           startBtn.addEventListener('click', () => {
-            setFlashSession({ idx: 0, pool: state.cohort });
+            setFlashSession({ idx: 0, pool: state.cohort, ratings: {}, mode: 'study' });
             render();
           });
           content.appendChild(startBtn);
         } else if (state.subtab.Study === 'Review') {
-          renderReview(content, render);
+          await renderReview(content, render);
         } else if (state.subtab.Study === 'Quiz') {
           const startBtn = document.createElement('button');
           startBtn.className = 'btn';

--- a/js/review/constants.js
+++ b/js/review/constants.js
@@ -1,0 +1,10 @@
+export const REVIEW_RATINGS = ['again', 'hard', 'good', 'easy'];
+export const RETIRE_RATING = 'retire';
+
+// Stored as minutes to keep persistence compact.
+export const DEFAULT_REVIEW_STEPS = {
+  again: 10,
+  hard: 60,
+  good: 720,
+  easy: 2160
+};

--- a/js/review/settings.js
+++ b/js/review/settings.js
@@ -1,0 +1,14 @@
+import { DEFAULT_REVIEW_STEPS, REVIEW_RATINGS } from './constants.js';
+
+export function normalizeReviewSteps(raw) {
+  const normalized = { ...DEFAULT_REVIEW_STEPS };
+  if (!raw || typeof raw !== 'object') return normalized;
+  for (const key of REVIEW_RATINGS) {
+    const value = raw[key];
+    const num = Number(value);
+    if (Number.isFinite(num) && num > 0) {
+      normalized[key] = num;
+    }
+  }
+  return normalized;
+}

--- a/js/review/sr-data.js
+++ b/js/review/sr-data.js
@@ -1,0 +1,48 @@
+import { REVIEW_RATINGS, RETIRE_RATING } from './constants.js';
+
+export const SR_VERSION = 2;
+
+function sanitizeNumber(value, fallback = 0) {
+  const num = Number(value);
+  if (!Number.isFinite(num) || num < 0) return fallback;
+  return num;
+}
+
+export function defaultSectionState() {
+  return {
+    streak: 0,
+    lastRating: null,
+    last: 0,
+    due: 0,
+    retired: false
+  };
+}
+
+export function normalizeSectionRecord(record) {
+  const base = defaultSectionState();
+  if (!record || typeof record !== 'object') return base;
+  if (typeof record.streak === 'number' && Number.isFinite(record.streak) && record.streak > 0) {
+    base.streak = Math.max(0, Math.round(record.streak));
+  }
+  if (typeof record.lastRating === 'string') {
+    const rating = record.lastRating;
+    if (REVIEW_RATINGS.includes(rating) || rating === RETIRE_RATING) {
+      base.lastRating = rating;
+    }
+  }
+  base.last = sanitizeNumber(record.last, 0);
+  base.due = sanitizeNumber(record.due, 0);
+  base.retired = Boolean(record.retired);
+  return base;
+}
+
+export function normalizeSrRecord(sr) {
+  const normalized = { version: SR_VERSION, sections: {} };
+  if (!sr || typeof sr !== 'object') return normalized;
+  const sections = sr.sections && typeof sr.sections === 'object' ? sr.sections : {};
+  for (const [key, value] of Object.entries(sections)) {
+    if (!key) continue;
+    normalized.sections[key] = normalizeSectionRecord(value);
+  }
+  return normalized;
+}

--- a/js/types.js
+++ b/js/types.js
@@ -1,7 +1,8 @@
 /** @typedef {"disease"|"drug"|"concept"} Kind */
 /** @typedef {"assoc"|"treats"|"causes"|"mech"|"contra"} LinkType */
 
-/** @typedef {{ box:number, last:number, due:number, ease:number }} SR */
+/** @typedef {{ streak:number, lastRating:string|null, last:number, due:number, retired:boolean }} SectionSR */
+/** @typedef {{ version:number, sections:Record<string, SectionSR> }} SR */
 
 /** @typedef {{ blockId:string, id:number, name:string, week:number }} LectureRef */
 

--- a/js/ui/components/flashcards.js
+++ b/js/ui/components/flashcards.js
@@ -1,12 +1,41 @@
 import { state, setFlashSession } from '../../state.js';
 import { setToggleState } from '../../utils.js';
-import { sectionDefsForKind } from './sections.js';
 import { renderRichText } from './rich-text.js';
+import { sectionsForItem } from './section-utils.js';
+import { REVIEW_RATINGS, RETIRE_RATING, DEFAULT_REVIEW_STEPS } from '../../review/constants.js';
+import { getReviewDurations, rateSection } from '../../review/scheduler.js';
+import { upsertItem } from '../../storage/storage.js';
 
-// Render flashcards session. Uses session.pool if provided, else state.cohort
+const RATING_LABELS = {
+  again: 'Again',
+  hard: 'Hard',
+  good: 'Good',
+  easy: 'Easy',
+  [RETIRE_RATING]: 'Retire'
+};
+
+const RATING_CLASS = {
+  again: 'danger',
+  hard: 'secondary',
+  good: '',
+  easy: '',
+  [RETIRE_RATING]: 'secondary'
+};
+
+function ratingKey(item, sectionKey) {
+  const id = item?.id || 'item';
+  return `${id}::${sectionKey}`;
+}
+
+function sessionEntryAt(session, idx) {
+  const pool = Array.isArray(session.pool) ? session.pool : [];
+  return pool[idx] || null;
+}
+
 export function renderFlashcards(root, redraw) {
-  const session = state.flashSession || { idx: 0, pool: state.cohort };
-  const items = session.pool || state.cohort;
+  const active = state.flashSession || { idx: 0, pool: state.cohort, ratings: {}, mode: 'study' };
+  active.ratings = active.ratings || {};
+  const items = Array.isArray(active.pool) && active.pool.length ? active.pool : state.cohort;
   root.innerHTML = '';
 
   if (!items.length) {
@@ -16,13 +45,22 @@ export function renderFlashcards(root, redraw) {
     return;
   }
 
-  if (session.idx >= items.length) {
+  if (active.idx >= items.length) {
     setFlashSession(null);
     redraw();
     return;
   }
 
-  const item = items[session.idx];
+  const entry = sessionEntryAt(active, active.idx);
+  const item = entry && entry.item ? entry.item : entry;
+  if (!item) {
+    setFlashSession(null);
+    redraw();
+    return;
+  }
+
+  const allowedSections = entry && entry.sections ? entry.sections : null;
+  const sections = sectionsForItem(item, allowedSections);
 
   const card = document.createElement('section');
   card.className = 'card flashcard';
@@ -32,44 +70,144 @@ export function renderFlashcards(root, redraw) {
   title.textContent = item.name || item.concept || '';
   card.appendChild(title);
 
-  sectionsFor(item).forEach(([label, field]) => {
+  const durationsPromise = getReviewDurations().catch(() => ({ ...DEFAULT_REVIEW_STEPS }));
+  const ratedSections = new Map();
+
+  const sectionBlocks = sections.length ? sections : [];
+  if (!sectionBlocks.length) {
+    const empty = document.createElement('div');
+    empty.className = 'flash-empty';
+    empty.textContent = 'No content available for this card.';
+    card.appendChild(empty);
+  }
+
+  sectionBlocks.forEach(({ key, label }) => {
+    const ratingId = ratingKey(item, key);
+    const previousRating = active.ratings[ratingId] || null;
+    if (previousRating) {
+      ratedSections.set(key, previousRating);
+    }
+
     const sec = document.createElement('div');
     sec.className = 'flash-section';
     sec.setAttribute('role', 'button');
     sec.tabIndex = 0;
+
     const head = document.createElement('div');
     head.className = 'flash-heading';
     head.textContent = label;
+
     const body = document.createElement('div');
     body.className = 'flash-body';
-    renderRichText(body, item[field] || '');
-    sec.appendChild(head);
-    sec.appendChild(body);
+    renderRichText(body, item[key] || '');
+
+    const ratingRow = document.createElement('div');
+    ratingRow.className = 'flash-rating';
+
+    const ratingButtons = document.createElement('div');
+    ratingButtons.className = 'flash-rating-options';
+
+    const status = document.createElement('span');
+    status.className = 'flash-rating-status';
+
+    const selectRating = (value) => {
+      ratedSections.set(key, value);
+      active.ratings[ratingId] = value;
+      Array.from(ratingButtons.querySelectorAll('button')).forEach(btn => {
+        const btnValue = btn.dataset.value;
+        const isSelected = btnValue === value;
+        btn.classList.toggle('is-selected', isSelected);
+        if (isSelected) {
+          btn.setAttribute('aria-pressed', 'true');
+        } else {
+          btn.setAttribute('aria-pressed', 'false');
+        }
+      });
+      updateNextState();
+    };
+
+    const handleRating = async (value) => {
+      const durations = await durationsPromise;
+      setToggleState(sec, true, 'revealed');
+      ratingRow.classList.add('is-saving');
+      status.textContent = 'Saving…';
+      status.classList.remove('is-error');
+      try {
+        rateSection(item, key, value, durations, Date.now());
+        await upsertItem(item);
+        selectRating(value);
+        status.textContent = value === RETIRE_RATING ? 'Retired' : 'Saved';
+      } catch (err) {
+        console.error('Failed to record rating', err);
+        status.textContent = 'Save failed';
+        status.classList.add('is-error');
+      } finally {
+        ratingRow.classList.remove('is-saving');
+      }
+    };
+
+    [...REVIEW_RATINGS, RETIRE_RATING].forEach(value => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.dataset.value = value;
+      btn.className = 'btn flash-rating-btn';
+      const variant = RATING_CLASS[value];
+      if (variant) btn.classList.add(variant);
+      btn.textContent = RATING_LABELS[value];
+      btn.setAttribute('aria-pressed', 'false');
+      btn.addEventListener('click', (event) => {
+        event.stopPropagation();
+        handleRating(value);
+      });
+      btn.addEventListener('keydown', (event) => {
+        event.stopPropagation();
+      });
+      ratingButtons.appendChild(btn);
+    });
+
+    if (previousRating) {
+      selectRating(previousRating);
+      status.textContent = previousRating === RETIRE_RATING ? 'Retired' : 'Saved';
+    }
+
+    ratingRow.appendChild(ratingButtons);
+    ratingRow.appendChild(status);
+
     setToggleState(sec, false, 'revealed');
     const toggleReveal = () => {
+      if (sec.classList.contains('flash-section-disabled')) return;
+      if (sec.contains(document.activeElement) && document.activeElement?.tagName === 'BUTTON') return;
       const next = sec.dataset.active !== 'true';
       setToggleState(sec, next, 'revealed');
     };
-    sec.addEventListener('click', toggleReveal);
+    sec.addEventListener('click', (event) => {
+      if (event.target instanceof HTMLElement && event.target.closest('.flash-rating')) return;
+      toggleReveal();
+    });
     sec.addEventListener('keydown', (e) => {
+      if (e.target instanceof HTMLElement && e.target.closest('.flash-rating')) return;
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
         toggleReveal();
       }
     });
+
+    sec.appendChild(head);
+    sec.appendChild(body);
+    sec.appendChild(ratingRow);
     card.appendChild(sec);
   });
 
   const controls = document.createElement('div');
-  controls.className = 'row';
+  controls.className = 'row flash-controls';
 
   const prev = document.createElement('button');
   prev.className = 'btn';
   prev.textContent = 'Prev';
-  prev.disabled = session.idx === 0;
+  prev.disabled = active.idx === 0;
   prev.addEventListener('click', () => {
-    if (session.idx > 0) {
-      setFlashSession({ idx: session.idx - 1, pool: items });
+    if (active.idx > 0) {
+      setFlashSession({ idx: active.idx - 1, pool: items, ratings: active.ratings, mode: active.mode });
       redraw();
     }
   });
@@ -77,20 +215,23 @@ export function renderFlashcards(root, redraw) {
 
   const next = document.createElement('button');
   next.className = 'btn';
-  next.textContent = session.idx < items.length - 1 ? 'Next' : 'Finish';
+  const isLast = active.idx >= items.length - 1;
+  const isReview = active.mode === 'review';
+  next.textContent = isLast ? (isReview ? 'Finish review' : 'Finish') : 'Next';
+  next.disabled = sectionBlocks.length > 0;
   next.addEventListener('click', () => {
-    const idx = session.idx + 1;
+    const idx = active.idx + 1;
     if (idx >= items.length) {
       setFlashSession(null);
     } else {
-      setFlashSession({ idx, pool: items });
+      setFlashSession({ idx, pool: items, ratings: active.ratings, mode: active.mode });
     }
     redraw();
   });
   controls.appendChild(next);
 
   const exit = document.createElement('button');
-  exit.className = 'btn';
+  exit.className = 'btn secondary';
   exit.textContent = 'End';
   exit.addEventListener('click', () => {
     setFlashSession(null);
@@ -109,8 +250,15 @@ export function renderFlashcards(root, redraw) {
       prev.click();
     }
   });
-}
 
-function sectionsFor(item) {
-  return sectionDefsForKind(item.kind).map(def => [def.label, def.key]);
+  updateNextState();
+
+  function updateNextState() {
+    if (!sectionBlocks.length) {
+      next.disabled = false;
+      return;
+    }
+    const allRated = sectionBlocks.every(sec => ratedSections.get(sec.key));
+    next.disabled = !allRated;
+  }
 }

--- a/js/ui/components/review.js
+++ b/js/ui/components/review.js
@@ -1,77 +1,226 @@
-import { state, setReviewConfig, setFlashSession, setQuizSession } from '../../state.js';
+import { state, setFlashSession } from '../../state.js';
+import { collectDueSections } from '../../review/scheduler.js';
+import { listBlocks } from '../../storage/storage.js';
+import { getSectionLabel } from './section-utils.js';
 
-// Render Review mode controls
-export function renderReview(root, redraw) {
-  const cfg = state.review;
-  const section = document.createElement('section');
-  section.className = 'review-controls';
+const REVIEW_SCOPES = ['all', 'blocks', 'lectures'];
+let activeScope = 'all';
+let blockTitleCache = null;
 
-  const countLabel = document.createElement('label');
-  countLabel.textContent = 'Count:';
-  const countInput = document.createElement('input');
-  countInput.type = 'number';
-  countInput.min = '1';
-  countInput.value = cfg.count;
-  countInput.addEventListener('change', () => setReviewConfig({ count: Number(countInput.value) }));
-  countLabel.appendChild(countInput);
-  section.appendChild(countLabel);
-
-  const formatLabel = document.createElement('label');
-  formatLabel.textContent = 'Format:';
-  const formatSel = document.createElement('select');
-  ['flashcards','quiz'].forEach(f => {
-    const opt = document.createElement('option');
-    opt.value = f; opt.textContent = f;
-    if (cfg.format === f) opt.selected = true;
-    formatSel.appendChild(opt);
+function ensureBlockTitleMap(blocks) {
+  if (blockTitleCache) return blockTitleCache;
+  const map = new Map();
+  blocks.forEach(block => {
+    if (!block || !block.blockId) return;
+    map.set(block.blockId, block.title || block.blockId);
   });
-  formatSel.addEventListener('change', () => setReviewConfig({ format: formatSel.value }));
-  formatLabel.appendChild(formatSel);
-  section.appendChild(formatLabel);
-
-  const startBtn = document.createElement('button');
-  startBtn.className = 'btn';
-  startBtn.textContent = 'Start Review';
-  startBtn.addEventListener('click', () => {
-    const items = sampleItems(state.cohort, cfg.count);
-    if (!items.length) return;
-    if (cfg.format === 'flashcards') {
-      setFlashSession({ idx: 0, pool: items });
-    } else {
-      setQuizSession({ idx:0, score:0, pool: items });
-    }
-    redraw();
-  });
-  section.appendChild(startBtn);
-
-  root.appendChild(section);
+  blockTitleCache = map;
+  return map;
 }
 
-function sampleItems(cohort, count) {
-  const sorted = [...cohort].sort((a,b) => {
-    const ad = (a.sr && a.sr.due) || a.updatedAt || 0;
-    const bd = (b.sr && b.sr.due) || b.updatedAt || 0;
-    return ad - bd;
+function titleOf(item) {
+  return item?.name || item?.concept || 'Untitled';
+}
+
+function formatOverdue(due, now) {
+  const diffMs = Math.max(0, now - due);
+  if (diffMs < 60 * 1000) return 'due now';
+  const minutes = Math.round(diffMs / (60 * 1000));
+  if (minutes < 60) return `${minutes} min overdue`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours} hr overdue`;
+  const days = Math.round(hours / 24);
+  return `${days} day${days === 1 ? '' : 's'} overdue`;
+}
+
+function groupByBlock(entries, blockTitles) {
+  const groups = new Map();
+  entries.forEach(entry => {
+    const blocks = Array.isArray(entry.item.blocks) && entry.item.blocks.length
+      ? entry.item.blocks
+      : ['__unassigned'];
+    blocks.forEach(blockId => {
+      const group = groups.get(blockId) || { id: blockId, entries: [] };
+      group.entries.push(entry);
+      groups.set(blockId, group);
+    });
   });
-  if (sorted.length <= count) return sorted;
-  const third = Math.ceil(sorted.length / 3);
-  const oldest = sorted.slice(0, third);
-  const middle = sorted.slice(third, third*2);
-  const newest = sorted.slice(third*2);
-  const take = (arr, n) => {
-    const out = [];
-    for (let i=0; i<n && arr.length; i++) {
-      const idx = Math.floor(Math.random()*arr.length);
-      out.push(arr.splice(idx,1)[0]);
-    }
-    return out;
+  return Array.from(groups.values()).map(group => ({
+    id: group.id,
+    title: group.id === '__unassigned' ? 'Unassigned' : (blockTitles.get(group.id) || group.id),
+    entries: group.entries
+  })).sort((a, b) => b.entries.length - a.entries.length);
+}
+
+function groupByLecture(entries, blockTitles) {
+  const groups = new Map();
+  entries.forEach(entry => {
+    const lectures = Array.isArray(entry.item.lectures) && entry.item.lectures.length
+      ? entry.item.lectures
+      : [{ blockId: '__unassigned', id: '__none', name: 'Unassigned lecture' }];
+    lectures.forEach(lec => {
+      const key = `${lec.blockId || '__unassigned'}::${lec.id}`;
+      const blockTitle = blockTitles.get(lec.blockId) || lec.blockId || 'Unassigned';
+      const title = lec.name ? `${blockTitle} – ${lec.name}` : `${blockTitle} – Lecture ${lec.id}`;
+      const group = groups.get(key) || { id: key, title, entries: [] };
+      group.entries.push(entry);
+      groups.set(key, group);
+    });
+  });
+  return Array.from(groups.values()).sort((a, b) => b.entries.length - a.entries.length);
+}
+
+function buildSessionPayload(entries) {
+  return entries.map(entry => ({ item: entry.item, sections: [entry.sectionKey] }));
+}
+
+function renderEmptyState(container) {
+  const empty = document.createElement('div');
+  empty.className = 'review-empty';
+  empty.textContent = 'No cards are due right now. Nice work!';
+  container.appendChild(empty);
+}
+
+function renderAllView(container, entries, now, start) {
+  const actionRow = document.createElement('div');
+  actionRow.className = 'review-actions';
+  const startBtn = document.createElement('button');
+  startBtn.className = 'btn';
+  startBtn.textContent = `Start review (${entries.length})`;
+  startBtn.disabled = entries.length === 0;
+  startBtn.addEventListener('click', () => {
+    if (!entries.length) return;
+    start(buildSessionPayload(entries));
+  });
+  actionRow.appendChild(startBtn);
+  container.appendChild(actionRow);
+
+  if (!entries.length) {
+    renderEmptyState(container);
+    return;
+  }
+
+  const list = document.createElement('ul');
+  list.className = 'review-entry-list';
+  entries.forEach(entry => {
+    const item = document.createElement('li');
+    item.className = 'review-entry';
+    const title = document.createElement('div');
+    title.className = 'review-entry-title';
+    title.textContent = titleOf(entry.item);
+    const meta = document.createElement('div');
+    meta.className = 'review-entry-meta';
+    meta.textContent = `${getSectionLabel(entry.item, entry.sectionKey)} • ${formatOverdue(entry.due, now)}`;
+    item.appendChild(title);
+    item.appendChild(meta);
+    list.appendChild(item);
+  });
+  container.appendChild(list);
+}
+
+function renderGroupView(container, groups, label, start) {
+  if (!groups.length) {
+    renderEmptyState(container);
+    return;
+  }
+  const list = document.createElement('div');
+  list.className = 'review-group-list';
+  groups.forEach(group => {
+    const card = document.createElement('div');
+    card.className = 'review-group-card';
+    const heading = document.createElement('div');
+    heading.className = 'review-group-heading';
+    const title = document.createElement('div');
+    title.className = 'review-group-title';
+    title.textContent = group.title;
+    const count = document.createElement('span');
+    count.className = 'review-group-count';
+    count.textContent = `${group.entries.length} card${group.entries.length === 1 ? '' : 's'}`;
+    heading.appendChild(title);
+    heading.appendChild(count);
+    card.appendChild(heading);
+
+    const actions = document.createElement('div');
+    actions.className = 'review-group-actions';
+    const startBtn = document.createElement('button');
+    startBtn.className = 'btn';
+    startBtn.textContent = `Start ${label}`;
+    startBtn.addEventListener('click', () => {
+      start(buildSessionPayload(group.entries));
+    });
+    actions.appendChild(startBtn);
+    card.appendChild(actions);
+
+    list.appendChild(card);
+  });
+  container.appendChild(list);
+}
+
+export async function renderReview(root, redraw) {
+  root.innerHTML = '';
+  const cohort = state.cohort || [];
+  if (!cohort.length) {
+    const empty = document.createElement('div');
+    empty.className = 'review-empty';
+    empty.textContent = 'Build a study set to generate review cards.';
+    root.appendChild(empty);
+    return;
+  }
+
+  const now = Date.now();
+  const dueEntries = collectDueSections(cohort, { now });
+  const blocks = await listBlocks();
+  const blockTitles = ensureBlockTitleMap(blocks);
+
+  const wrapper = document.createElement('section');
+  wrapper.className = 'card review-panel';
+
+  const heading = document.createElement('h2');
+  heading.textContent = 'Review queue';
+  wrapper.appendChild(heading);
+
+  const summary = document.createElement('div');
+  summary.className = 'review-summary';
+  summary.textContent = `Cards due: ${dueEntries.length}`;
+  wrapper.appendChild(summary);
+
+  const tabs = document.createElement('div');
+  tabs.className = 'review-tabs';
+  REVIEW_SCOPES.forEach(scope => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'tab';
+    const label = scope === 'all' ? 'All' : scope === 'blocks' ? 'By block' : 'By lecture';
+    if (activeScope === scope) btn.classList.add('active');
+    btn.textContent = label;
+    btn.addEventListener('click', () => {
+      if (activeScope === scope) return;
+      activeScope = scope;
+      renderReview(root, redraw);
+    });
+    tabs.appendChild(btn);
+  });
+  wrapper.appendChild(tabs);
+
+  const body = document.createElement('div');
+  body.className = 'review-body';
+  wrapper.appendChild(body);
+
+  const startSession = (pool) => {
+    if (!pool.length) return;
+    setFlashSession({ idx: 0, pool, ratings: {}, mode: 'review' });
+    redraw();
   };
-  const res = [];
-  const nOld = Math.round(count*0.6);
-  const nMid = Math.round(count*0.3);
-  const nNew = count - nOld - nMid;
-  res.push(...take(oldest, nOld));
-  res.push(...take(middle, nMid));
-  res.push(...take(newest, nNew));
-  return res;
+
+  if (activeScope === 'all') {
+    renderAllView(body, dueEntries, now, startSession);
+  } else if (activeScope === 'blocks') {
+    const groups = groupByBlock(dueEntries, blockTitles);
+    renderGroupView(body, groups, 'block review', startSession);
+  } else {
+    const groups = groupByLecture(dueEntries, blockTitles);
+    renderGroupView(body, groups, 'lecture review', startSession);
+  }
+
+  root.appendChild(wrapper);
 }

--- a/js/ui/components/section-utils.js
+++ b/js/ui/components/section-utils.js
@@ -1,0 +1,32 @@
+import { sectionDefsForKind } from './sections.js';
+
+function stripHtml(value) {
+  return String(value || '')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function hasSectionContent(item, key) {
+  if (!item || !key) return false;
+  const defs = sectionDefsForKind(item.kind);
+  if (!defs.some(def => def.key === key)) return false;
+  const raw = item[key];
+  if (raw === null || raw === undefined) return false;
+  return stripHtml(raw).length > 0;
+}
+
+export function sectionsForItem(item, allowedKeys = null) {
+  const defs = sectionDefsForKind(item.kind);
+  const allowSet = allowedKeys ? new Set(allowedKeys) : null;
+  return defs
+    .filter(def => (!allowSet || allowSet.has(def.key)) && hasSectionContent(item, def.key))
+    .map(def => ({ key: def.key, label: def.label }));
+}
+
+export function getSectionLabel(item, key) {
+  const defs = sectionDefsForKind(item.kind);
+  const def = defs.find(entry => entry.key === key);
+  return def ? def.label : key;
+}

--- a/js/validators.js
+++ b/js/validators.js
@@ -1,3 +1,5 @@
+import { normalizeSrRecord } from './review/sr-data.js';
+
 const randomId = () => (globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2));
 
 function escapeHtml(str = '') {
@@ -47,6 +49,6 @@ export function cleanItem(item) {
     lectures: item.lectures || [],
     mapPos: item.mapPos || null,
     mapHidden: !!item.mapHidden,
-    sr: item.sr || { box:0, last:0, due:0, ease:2.5 }
+    sr: normalizeSrRecord(item.sr)
   };
 }

--- a/style.css
+++ b/style.css
@@ -1805,6 +1805,61 @@ button.builder-pill.builder-pill-outline {
   display: block;
 }
 
+.flash-rating {
+  display: none;
+  margin-top: var(--pad-sm);
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.flash-section.revealed .flash-rating {
+  display: flex;
+}
+
+.flash-rating-options {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.flash-rating-btn {
+  min-width: 84px;
+}
+
+.flash-rating-btn.is-selected {
+  box-shadow: 0 0 0 2px var(--accent);
+}
+
+.flash-rating-status {
+  font-size: 0.8rem;
+  color: var(--gray);
+}
+
+.flash-rating-status.is-error {
+  color: #fca5a5;
+}
+
+.flash-rating.is-saving .flash-rating-status {
+  color: var(--accent);
+}
+
+.flash-rating.is-saving .flash-rating-btn {
+  pointer-events: none;
+  opacity: 0.75;
+}
+
+.flash-empty {
+  background: var(--muted);
+  color: var(--gray);
+  padding: var(--pad);
+  border-radius: var(--radius);
+}
+
+.flash-controls {
+  gap: var(--pad-sm);
+}
+
 /* Browse cards */
 .block-header {
   background: linear-gradient(90deg, var(--purple), var(--blue));
@@ -4916,6 +4971,130 @@ body.map-toolbox-dragging {
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--gray);
+}
+
+.review-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+}
+
+.review-summary {
+  color: var(--gray);
+  font-size: 0.95rem;
+}
+
+.review-tabs {
+  display: flex;
+  gap: var(--pad-sm);
+  flex-wrap: wrap;
+}
+
+.review-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+}
+
+.review-actions {
+  display: flex;
+  justify-content: flex-start;
+  margin-bottom: var(--pad-sm);
+}
+
+.review-entry-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+}
+
+.review-entry {
+  background: var(--panel-elevated);
+  border-radius: var(--radius);
+  padding: var(--pad-sm);
+  box-shadow: inset 0 0 0 1px var(--border);
+}
+
+.review-entry-title {
+  font-weight: 600;
+}
+
+.review-entry-meta {
+  color: var(--gray);
+  font-size: 0.85rem;
+  margin-top: 4px;
+}
+
+.review-group-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+}
+
+.review-group-card {
+  background: var(--panel-elevated);
+  border-radius: var(--radius);
+  padding: var(--pad);
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+  box-shadow: inset 0 0 0 1px var(--border);
+}
+
+.review-group-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.review-group-title {
+  font-weight: 600;
+}
+
+.review-group-count {
+  color: var(--gray);
+  font-size: 0.85rem;
+}
+
+.review-group-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.review-empty {
+  color: var(--gray);
+  font-style: italic;
+  padding: var(--pad);
+  border-radius: var(--radius);
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.settings-subheading {
+  margin-top: var(--pad);
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.settings-review-grid {
+  display: grid;
+  gap: var(--pad-sm);
+  margin-top: var(--pad-sm);
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.settings-review-row {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  font-weight: 500;
+}
+
+.settings-review-input {
+  width: 100%;
 }
 
 .block-mode-bank {

--- a/test/review.scheduler.test.js
+++ b/test/review.scheduler.test.js
@@ -1,0 +1,93 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { rateSection, collectDueSections } from '../js/review/scheduler.js';
+import { DEFAULT_REVIEW_STEPS, RETIRE_RATING } from '../js/review/constants.js';
+
+const baseDurations = { ...DEFAULT_REVIEW_STEPS };
+
+function createItem({ id, kind = 'disease', fields = {}, sr = null }) {
+  return {
+    id,
+    kind,
+    name: id,
+    etiology: '',
+    pathophys: '',
+    clinical: '',
+    diagnosis: '',
+    treatment: '',
+    complications: '',
+    mnemonic: '',
+    ...fields,
+    sr: sr || { version: 2, sections: {} },
+    blocks: [],
+    lectures: []
+  };
+}
+
+test('rateSection schedules intervals based on ratings', () => {
+  const item = createItem({ id: 'alpha' });
+  const now = Date.now();
+
+  let state = rateSection(item, 'etiology', 'again', baseDurations, now);
+  assert.equal(state.streak, 0);
+  assert.equal(state.lastRating, 'again');
+  assert.equal(state.retired, false);
+  assert.ok(Math.abs(state.due - (now + baseDurations.again * 60 * 1000)) < 5 * 1000);
+
+  const later = now + 1000;
+  state = rateSection(item, 'etiology', 'good', baseDurations, later);
+  assert.equal(state.streak, 1);
+  const expectedGood = later + baseDurations.good * 60 * 1000;
+  assert.ok(Math.abs(state.due - expectedGood) < 5 * 1000);
+
+  const evenLater = later + 1000;
+  state = rateSection(item, 'etiology', 'easy', baseDurations, evenLater);
+  assert.equal(state.streak, 3);
+  const expectedEasy = evenLater + baseDurations.easy * 3 * 60 * 1000;
+  assert.ok(Math.abs(state.due - expectedEasy) < 5 * 1000);
+
+  state = rateSection(item, 'etiology', RETIRE_RATING, baseDurations, evenLater + 1000);
+  assert.equal(state.retired, true);
+  assert.equal(state.lastRating, RETIRE_RATING);
+  assert.equal(state.due, Number.MAX_SAFE_INTEGER);
+});
+
+test('collectDueSections returns only active overdue sections', () => {
+  const now = Date.now();
+  const overdue = createItem({
+    id: 'due-1',
+    fields: { etiology: '<p>text</p>' },
+    sr: {
+      version: 2,
+      sections: {
+        etiology: { streak: 1, lastRating: 'good', last: now - 10_000, due: now - 1_000, retired: false }
+      }
+    }
+  });
+  const future = createItem({
+    id: 'future-1',
+    fields: { etiology: '<p>later</p>' },
+    sr: {
+      version: 2,
+      sections: {
+        etiology: { streak: 1, lastRating: 'good', last: now - 10_000, due: now + 60_000, retired: false }
+      }
+    }
+  });
+  const retired = createItem({
+    id: 'retired-1',
+    fields: { etiology: '<p>skip</p>' },
+    sr: {
+      version: 2,
+      sections: {
+        etiology: { streak: 1, lastRating: RETIRE_RATING, last: now - 10_000, due: Number.MAX_SAFE_INTEGER, retired: true }
+      }
+    }
+  });
+
+  const results = collectDueSections([overdue, future, retired], { now });
+  assert.equal(results.length, 1);
+  assert.equal(results[0].itemId, 'due-1');
+  assert.equal(results[0].sectionKey, 'etiology');
+});

--- a/test/storage.perf.test.js
+++ b/test/storage.perf.test.js
@@ -5,7 +5,7 @@ import { initDB, upsertItem, findItemsByFilter } from '../js/storage/storage.js'
 
 const TOTAL_ITEMS = 120;
 
-const srDefaults = { box: 0, last: 0, due: 0, ease: 2.5 };
+const srDefaults = { version: 2, sections: {} };
 
 function createBaseDisease(id, name) {
   return {


### PR DESCRIPTION
## Summary
- add per-section flashcard difficulty controls that persist spaced review state per section
- revamp review mode to surface due sections with all/block/lecture groupings and launch review sessions
- allow configuring review timing in settings and cover the scheduler with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd9be0a7688322962271daa2731b7a