### PR TITLE
Refine flashcard review flow and study mode styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -105,7 +105,7 @@ button:not(.tab):not(.fab-btn):not(.builder-pill):hover {
   transition: background 0.25s ease, color 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
 }
 
-[data-toggle="true"][data-active="true"] {
+[data-toggle="true"][data-active="true"]:not(.builder-pill) {
   background: linear-gradient(135deg, rgba(56, 189, 248, 0.96), rgba(192, 132, 252, 0.92));
   border-color: transparent;
   color: #031327;
@@ -756,6 +756,21 @@ button:not(.tab):not(.fab-btn):not(.builder-pill):hover {
 .quiz-suggestions li:hover {
   background: rgba(56, 189, 248, 0.18);
   border-color: rgba(56, 189, 248, 0.36);
+}
+
+.quiz-answer-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--pad-xs);
+}
+
+.quiz-answer-actions .btn {
+  min-width: 0;
+}
+
+.quiz-reveal-btn {
+  white-space: nowrap;
 }
 
 .quiz-feedback {
@@ -1951,12 +1966,51 @@ input[type="checkbox"]:checked::after {
   transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
 }
 
+.builder-mode-toggle[data-mode="flashcards"]:not(.is-active) {
+  background: rgba(34, 197, 94, 0.14);
+  border-color: rgba(34, 197, 94, 0.3);
+  color: rgba(207, 250, 222, 0.85);
+}
+
+.builder-mode-toggle[data-mode="quiz"]:not(.is-active) {
+  background: rgba(129, 140, 248, 0.16);
+  border-color: rgba(129, 140, 248, 0.34);
+  color: rgba(224, 231, 255, 0.85);
+}
+
+.builder-mode-toggle[data-mode="blocks"]:not(.is-active) {
+  background: rgba(249, 115, 22, 0.16);
+  border-color: rgba(249, 115, 22, 0.32);
+  color: rgba(254, 226, 226, 0.85);
+}
+
 .builder-mode-toggle:hover,
 .builder-mode-toggle:focus-visible {
   background: rgba(56, 189, 248, 0.18);
   border-color: rgba(56, 189, 248, 0.36);
   color: var(--text);
   transform: translateY(-1px);
+}
+
+.builder-mode-toggle[data-mode="flashcards"]:not(.is-active):hover,
+.builder-mode-toggle[data-mode="flashcards"]:not(.is-active):focus-visible {
+  background: rgba(34, 197, 94, 0.24);
+  border-color: rgba(34, 197, 94, 0.5);
+  color: #eafff3;
+}
+
+.builder-mode-toggle[data-mode="quiz"]:not(.is-active):hover,
+.builder-mode-toggle[data-mode="quiz"]:not(.is-active):focus-visible {
+  background: rgba(129, 140, 248, 0.26);
+  border-color: rgba(129, 140, 248, 0.52);
+  color: #fdf4ff;
+}
+
+.builder-mode-toggle[data-mode="blocks"]:not(.is-active):hover,
+.builder-mode-toggle[data-mode="blocks"]:not(.is-active):focus-visible {
+  background: rgba(249, 115, 22, 0.26);
+  border-color: rgba(249, 115, 22, 0.5);
+  color: #fff7ed;
 }
 
 .builder-mode-toggle.is-active {
@@ -2231,6 +2285,15 @@ button.builder-pill.builder-pill-outline {
 .flash-rating.is-saving .flash-rating-btn {
   pointer-events: none;
   opacity: 0.75;
+}
+
+.flash-rating.is-locked .flash-rating-options {
+  display: none;
+}
+
+.flash-rating.is-locked .flash-rating-status {
+  color: var(--text-muted);
+  font-style: italic;
 }
 
 .flash-empty {


### PR DESCRIPTION
## Summary
- detect existing spaced-repetition state when rendering flashcards so sections already queued for review skip rating, persist session updates, and harden prev/next navigation
- style the Study mode pills with distinct Flashcards, Quiz, and Blocks colors while hiding flashcard rating controls once a section is in the queue
- rebuild the browser bundle to ship the new interactions and styles

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cde081607c8322a91625cde79d7286