### PR TITLE
Revamp study controls and review accessibility

### DIFF
--- a/js/review/pool.js
+++ b/js/review/pool.js
@@ -1,0 +1,36 @@
+import { state } from '../state.js';
+import { listItemsByKind } from '../storage/storage.js';
+
+const DEFAULT_KINDS = ['disease', 'drug', 'concept'];
+
+export async function loadReviewSourceItems() {
+  const existingCohort = Array.isArray(state.cohort) && state.cohort.length ? state.cohort : null;
+  if (existingCohort) {
+    return existingCohort;
+  }
+
+  const kinds = Array.isArray(state.builder?.types) && state.builder.types.length
+    ? state.builder.types
+    : DEFAULT_KINDS;
+
+  const seenIds = new Set();
+  const items = [];
+
+  for (const kind of kinds) {
+    try {
+      const entries = await listItemsByKind(kind);
+      if (!Array.isArray(entries)) continue;
+      for (const item of entries) {
+        if (!item) continue;
+        const id = item.id || `${kind}::${items.length}`;
+        if (seenIds.has(id)) continue;
+        seenIds.add(id);
+        items.push(item);
+      }
+    } catch (err) {
+      console.warn('Failed to load review items for kind', kind, err);
+    }
+  }
+
+  return items;
+}

--- a/js/ui/components/builder.js
+++ b/js/ui/components/builder.js
@@ -4,6 +4,7 @@ import { setToggleState } from '../../utils.js';
 import { hydrateStudySessions, getStudySessionEntry, removeAllStudySessions, removeStudySession } from '../../study/study-sessions.js';
 
 import { collectDueSections } from '../../review/scheduler.js';
