### PR TITLE
Refine study mode controls and navigation

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -54,6 +54,10 @@ async function render() {
     if (variant) btn.classList.add(variant);
     btn.textContent = t;
     btn.addEventListener('click', () => {
+      const wasActive = state.tab === t;
+      if (t === 'Study' && wasActive && state.subtab?.Study === 'Review' && !state.flashSession && !state.quizSession) {
+        setSubtab('Study', 'Builder');
+      }
       setTab(t);
       render();
     });

--- a/js/ui/components/builder.js
+++ b/js/ui/components/builder.js
@@ -352,10 +352,46 @@ function renderModeCard(rerender, redraw) {
   title.textContent = 'Modes';
   card.appendChild(title);
 
-  const modeRow = document.createElement('div');
-  modeRow.className = 'builder-mode-options';
+  const layout = document.createElement('div');
+  layout.className = 'builder-mode-layout';
+
+  const controls = document.createElement('div');
+  controls.className = 'builder-mode-controls';
+
+  const status = document.createElement('div');
+  status.className = 'builder-mode-status';
+  controls.appendChild(status);
+
+  const actions = document.createElement('div');
+  actions.className = 'builder-mode-actions';
+
+  const startBtn = document.createElement('button');
+  startBtn.type = 'button';
+  startBtn.className = 'btn builder-start-btn';
+
+  const resumeBtn = document.createElement('button');
+  resumeBtn.type = 'button';
+  resumeBtn.className = 'btn builder-resume-btn';
+  resumeBtn.textContent = 'Resume';
+
+  const reviewBtn = document.createElement('button');
+  reviewBtn.type = 'button';
+  reviewBtn.className = 'btn secondary builder-review-link';
+  reviewBtn.textContent = 'Review';
+
   const modes = ['Flashcards', 'Quiz', 'Blocks'];
   const selected = state.study?.selectedMode || 'Flashcards';
+
+  const modeColumn = document.createElement('div');
+  modeColumn.className = 'builder-mode-option-column';
+
+  const modeLabel = document.createElement('div');
+  modeLabel.className = 'builder-mode-options-title';
+  modeLabel.textContent = 'Choose a mode';
+  modeColumn.appendChild(modeLabel);
+
+  const modeRow = document.createElement('div');
+  modeRow.className = 'builder-mode-options';
   modes.forEach(mode => {
     const btn = document.createElement('button');
     btn.type = 'button';
@@ -371,30 +407,24 @@ function renderModeCard(rerender, redraw) {
     });
     modeRow.appendChild(btn);
   });
-  card.appendChild(modeRow);
-
-  const status = document.createElement('div');
-  status.className = 'builder-mode-status';
-  card.appendChild(status);
-
-  const startBtn = document.createElement('button');
-  startBtn.type = 'button';
-  startBtn.className = 'btn builder-start-btn';
+  modeColumn.appendChild(modeRow);
 
   const storageKey = MODE_KEY[selected] || null;
   const savedEntry = storageKey ? getStudySessionEntry(storageKey) : null;
   const hasSaved = !!(savedEntry && savedEntry.session);
   const cohort = Array.isArray(state.cohort) ? state.cohort : [];
   const hasCohort = cohort.length > 0;
-  const canStartFresh = selected === 'Blocks' ? hasCohort : hasCohort;
-  const buttonEnabled = hasSaved || canStartFresh;
+  const canStart = selected === 'Blocks' ? hasCohort : hasCohort;
   const labelTitle = selected.toLowerCase();
-  startBtn.textContent = `${hasSaved ? 'Resume' : 'Start'} ${selected}`;
-  startBtn.disabled = !buttonEnabled;
 
-  startBtn.classList.toggle('is-ready', buttonEnabled && !hasSaved);
-  startBtn.classList.toggle('is-resume', hasSaved);
+  startBtn.textContent = 'Start';
+  startBtn.disabled = !canStart;
+  startBtn.classList.toggle('is-ready', canStart);
 
+  resumeBtn.disabled = !hasSaved;
+  resumeBtn.classList.toggle('is-ready', hasSaved);
+
+  reviewBtn.disabled = !hasCohort;
 
   if (hasSaved) {
     const count = Array.isArray(savedEntry?.cohort) ? savedEntry.cohort.length : 0;
@@ -408,7 +438,7 @@ function renderModeCard(rerender, redraw) {
   }
 
   startBtn.addEventListener('click', async () => {
-    if (!buttonEnabled) return;
+    if (!canStart) return;
     setStudySelectedMode(selected);
     if (selected === 'Blocks') {
       setSubtab('Study', 'Blocks');
@@ -421,22 +451,9 @@ function renderModeCard(rerender, redraw) {
 
     const handleError = (err) => console.warn('Failed to update study session state', err);
 
-    if (hasSaved && savedEntry) {
-      await removeStudySession(key).catch(handleError);
-      const restoredCohort = Array.isArray(savedEntry.cohort) ? savedEntry.cohort : [];
-      setCohort(restoredCohort);
-      if (selected === 'Flashcards') {
-        setFlashSession(savedEntry.session);
-      } else if (selected === 'Quiz') {
-        setQuizSession(savedEntry.session);
-      }
-      setSubtab('Study', 'Builder');
-      redraw();
-      return;
-    }
-
-    if (!cohort.length) return;
     await removeStudySession(key).catch(handleError);
+    if (!cohort.length) return;
+
     if (selected === 'Flashcards') {
       setFlashSession({ idx: 0, pool: cohort, ratings: {}, mode: 'study' });
     } else if (selected === 'Quiz') {
@@ -446,7 +463,37 @@ function renderModeCard(rerender, redraw) {
     redraw();
   });
 
-  card.appendChild(startBtn);
+  resumeBtn.addEventListener('click', async () => {
+    if (!hasSaved || !storageKey || !savedEntry) return;
+    setStudySelectedMode(selected);
+    const handleError = (err) => console.warn('Failed to update study session state', err);
+    await removeStudySession(storageKey).catch(handleError);
+    const restoredCohort = Array.isArray(savedEntry.cohort) ? savedEntry.cohort : [];
+    setCohort(restoredCohort);
+    if (selected === 'Flashcards') {
+      setFlashSession(savedEntry.session);
+    } else if (selected === 'Quiz') {
+      setQuizSession(savedEntry.session);
+    }
+    setSubtab('Study', 'Builder');
+    redraw();
+  });
+
+  reviewBtn.addEventListener('click', () => {
+    setSubtab('Study', 'Review');
+    redraw();
+  });
+
+  actions.appendChild(startBtn);
+  actions.appendChild(resumeBtn);
+  actions.appendChild(reviewBtn);
+
+  controls.appendChild(actions);
+
+  layout.appendChild(controls);
+  layout.appendChild(modeColumn);
+
+  card.appendChild(layout);
   return card;
 }
 

--- a/style.css
+++ b/style.css
@@ -598,17 +598,10 @@ button:not(.tab):not(.fab-btn):not(.builder-pill):hover {
   box-shadow: 0 18px 36px rgba(22, 163, 74, 0.35);
 }
 
-.builder-start-btn.is-resume {
-  background: linear-gradient(135deg, rgba(251, 191, 36, 0.95), rgba(249, 115, 22, 0.9));
-  color: #0f172a;
-  border-color: transparent;
-  box-shadow: 0 18px 36px rgba(217, 119, 6, 0.35);
-}
-
 .builder-start-btn.is-ready:hover,
 .builder-start-btn.is-ready:focus-visible,
-.builder-start-btn.is-resume:hover,
-.builder-start-btn.is-resume:focus-visible {
+.builder-resume-btn.is-ready:hover,
+.builder-resume-btn.is-ready:focus-visible {
   transform: translateY(-1px);
 }
 
@@ -1892,19 +1885,61 @@ input[type="checkbox"]:checked::after {
   gap: var(--pad-sm);
 }
 
+
 .builder-mode-card {
   display: flex;
   flex-direction: column;
   gap: var(--pad);
 }
 
-.builder-mode-options {
+.builder-mode-layout {
   display: flex;
   flex-wrap: wrap;
+  align-items: flex-start;
+  gap: var(--pad);
+}
+
+.builder-mode-controls {
+  flex: 1 1 240px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+}
+
+.builder-mode-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+}
+
+.builder-mode-actions .btn {
+  width: 100%;
+  min-width: 0;
+}
+
+.builder-mode-option-column {
+  flex: 1 1 200px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+}
+
+.builder-mode-options-title {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--gray);
+}
+
+.builder-mode-options {
+  display: flex;
+  flex-direction: column;
   gap: var(--pad-sm);
 }
 
 .builder-mode-toggle {
+  width: 100%;
   padding: 8px 18px;
   border-radius: var(--radius);
   border: 1px solid rgba(148, 163, 184, 0.28);
@@ -1912,6 +1947,7 @@ input[type="checkbox"]:checked::after {
   color: var(--text-muted);
   font-weight: 600;
   letter-spacing: 0.01em;
+  text-align: left;
   transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
 }
 
@@ -1943,8 +1979,28 @@ input[type="checkbox"]:checked::after {
 }
 
 .builder-start-btn {
-  align-self: flex-start;
   min-width: 0;
+}
+
+.builder-resume-btn {
+  min-width: 0;
+}
+
+.builder-resume-btn.is-ready {
+  background: linear-gradient(135deg, rgba(251, 191, 36, 0.95), rgba(249, 115, 22, 0.9));
+  color: #0f172a;
+  border-color: transparent;
+  box-shadow: 0 18px 36px rgba(217, 119, 6, 0.35);
+}
+
+.builder-review-link {
+  min-width: 0;
+}
+
+@media (max-width: 960px) {
+  .builder-mode-layout {
+    flex-direction: column;
+  }
 }
 
 button.builder-pill {


### PR DESCRIPTION
## Summary
- restyle the study mode card to put the mode picker on the right with shared start, resume, and review actions
- add per-mode resume handling that restores saved flashcard or quiz sessions while the start button always begins a fresh run
- allow re-clicking the Study tab to return from the review screen to the builder

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdc850e6508322aed3cb4676b53138