### PR TITLE
Fix flashcard and quiz study mode interactions

### DIFF
--- a/style.css
+++ b/style.css
@@ -105,7 +105,7 @@ button:not(.tab):not(.fab-btn):not(.builder-pill):hover {
   transition: background 0.25s ease, color 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
 }
 
-[data-toggle="true"][data-active="true"] {
+[data-toggle="true"][data-active="true"]:not(.builder-pill) {
   background: linear-gradient(135deg, rgba(56, 189, 248, 0.96), rgba(192, 132, 252, 0.92));
   border-color: transparent;
   color: #031327;
@@ -756,6 +756,21 @@ button:not(.tab):not(.fab-btn):not(.builder-pill):hover {
 .quiz-suggestions li:hover {
   background: rgba(56, 189, 248, 0.18);
   border-color: rgba(56, 189, 248, 0.36);
+}
+
+.quiz-answer-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--pad-xs);
+}
+
+.quiz-answer-actions .btn {
+  min-width: 0;
+}
+
+.quiz-reveal-btn {
+  white-space: nowrap;
 }
 
 .quiz-feedback {


### PR DESCRIPTION
## Summary
- normalize stored flashcard sessions so navigation, resume, and saves always use a valid pool
- overhaul quiz answer flow with a check button, reveal option, and improved state gating while removing extra prompts
- adjust styles so builder pills regain their gradient selection and new quiz actions render cleanly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cde081607c8322a91625cde79d7286