### PR TITLE
Allow blocks mode sessions to be saved and resumed

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -54,6 +54,10 @@ async function render() {
     if (variant) btn.classList.add(variant);
     btn.textContent = t;
     btn.addEventListener('click', () => {
+      const wasActive = state.tab === t;
+      if (t === 'Study' && wasActive && state.subtab?.Study === 'Review' && !state.flashSession && !state.quizSession) {
+        setSubtab('Study', 'Builder');
+      }
       setTab(t);
       render();
     });
@@ -190,7 +194,7 @@ async function render() {
       } else if (state.quizSession) {
         renderQuiz(content, render);
       } else if (state.subtab.Study === 'Blocks') {
-        renderBlockMode(content);
+        renderBlockMode(content, render);
       } else if (state.subtab.Study === 'Review') {
         await renderReview(content, render);
       }

--- a/style.css
+++ b/style.css
@@ -598,17 +598,10 @@ button:not(.tab):not(.fab-btn):not(.builder-pill):hover {
   box-shadow: 0 18px 36px rgba(22, 163, 74, 0.35);
 }
 
-.builder-start-btn.is-resume {
-  background: linear-gradient(135deg, rgba(251, 191, 36, 0.95), rgba(249, 115, 22, 0.9));
-  color: #0f172a;
-  border-color: transparent;
-  box-shadow: 0 18px 36px rgba(217, 119, 6, 0.35);
-}
-
 .builder-start-btn.is-ready:hover,
 .builder-start-btn.is-ready:focus-visible,
-.builder-start-btn.is-resume:hover,
-.builder-start-btn.is-resume:focus-visible {
+.builder-resume-btn.is-ready:hover,
+.builder-resume-btn.is-ready:focus-visible {
   transform: translateY(-1px);
 }
 
@@ -1892,19 +1885,61 @@ input[type="checkbox"]:checked::after {
   gap: var(--pad-sm);
 }
 
+
 .builder-mode-card {
   display: flex;
   flex-direction: column;
   gap: var(--pad);
 }
 
-.builder-mode-options {
+.builder-mode-layout {
   display: flex;
   flex-wrap: wrap;
+  align-items: flex-start;
+  gap: var(--pad);
+}
+
+.builder-mode-controls {
+  flex: 1 1 240px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+}
+
+.builder-mode-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+}
+
+.builder-mode-actions .btn {
+  width: 100%;
+  min-width: 0;
+}
+
+.builder-mode-option-column {
+  flex: 1 1 200px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+}
+
+.builder-mode-options-title {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--gray);
+}
+
+.builder-mode-options {
+  display: flex;
+  flex-direction: column;
   gap: var(--pad-sm);
 }
 
 .builder-mode-toggle {
+  width: 100%;
   padding: 8px 18px;
   border-radius: var(--radius);
   border: 1px solid rgba(148, 163, 184, 0.28);
@@ -1912,6 +1947,7 @@ input[type="checkbox"]:checked::after {
   color: var(--text-muted);
   font-weight: 600;
   letter-spacing: 0.01em;
+  text-align: left;
   transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
 }
 
@@ -1943,8 +1979,28 @@ input[type="checkbox"]:checked::after {
 }
 
 .builder-start-btn {
-  align-self: flex-start;
   min-width: 0;
+}
+
+.builder-resume-btn {
+  min-width: 0;
+}
+
+.builder-resume-btn.is-ready {
+  background: linear-gradient(135deg, rgba(251, 191, 36, 0.95), rgba(249, 115, 22, 0.9));
+  color: #0f172a;
+  border-color: transparent;
+  box-shadow: 0 18px 36px rgba(217, 119, 6, 0.35);
+}
+
+.builder-review-link {
+  min-width: 0;
+}
+
+@media (max-width: 960px) {
+  .builder-mode-layout {
+    flex-direction: column;
+  }
 }
 
 button.builder-pill {
@@ -5436,6 +5492,23 @@ body.map-toolbox-dragging {
 .block-mode-bank-empty {
   color: var(--gray);
   font-size: 0.95rem;
+}
+
+.block-mode-footer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+}
+
+.block-mode-footer-status {
+  color: var(--gray);
+  font-size: 0.85rem;
+}
+
+.block-mode-footer-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad-sm);
 }
 
 .block-mode-empty {


### PR DESCRIPTION
## Summary
- let the study sidebar track saved Blocks sessions alongside flashcards and quizzes so resume handles each mode consistently
- add save & exit controls to Blocks mode that persist assignments and restore them on resume while wiring in refreshed styling
- pass the app renderer through to Blocks mode and rebuild the bundle so navigation back to the builder works after saving

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68cdc850e6508322aed3cb4676b53138