### PR TITLE
Improve study navigation and show upcoming reviews

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -161,42 +161,15 @@ async function render() {
     } else if (state.quizSession) {
       renderQuiz(content, render);
     } else {
-      const wrap = document.createElement('div');
-      await renderBuilder(wrap, render);
-      content.appendChild(wrap);
-
-      const subnav = document.createElement('div');
-      subnav.className = 'tabs row subtabs';
-      const buttons = [
-        { key: 'Builder', label: 'Study home' },
-        { key: 'Review', label: 'Review' }
-      ];
-      const activeKey = state.subtab.Study === 'Blocks' ? 'Builder' : state.subtab.Study;
-      buttons.forEach(({ key, label }) => {
-        const sb = document.createElement('button');
-        sb.className = 'tab';
-        const isActive = activeKey === key;
-        if (isActive) sb.classList.add('active');
-        sb.dataset.toggle = 'true';
-        sb.dataset.active = isActive ? 'true' : 'false';
-        sb.setAttribute('aria-pressed', isActive ? 'true' : 'false');
-        sb.textContent = label;
-        sb.addEventListener('click', () => {
-          setSubtab('Study', key);
-          render();
-        });
-        subnav.appendChild(sb);
-      });
-      content.appendChild(subnav);
-
-      if (state.flashSession) {
-        renderFlashcards(content, render);
-      } else if (state.quizSession) {
-        renderQuiz(content, render);
-      } else if (state.subtab.Study === 'Blocks') {
-        renderBlockMode(content, render);
-      } else if (state.subtab.Study === 'Review') {
+      const activeStudy = state.subtab.Study === 'Blocks' ? 'Blocks' : (state.subtab.Study || 'Builder');
+      if (activeStudy === 'Review') {
         await renderReview(content, render);
+      } else if (activeStudy === 'Blocks') {
+        renderBlockMode(content, render);
+      } else {
+        const wrap = document.createElement('div');
+        await renderBuilder(wrap, render);
+        content.appendChild(wrap);
       }
     }
   } else if (state.tab === 'Exams') {

--- a/js/ui/components/builder.js
+++ b/js/ui/components/builder.js
@@ -508,8 +508,8 @@ function renderModeCard(rerender, redraw) {
 
   controls.appendChild(actions);
 
-  layout.appendChild(controls);
   layout.appendChild(modeColumn);
+  layout.appendChild(controls);
 
   card.appendChild(layout);
   return card;

--- a/style.css
+++ b/style.css
@@ -1894,13 +1894,13 @@ input[type="checkbox"]:checked::after {
 
 .builder-mode-layout {
   display: flex;
-  flex-wrap: wrap;
-  align-items: flex-start;
+  flex-direction: column;
+  align-items: stretch;
   gap: var(--pad);
 }
 
 .builder-mode-controls {
-  flex: 1 1 240px;
+  flex: 1 1 auto;
   display: flex;
   flex-direction: column;
   gap: var(--pad-sm);
@@ -1918,7 +1918,7 @@ input[type="checkbox"]:checked::after {
 }
 
 .builder-mode-option-column {
-  flex: 1 1 200px;
+  flex: 1 1 auto;
   display: flex;
   flex-direction: column;
   gap: var(--pad-sm);
@@ -1999,7 +1999,7 @@ input[type="checkbox"]:checked::after {
 
 @media (max-width: 960px) {
   .builder-mode-layout {
-    flex-direction: column;
+    gap: var(--pad);
   }
 }
 
@@ -5375,7 +5375,13 @@ body.map-toolbox-dragging {
 .review-actions {
   display: flex;
   justify-content: flex-start;
+  flex-wrap: wrap;
+  gap: var(--pad-sm);
   margin-bottom: var(--pad-sm);
+}
+
+.review-actions .btn {
+  flex: none;
 }
 
 .review-entry-list {
@@ -5402,6 +5408,30 @@ body.map-toolbox-dragging {
   color: var(--gray);
   font-size: 0.85rem;
   margin-top: 4px;
+}
+
+.review-entry.is-upcoming {
+  background: rgba(148, 163, 184, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.28);
+}
+
+.review-upcoming-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-sm);
+}
+
+.review-upcoming-title {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--gray);
+}
+
+.review-upcoming-note {
+  color: var(--gray);
+  font-size: 0.85rem;
 }
 
 .review-group-list {


### PR DESCRIPTION
## Summary
- reposition the study mode selector above the start/resume actions and drop the redundant study sub-navigation
- surface upcoming review cards alongside the due list with early review controls and updated styling
- add scheduler support and tests for collecting upcoming review sections

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdd5c9c56c8322b56891c4199531b0