+import { loadReviewSourceItems } from '../../review/pool.js';
 
 
 const MODE_KEY = {
@@ -375,11 +376,6 @@ function renderModeCard(rerender, redraw) {
   resumeBtn.className = 'btn builder-resume-btn';
   resumeBtn.textContent = 'Resume';
 
-  const reviewBtn = document.createElement('button');
-  reviewBtn.type = 'button';
-  reviewBtn.className = 'btn secondary builder-review-link';
-  reviewBtn.textContent = 'Review';
-
   const modes = ['Flashcards', 'Quiz', 'Blocks'];
   const selected = state.study?.selectedMode || 'Flashcards';
 
@@ -397,6 +393,7 @@ function renderModeCard(rerender, redraw) {
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.className = 'builder-mode-toggle';
+    btn.dataset.mode = mode.toLowerCase();
     const isActive = mode === selected;
     if (isActive) btn.classList.add('is-active');
     btn.dataset.active = isActive ? 'true' : 'false';
@@ -424,8 +421,6 @@ function renderModeCard(rerender, redraw) {
 
   resumeBtn.disabled = !hasSaved;
   resumeBtn.classList.toggle('is-ready', hasSaved);
-
-  reviewBtn.disabled = !hasCohort;
 
   if (hasSaved) {
     const count = Array.isArray(savedEntry?.cohort) ? savedEntry.cohort.length : 0;
@@ -497,14 +492,8 @@ function renderModeCard(rerender, redraw) {
   });
 
 
-  reviewBtn.addEventListener('click', () => {
-    setSubtab('Study', 'Review');
-    redraw();
-  });
-
   actions.appendChild(startBtn);
   actions.appendChild(resumeBtn);
-  actions.appendChild(reviewBtn);
 
   controls.appendChild(actions);
 
@@ -524,12 +513,9 @@ function renderReviewCard(redraw) {
   title.textContent = 'Review';
   card.appendChild(title);
 
-  const cohort = Array.isArray(state.cohort) ? state.cohort : [];
-  const dueCount = cohort.length ? collectReviewCount(cohort) : 0;
-
   const status = document.createElement('div');
   status.className = 'builder-review-status';
-  status.textContent = dueCount ? `${dueCount} card${dueCount === 1 ? '' : 's'} due` : 'All caught up!';
+  status.textContent = 'Loading review queue…';
   card.appendChild(status);
 
   const actions = document.createElement('div');
@@ -539,7 +525,7 @@ function renderReviewCard(redraw) {
   openBtn.type = 'button';
   openBtn.className = 'btn secondary';
   openBtn.textContent = 'Open review';
-  openBtn.disabled = !cohort.length;
+  openBtn.disabled = true;
   openBtn.addEventListener('click', () => {
     setSubtab('Study', 'Review');
     redraw();
@@ -563,11 +549,35 @@ function renderReviewCard(redraw) {
       redraw();
     });
     actions.appendChild(resumeBtn);
-    status.textContent = saved.metadata?.label ? `Saved • ${saved.metadata.label}` : 'Saved review session ready';
   }
 
   card.appendChild(actions);
+  updateReviewSummary(saved);
   return card;
+
+  async function updateReviewSummary(savedEntry = null) {
+    try {
+      const items = await loadReviewSourceItems();
+      const dueCount = collectReviewCount(items);
+      if (items.length) {
+        const base = dueCount ? `${dueCount} card${dueCount === 1 ? '' : 's'} due` : 'All caught up!';
+        if (savedEntry?.session) {
+          const savedLabel = savedEntry.metadata?.label ? savedEntry.metadata.label : 'Saved review session ready';
+          status.textContent = `${base} • ${savedLabel}`;
+        } else {
+          status.textContent = base;
+        }
+        openBtn.disabled = false;
+      } else {
+        status.textContent = 'Add cards to build your review queue.';
+        openBtn.disabled = true;
+      }
+    } catch (err) {
+      console.warn('Failed to summarize review queue', err);
+      status.textContent = 'Unable to load review queue.';
+      openBtn.disabled = false;
+    }
+  }
 }
 
 

--- a/js/ui/components/flashcards.js
+++ b/js/ui/components/flashcards.js
@@ -2,7 +2,7 @@ import { state, setFlashSession, setSubtab, setStudySelectedMode } from '../../s
 import { setToggleState } from '../../utils.js';
 import { renderRichText } from './rich-text.js';
 import { sectionsForItem } from './section-utils.js';
-import { REVIEW_RATINGS, RETIRE_RATING, DEFAULT_REVIEW_STEPS } from '../../review/constants.js';
+import { REVIEW_RATINGS, DEFAULT_REVIEW_STEPS } from '../../review/constants.js';
 import { getReviewDurations, rateSection } from '../../review/scheduler.js';
 import { upsertItem } from '../../storage/storage.js';
 import { persistStudySession, removeStudySession } from '../../study/study-sessions.js';
@@ -12,16 +12,14 @@ const RATING_LABELS = {
   again: 'Again',
   hard: 'Hard',
   good: 'Good',
-  easy: 'Easy',
-  [RETIRE_RATING]: 'Retire'
+  easy: 'Easy'
 };
 
 const RATING_CLASS = {
   again: 'danger',
   hard: 'secondary',
   good: '',
-  easy: '',
-  [RETIRE_RATING]: 'secondary'
+  easy: ''
 };
 
 function ratingKey(item, sectionKey) {
@@ -149,7 +147,7 @@ export function renderFlashcards(root, redraw) {
         rateSection(item, key, value, durations, Date.now());
         await upsertItem(item);
         selectRating(value);
-        status.textContent = value === RETIRE_RATING ? 'Retired' : 'Saved';
+        status.textContent = 'Saved';
       } catch (err) {
         console.error('Failed to record rating', err);
         status.textContent = 'Save failed';
@@ -159,7 +157,7 @@ export function renderFlashcards(root, redraw) {
       }
     };
 
-    [...REVIEW_RATINGS, RETIRE_RATING].forEach(value => {
+    REVIEW_RATINGS.forEach(value => {
       const btn = document.createElement('button');
       btn.type = 'button';
       btn.dataset.value = value;
@@ -180,7 +178,7 @@ export function renderFlashcards(root, redraw) {
 
     if (previousRating) {
       selectRating(previousRating);
-      status.textContent = previousRating === RETIRE_RATING ? 'Retired' : 'Saved';
+      status.textContent = 'Saved';
     }
 
     ratingRow.appendChild(ratingButtons);
@@ -247,7 +245,7 @@ export function renderFlashcards(root, redraw) {
   if (!isReview) {
     const saveExit = document.createElement('button');
     saveExit.className = 'btn secondary';
-    saveExit.textContent = 'Save & exit';
+    saveExit.textContent = 'Save & close';
     saveExit.addEventListener('click', async () => {
       const original = saveExit.textContent;
       saveExit.disabled = true;
@@ -272,23 +270,11 @@ export function renderFlashcards(root, redraw) {
       }
     });
     controls.appendChild(saveExit);
-
-    const exit = document.createElement('button');
-    exit.className = 'btn secondary';
-    exit.textContent = 'Exit without saving';
-    exit.addEventListener('click', () => {
-      removeStudySession('flashcards').catch(err => console.warn('Failed to discard flashcard session', err));
-      setFlashSession(null);
-      setStudySelectedMode('Flashcards');
-      setSubtab('Study', 'Builder');
-      redraw();
-    });
-    controls.appendChild(exit);
   } else {
 
     const saveExit = document.createElement('button');
     saveExit.className = 'btn secondary';
-    saveExit.textContent = 'Save & exit';
+    saveExit.textContent = 'Pause & save';
     saveExit.addEventListener('click', async () => {
       const original = saveExit.textContent;
       saveExit.disabled = true;
@@ -311,18 +297,6 @@ export function renderFlashcards(root, redraw) {
       }
     });
     controls.appendChild(saveExit);
-
-    const exitReview = document.createElement('button');
-    exitReview.className = 'btn secondary';
-    exitReview.textContent = 'Exit without saving';
-    exitReview.addEventListener('click', () => {
-      removeStudySession('review').catch(err => console.warn('Failed to discard review session', err));
-
-      setFlashSession(null);
-      setSubtab('Study', 'Review');
-      redraw();
-    });
-    controls.appendChild(exitReview);
   }
 
 

--- a/style.css
+++ b/style.css
@@ -1960,17 +1960,40 @@ input[type="checkbox"]:checked::after {
 }
 
 .builder-mode-toggle.is-active {
-  background: linear-gradient(135deg, rgba(56, 189, 248, 0.94), rgba(192, 132, 252, 0.9));
   border-color: transparent;
   color: #041021;
   box-shadow: 0 16px 28px rgba(2, 6, 23, 0.38);
   transform: translateY(-1px);
 }
 
-.builder-mode-toggle.is-active:hover,
-.builder-mode-toggle.is-active:focus-visible {
-  background: linear-gradient(135deg, rgba(56, 189, 248, 0.98), rgba(192, 132, 252, 0.96));
-  color: #020a16;
+.builder-mode-toggle.is-active[data-mode="flashcards"] {
+  background: linear-gradient(135deg, rgba(34, 197, 94, 0.96), rgba(14, 165, 233, 0.94));
+}
+
+.builder-mode-toggle.is-active[data-mode="flashcards"]:hover,
+.builder-mode-toggle.is-active[data-mode="flashcards"]:focus-visible {
+  background: linear-gradient(135deg, rgba(34, 197, 94, 1), rgba(14, 165, 233, 0.98));
+  color: #031320;
+}
+
+.builder-mode-toggle.is-active[data-mode="quiz"] {
+  background: linear-gradient(135deg, rgba(129, 140, 248, 0.95), rgba(236, 72, 153, 0.95));
+}
+
+.builder-mode-toggle.is-active[data-mode="quiz"]:hover,
+.builder-mode-toggle.is-active[data-mode="quiz"]:focus-visible {
+  background: linear-gradient(135deg, rgba(129, 140, 248, 0.98), rgba(236, 72, 153, 0.98));
+  color: #050818;
+}
+
+.builder-mode-toggle.is-active[data-mode="blocks"] {
+  background: linear-gradient(135deg, rgba(249, 115, 22, 0.96), rgba(244, 63, 94, 0.92));
+}
+
+.builder-mode-toggle.is-active[data-mode="blocks"]:hover,
+.builder-mode-toggle.is-active[data-mode="blocks"]:focus-visible {
+  background: linear-gradient(135deg, rgba(249, 115, 22, 0.99), rgba(244, 63, 94, 0.96));
+  color: #140404;
 }
 
 .builder-mode-status {
@@ -1991,10 +2014,6 @@ input[type="checkbox"]:checked::after {
   color: #0f172a;
   border-color: transparent;
   box-shadow: 0 18px 36px rgba(217, 119, 6, 0.35);
-}
-
-.builder-review-link {
-  min-width: 0;
 }
 
 @media (max-width: 960px) {
@@ -5398,6 +5417,18 @@ body.map-toolbox-dragging {
   border-radius: var(--radius);
   padding: var(--pad-sm);
   box-shadow: inset 0 0 0 1px var(--border);
+}
+
+.review-entry.is-clickable {
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+}
+
+.review-entry.is-clickable:hover,
+.review-entry.is-clickable:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.36);
+  background: rgba(56, 189, 248, 0.12);
 }
 
 .review-entry-title {


### PR DESCRIPTION
## Summary
- allow the review queue to load from the overall library, expose saved sessions, and let due/upcoming entries launch focused reviews
- simplify flashcard and quiz controls by removing retire/exit-without-saving options and using a single rating per quiz card with save-and-close actions
- add distinct active colors for flashcard, quiz, and block mode toggles and style clickable review entries for better affordance

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdda6ba6d883229503a12da0bbcb8e