### PR TITLE
Relax flashcard ratings and refresh study styling

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -5577,6 +5577,11 @@ var Sevenn = (() => {
   }
 
   // js/ui/components/flashcards.js
+  var KIND_ACCENTS = {
+    disease: "var(--pink)",
+    drug: "var(--blue)",
+    concept: "var(--green)"
+  };
   var RATING_LABELS = {
     again: "Again",
     hard: "Hard",
@@ -5589,6 +5594,19 @@ var Sevenn = (() => {
     good: "",
     easy: ""
   };
+  function getFlashcardAccent(item) {
+    if (item?.color) return item.color;
+    if (item?.kind && KIND_ACCENTS[item.kind]) return KIND_ACCENTS[item.kind];
+    return "var(--accent)";
+  }
+  function queueStatusLabel(snapshot) {
+    if (!snapshot || snapshot.retired) return "Already in review queue";
+    const rating = snapshot.lastRating;
+    if (rating && RATING_LABELS[rating]) {
+      return `In review (${RATING_LABELS[rating]})`;
+    }
+    return "Already in review queue";
+  }
   function ratingKey(item, sectionKey) {
     const id = item?.id || "item";
     return `${id}::${sectionKey}`;
@@ -5597,10 +5615,62 @@ var Sevenn = (() => {
     const pool = Array.isArray(session.pool) ? session.pool : [];
     return pool[idx] || null;
   }
+  function normalizeFlashSession(session, fallbackPool, defaultMode = "study") {
+    const source = session && typeof session === "object" ? session : {};
+    const next = { ...source };
+    let changed = !session || typeof session !== "object";
+    const fallback = Array.isArray(fallbackPool) ? fallbackPool : [];
+    const pool = Array.isArray(source.pool) && source.pool.length ? source.pool : fallback;
+    if (source.pool !== pool) {
+      next.pool = pool;
+      changed = true;
+    }
+    const ratings = source.ratings && typeof source.ratings === "object" ? source.ratings : {};
+    if (source.ratings !== ratings) {
+      next.ratings = ratings;
+      changed = true;
+    }
+    let idx = typeof source.idx === "number" && Number.isFinite(source.idx) ? Math.floor(source.idx) : 0;
+    if (idx < 0) idx = 0;
+    const maxIdx = pool.length ? pool.length - 1 : 0;
+    if (idx > maxIdx) idx = maxIdx;
+    if (idx !== source.idx) {
+      next.idx = idx;
+      changed = true;
+    }
+    const mode = source.mode === "review" ? "review" : defaultMode;
+    if (source.mode !== mode) {
+      next.mode = mode;
+      changed = true;
+    }
+    return changed ? next : session;
+  }
   function renderFlashcards(root, redraw) {
-    const active = state.flashSession || { idx: 0, pool: state.cohort, ratings: {}, mode: "study" };
+    const fallbackPool = Array.isArray(state.cohort) ? state.cohort : [];
+    let active = state.flashSession;
+    if (active) {
+      const normalized2 = normalizeFlashSession(active, fallbackPool, active.mode === "review" ? "review" : "study");
+      if (normalized2 !== active) {
+        setFlashSession(normalized2);
+        active = normalized2;
+      }
+    } else {
+      active = normalizeFlashSession({ idx: 0, pool: fallbackPool, ratings: {}, mode: "study" }, fallbackPool, "study");
+    }
     active.ratings = active.ratings || {};
-    const items = Array.isArray(active.pool) && active.pool.length ? active.pool : state.cohort;
+    const items = Array.isArray(active.pool) && active.pool.length ? active.pool : fallbackPool;
+    const resolvePool = () => Array.isArray(active.pool) && active.pool.length ? active.pool : items;
+    const commitSession = (patch = {}) => {
+      const pool = resolvePool();
+      const next2 = { ...active, pool, ...patch };
+      if (patch.ratings) {
+        next2.ratings = { ...patch.ratings };
+      } else {
+        next2.ratings = { ...active.ratings };
+      }
+      active = next2;
+      setFlashSession(next2);
+    };
     const isReview = active.mode === "review";
     root.innerHTML = "";
     if (!items.length) {
@@ -5637,7 +5707,6 @@ var Sevenn = (() => {
     title.textContent = item.name || item.concept || "";
     card.appendChild(title);
     const durationsPromise = getReviewDurations().catch(() => ({ ...DEFAULT_REVIEW_STEPS }));
-    const ratedSections = /* @__PURE__ */ new Map();
     const sectionBlocks = sections.length ? sections : [];
     if (!sectionBlocks.length) {
       const empty = document.createElement("div");
@@ -5648,9 +5717,8 @@ var Sevenn = (() => {
     sectionBlocks.forEach(({ key, label }) => {
       const ratingId = ratingKey(item, key);
       const previousRating = active.ratings[ratingId] || null;
-      if (previousRating) {
-        ratedSections.set(key, previousRating);
-      }
+      const snapshot = getSectionStateSnapshot(item, key);
+      const lockedByQueue = !isReview && Boolean(snapshot && snapshot.last && !snapshot.retired);
       const sec = document.createElement("div");
       sec.className = "flash-section";
       sec.setAttribute("role", "button");
@@ -5667,22 +5735,25 @@ var Sevenn = (() => {
       ratingButtons.className = "flash-rating-options";
       const status = document.createElement("span");
       status.className = "flash-rating-status";
+      let ratingLocked = lockedByQueue;
       const selectRating = (value) => {
-        ratedSections.set(key, value);
         active.ratings[ratingId] = value;
         Array.from(ratingButtons.querySelectorAll("button")).forEach((btn) => {
           const btnValue = btn.dataset.value;
           const isSelected = btnValue === value;
           btn.classList.toggle("is-selected", isSelected);
           if (isSelected) {
-            btn.setAttribute("aria-pressed", "true");
-          } else {
-            btn.setAttribute("aria-pressed", "false");
+            ratingButtons.dataset.selected = value;
+          } else if (ratingButtons.dataset.selected === btnValue) {
+            delete ratingButtons.dataset.selected;
           }
+          btn.setAttribute("aria-pressed", isSelected ? "true" : "false");
         });
-        updateNextState();
+        status.classList.remove("is-error");
+        commitSession({ ratings: { ...active.ratings } });
       };
       const handleRating = async (value) => {
+        if (ratingLocked) return;
         const durations = await durationsPromise;
         setToggleState(sec, true, "revealed");
         ratingRow.classList.add("is-saving");
@@ -5693,6 +5764,7 @@ var Sevenn = (() => {
           await upsertItem(item);
           selectRating(value);
           status.textContent = "Saved";
+          status.classList.remove("is-error");
         } catch (err) {
           console.error("Failed to record rating", err);
           status.textContent = "Save failed";
@@ -5705,7 +5777,8 @@ var Sevenn = (() => {
         const btn = document.createElement("button");
         btn.type = "button";
         btn.dataset.value = value;
-        btn.className = "btn flash-rating-btn";
+        btn.dataset.rating = value;
+        btn.className = "flash-rating-btn";
         const variant = RATING_CLASS[value];
         if (variant) btn.classList.add(variant);
         btn.textContent = RATING_LABELS[value];
@@ -5719,9 +5792,43 @@ var Sevenn = (() => {
         });
         ratingButtons.appendChild(btn);
       });
+      const unlockRating = () => {
+        if (!ratingLocked) return;
+        ratingLocked = false;
+        ratingRow.classList.remove("is-locked");
+        ratingButtons.hidden = false;
+        status.classList.remove("flash-rating-status-action");
+        status.removeAttribute("role");
+        status.removeAttribute("tabindex");
+        status.textContent = previousRating ? "Update rating" : "Select a rating (optional)";
+      };
+      if (lockedByQueue) {
+        ratingLocked = true;
+        ratingRow.classList.add("is-locked");
+        ratingButtons.hidden = true;
+        const label2 = queueStatusLabel(snapshot);
+        status.textContent = `${label2} \u2014 click to adjust`;
+        status.classList.add("flash-rating-status-action");
+        status.setAttribute("role", "button");
+        status.setAttribute("tabindex", "0");
+        status.setAttribute("aria-label", "Update review rating");
+        status.addEventListener("click", (event) => {
+          event.stopPropagation();
+          unlockRating();
+        });
+        status.addEventListener("keydown", (event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            unlockRating();
+          }
+        });
+      } else if (previousRating) {
+        status.textContent = "Saved";
+      } else {
+        status.textContent = "Select a rating (optional)";
+      }
       if (previousRating) {
         selectRating(previousRating);
-        status.textContent = "Saved";
       }
       ratingRow.appendChild(ratingButtons);
       ratingRow.appendChild(status);
@@ -5756,7 +5863,7 @@ var Sevenn = (() => {
     prev.disabled = active.idx === 0;
     prev.addEventListener("click", () => {
       if (active.idx > 0) {
-        setFlashSession({ ...active, idx: active.idx - 1, pool: items });
+        commitSession({ idx: active.idx - 1 });
         redraw();
       }
     });
@@ -5765,13 +5872,12 @@ var Sevenn = (() => {
     next.className = "btn";
     const isLast = active.idx >= items.length - 1;
     next.textContent = isLast ? isReview ? "Finish review" : "Finish" : "Next";
-    next.disabled = sectionBlocks.length > 0;
     next.addEventListener("click", () => {
       const idx = active.idx + 1;
       if (idx >= items.length) {
         setFlashSession(null);
       } else {
-        setFlashSession({ ...active, idx, pool: items });
+        commitSession({ idx });
       }
       redraw();
     });
@@ -5785,9 +5891,10 @@ var Sevenn = (() => {
         saveExit.disabled = true;
         saveExit.textContent = "Saving\u2026";
         try {
+          const pool = resolvePool();
           await persistStudySession("flashcards", {
-            session: { ...active, idx: active.idx, pool: items, ratings: active.ratings },
-            cohort: items
+            session: { ...active, idx: active.idx, pool, ratings: { ...active.ratings || {} } },
+            cohort: pool
           });
           setFlashSession(null);
           setStudySelectedMode("Flashcards");
@@ -5813,8 +5920,9 @@ var Sevenn = (() => {
         saveExit.disabled = true;
         saveExit.textContent = "Saving\u2026";
         try {
+          const pool = resolvePool();
           await persistStudySession("review", {
-            session: { ...active, idx: active.idx, pool: items, ratings: active.ratings },
+            session: { ...active, idx: active.idx, pool, ratings: { ...active.ratings || {} } },
             cohort: state.cohort,
             metadata: active.metadata || { label: "Review session" }
           });
@@ -5843,15 +5951,11 @@ var Sevenn = (() => {
         prev.click();
       }
     });
-    updateNextState();
-    function updateNextState() {
-      if (!sectionBlocks.length) {
-        next.disabled = false;
-        return;
-      }
-      const allRated = sectionBlocks.every((sec) => ratedSections.get(sec.key));
-      next.disabled = !allRated;
-    }
+    const accent = getFlashcardAccent(item);
+    card.style.setProperty("--flash-accent", accent);
+    card.style.setProperty("--flash-accent-soft", `color-mix(in srgb, ${accent} 16%, transparent)`);
+    card.style.setProperty("--flash-accent-strong", `color-mix(in srgb, ${accent} 32%, rgba(15, 23, 42, 0.08))`);
+    card.style.setProperty("--flash-accent-border", `color-mix(in srgb, ${accent} 42%, transparent)`);
   }
 
   // js/ui/components/review.js
@@ -6206,18 +6310,23 @@ var Sevenn = (() => {
   function ensureSessionDefaults(session) {
     if (!session) return;
     if (!Array.isArray(session.pool)) session.pool = [];
-    if (!session.dict) {
-      session.dict = session.pool.map((it) => ({
-        id: it.id,
-        title: titleOf3(it),
-        lower: titleOf3(it).toLowerCase()
-      }));
-    }
+    session.dict = session.pool.map((it) => ({
+      id: it.id,
+      title: titleOf3(it),
+      lower: titleOf3(it).toLowerCase()
+    }));
     if (!session.answers || typeof session.answers !== "object") {
       session.answers = {};
     }
     if (!session.ratings || typeof session.ratings !== "object") {
       session.ratings = {};
+    }
+    if (typeof session.idx !== "number" || Number.isNaN(session.idx)) {
+      session.idx = 0;
+    }
+    session.idx = Math.max(0, Math.min(Math.floor(session.idx), session.pool.length ? session.pool.length - 1 : 0));
+    if (typeof session.score !== "number" || Number.isNaN(session.score)) {
+      session.score = computeScore(session.answers);
     }
   }
   function computeScore(answers) {
@@ -6268,9 +6377,11 @@ var Sevenn = (() => {
       renderCompletion(root, session, redraw);
       return;
     }
-    const answer = session.answers[session.idx] || { value: "", isCorrect: false, checked: false };
-    const hasSubmitted = Boolean(answer.checked);
-    const wasCorrect = hasSubmitted && answer.isCorrect;
+    const answer = session.answers[session.idx] || { value: "", isCorrect: false, checked: false, revealed: false };
+    const hasResult = Boolean(answer.checked);
+    const wasCorrect = hasResult && answer.isCorrect;
+    const wasRevealed = hasResult && answer.revealed;
+    const isSolved = wasCorrect || wasRevealed;
     const card = document.createElement("section");
     card.className = "card quiz-card";
     root.appendChild(card);
@@ -6324,23 +6435,50 @@ var Sevenn = (() => {
     const suggestions = document.createElement("ul");
     suggestions.className = "quiz-suggestions";
     form.appendChild(suggestions);
+    const actions = document.createElement("div");
+    actions.className = "quiz-answer-actions";
+    const checkBtn = document.createElement("button");
+    checkBtn.type = "button";
+    checkBtn.className = "btn quiz-check-btn";
+    checkBtn.textContent = "Check";
+    checkBtn.disabled = !input.value.trim();
+    checkBtn.addEventListener("click", () => gradeAnswer());
+    actions.appendChild(checkBtn);
+    const revealBtn = document.createElement("button");
+    revealBtn.type = "button";
+    revealBtn.className = "btn secondary quiz-reveal-btn";
+    revealBtn.textContent = "Show answer";
+    revealBtn.hidden = !(hasResult && !wasCorrect && !wasRevealed);
+    actions.appendChild(revealBtn);
+    form.appendChild(actions);
     const feedback = document.createElement("div");
     feedback.className = "quiz-feedback";
-    if (hasSubmitted) {
-      feedback.textContent = wasCorrect ? "Correct!" : `Incorrect \u2022 Answer: ${titleOf3(item)}`;
-      feedback.classList.add(wasCorrect ? "is-correct" : "is-incorrect");
+    if (wasCorrect) {
+      feedback.textContent = "Correct!";
+      feedback.classList.add("is-correct");
+    } else if (wasRevealed) {
+      feedback.textContent = `Answer: ${titleOf3(item)}`;
+      feedback.classList.add("is-incorrect");
+    } else if (hasResult) {
+      feedback.textContent = "Incorrect. Try again or reveal the answer.";
+      feedback.classList.add("is-incorrect");
     }
     form.appendChild(feedback);
     card.appendChild(form);
     input.addEventListener("input", () => {
+      checkBtn.disabled = !input.value.trim();
       const v = input.value.toLowerCase();
       const existing = session.answers[session.idx];
       if (existing && existing.checked) {
-        delete session.answers[session.idx];
-        session.score = computeScore(session.answers);
+        const answers = { ...session.answers };
+        delete answers[session.idx];
+        session.answers = answers;
+        session.score = computeScore(answers);
         setQuizSession({ ...session });
         feedback.textContent = "";
         feedback.classList.remove("is-correct", "is-incorrect");
+        revealBtn.hidden = true;
+        revealBtn.disabled = false;
         tally.textContent = `Score: ${session.score}`;
         updateNavState();
       }
@@ -6358,6 +6496,21 @@ var Sevenn = (() => {
         suggestions.appendChild(li);
       });
     });
+    revealBtn.addEventListener("click", () => {
+      const revealValue = titleOf3(item);
+      const answers = { ...session.answers, [session.idx]: { value: revealValue, isCorrect: false, checked: true, revealed: true } };
+      session.answers = answers;
+      session.score = computeScore(answers);
+      setQuizSession({ ...session });
+      input.value = revealValue;
+      feedback.textContent = `Answer: ${titleOf3(item)}`;
+      feedback.classList.remove("is-correct");
+      feedback.classList.add("is-incorrect");
+      revealBtn.hidden = true;
+      suggestions.innerHTML = "";
+      tally.textContent = `Score: ${session.score}`;
+      updateNavState();
+    });
     form.addEventListener("submit", (event) => {
       event.preventDefault();
       gradeAnswer();
@@ -6366,16 +6519,9 @@ var Sevenn = (() => {
     const ratingPanel = document.createElement("div");
     ratingPanel.className = "quiz-rating-panel";
     card.appendChild(ratingPanel);
-    const ratingTitle = document.createElement("h3");
-    ratingTitle.textContent = "How well did you know this card?";
-    ratingPanel.appendChild(ratingTitle);
     const ratingRow = document.createElement("div");
     ratingRow.className = "quiz-rating-row";
     ratingPanel.appendChild(ratingRow);
-    const ratingLabel = document.createElement("div");
-    ratingLabel.className = "quiz-rating-label";
-    ratingLabel.textContent = "Rate this card";
-    ratingRow.appendChild(ratingLabel);
     const options = document.createElement("div");
     options.className = "quiz-rating-options";
     ratingRow.appendChild(options);
@@ -6398,7 +6544,8 @@ var Sevenn = (() => {
       updateNavState();
     };
     const handleRating = async (value) => {
-      if (!session.answers[session.idx]) return;
+      const current = session.answers[session.idx];
+      if (!(current && current.checked && (current.isCorrect || current.revealed))) return;
       status.textContent = "Saving\u2026";
       status.classList.remove("is-error");
       try {
@@ -6425,7 +6572,7 @@ var Sevenn = (() => {
       const variant = RATING_CLASS2[value];
       if (variant) btn.classList.add(variant);
       btn.textContent = RATING_LABELS2[value];
-      btn.disabled = !hasSubmitted;
+      btn.disabled = !isSolved;
       btn.setAttribute("aria-pressed", "false");
       btn.addEventListener("click", () => handleRating(value));
       options.appendChild(btn);
@@ -6452,15 +6599,6 @@ var Sevenn = (() => {
       redraw();
     });
     controls.appendChild(backBtn);
-    const submitBtn = document.createElement("button");
-    submitBtn.type = "submit";
-    submitBtn.className = "btn";
-    submitBtn.textContent = hasSubmitted ? "Resubmit" : "Submit";
-    submitBtn.disabled = !input.value.trim();
-    form.addEventListener("input", () => {
-      submitBtn.disabled = !input.value.trim();
-    });
-    controls.appendChild(submitBtn);
     const nextBtn = document.createElement("button");
     nextBtn.type = "button";
     nextBtn.className = "btn";
@@ -6516,28 +6654,38 @@ var Sevenn = (() => {
       const normalized2 = guess.toLowerCase();
       const correct = titleOf3(item).toLowerCase();
       const isCorrect = normalized2 === correct;
-      const answers = { ...session.answers, [session.idx]: { value: guess, isCorrect, checked: true } };
+      const answers = {
+        ...session.answers,
+        [session.idx]: { value: guess, isCorrect, checked: true, revealed: false }
+      };
       const nextScore = computeScore(answers);
       session.answers = answers;
       session.score = nextScore;
       setQuizSession({ ...session });
       tally.textContent = `Score: ${session.score}`;
-      feedback.textContent = isCorrect ? "Correct!" : `Incorrect \u2022 Answer: ${titleOf3(item)}`;
+      feedback.textContent = isCorrect ? "Correct!" : "Incorrect. Try again or reveal the answer.";
       feedback.classList.remove("is-correct", "is-incorrect");
       feedback.classList.add(isCorrect ? "is-correct" : "is-incorrect");
+      suggestions.innerHTML = "";
+      revealBtn.hidden = isCorrect;
+      if (!isCorrect) {
+        revealBtn.disabled = false;
+        revealBtn.focus();
+      }
       updateNavState();
     }
     function updateNavState() {
       const currentAnswer = session.answers[session.idx];
-      const answered = Boolean(currentAnswer && currentAnswer.checked);
+      const solved = Boolean(currentAnswer && currentAnswer.checked && (currentAnswer.isCorrect || currentAnswer.revealed));
       const hasRating = !sections.length || Boolean(selectedRating);
-      nextBtn.disabled = !(answered && hasRating);
-      submitBtn.textContent = answered ? "Resubmit" : "Submit";
+      nextBtn.disabled = !(solved && hasRating);
       Array.from(options.querySelectorAll("button")).forEach((btn) => {
-        btn.disabled = !answered;
+        btn.disabled = !solved;
       });
-      if (!answered) {
+      if (!solved) {
         status.textContent = "";
+      } else {
+        revealBtn.hidden = true;
       }
     }
   }

--- a/style.css
+++ b/style.css
@@ -88,7 +88,7 @@ button:focus-visible {
   outline-offset: 3px;
 }
 
-button:not(.tab):not(.fab-btn):not(.builder-pill) {
+button:not(.tab):not(.fab-btn):not(.builder-pill):not(.builder-mode-toggle) {
   background: rgba(148, 163, 184, 0.14);
   color: var(--text);
   border: 1px solid var(--border);
@@ -97,7 +97,7 @@ button:not(.tab):not(.fab-btn):not(.builder-pill) {
   box-shadow: none;
 }
 
-button:not(.tab):not(.fab-btn):not(.builder-pill):hover {
+button:not(.tab):not(.fab-btn):not(.builder-pill):not(.builder-mode-toggle):hover {
   background: rgba(148, 163, 184, 0.22);
 }
 
@@ -105,7 +105,7 @@ button:not(.tab):not(.fab-btn):not(.builder-pill):hover {
   transition: background 0.25s ease, color 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
 }
 
-[data-toggle="true"][data-active="true"] {
+[data-toggle="true"][data-active="true"]:not(.builder-pill):not(.builder-mode-toggle) {
   background: linear-gradient(135deg, rgba(56, 189, 248, 0.96), rgba(192, 132, 252, 0.92));
   border-color: transparent;
   color: #031327;
@@ -114,8 +114,8 @@ button:not(.tab):not(.fab-btn):not(.builder-pill):hover {
   transform: translateY(-1px);
 }
 
-[data-toggle="true"][data-active="true"]:hover,
-[data-toggle="true"][data-active="true"]:focus-visible {
+[data-toggle="true"][data-active="true"]:not(.builder-pill):not(.builder-mode-toggle):hover,
+[data-toggle="true"][data-active="true"]:not(.builder-pill):not(.builder-mode-toggle):focus-visible {
   background: linear-gradient(135deg, rgba(56, 189, 248, 0.98), rgba(192, 132, 252, 0.96));
   color: #020a16;
 }
@@ -756,6 +756,21 @@ button:not(.tab):not(.fab-btn):not(.builder-pill):hover {
 .quiz-suggestions li:hover {
   background: rgba(56, 189, 248, 0.18);
   border-color: rgba(56, 189, 248, 0.36);
+}
+
+.quiz-answer-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--pad-xs);
+}
+
+.quiz-answer-actions .btn {
+  min-width: 0;
+}
+
+.quiz-reveal-btn {
+  white-space: nowrap;
 }
 
 .quiz-feedback {
@@ -1951,12 +1966,51 @@ input[type="checkbox"]:checked::after {
   transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
 }
 
+.builder-mode-toggle[data-mode="flashcards"]:not(.is-active) {
+  background: rgba(34, 197, 94, 0.14);
+  border-color: rgba(34, 197, 94, 0.3);
+  color: rgba(207, 250, 222, 0.85);
+}
+
+.builder-mode-toggle[data-mode="quiz"]:not(.is-active) {
+  background: rgba(129, 140, 248, 0.16);
+  border-color: rgba(129, 140, 248, 0.34);
+  color: rgba(224, 231, 255, 0.85);
+}
+
+.builder-mode-toggle[data-mode="blocks"]:not(.is-active) {
+  background: rgba(249, 115, 22, 0.16);
+  border-color: rgba(249, 115, 22, 0.32);
+  color: rgba(254, 226, 226, 0.85);
+}
+
 .builder-mode-toggle:hover,
 .builder-mode-toggle:focus-visible {
   background: rgba(56, 189, 248, 0.18);
   border-color: rgba(56, 189, 248, 0.36);
   color: var(--text);
   transform: translateY(-1px);
+}
+
+.builder-mode-toggle[data-mode="flashcards"]:not(.is-active):hover,
+.builder-mode-toggle[data-mode="flashcards"]:not(.is-active):focus-visible {
+  background: rgba(34, 197, 94, 0.24);
+  border-color: rgba(34, 197, 94, 0.5);
+  color: #eafff3;
+}
+
+.builder-mode-toggle[data-mode="quiz"]:not(.is-active):hover,
+.builder-mode-toggle[data-mode="quiz"]:not(.is-active):focus-visible {
+  background: rgba(129, 140, 248, 0.26);
+  border-color: rgba(129, 140, 248, 0.52);
+  color: #fdf4ff;
+}
+
+.builder-mode-toggle[data-mode="blocks"]:not(.is-active):hover,
+.builder-mode-toggle[data-mode="blocks"]:not(.is-active):focus-visible {
+  background: rgba(249, 115, 22, 0.26);
+  border-color: rgba(249, 115, 22, 0.5);
+  color: #fff7ed;
 }
 
 .builder-mode-toggle.is-active {
@@ -2145,6 +2199,11 @@ button.builder-pill.builder-pill-outline {
 
 /* Flashcards */
 .flashcard {
+  --flash-accent: var(--accent);
+  --flash-accent-soft: color-mix(in srgb, var(--flash-accent) 18%, rgba(15, 23, 42, 0.06));
+  --flash-accent-strong: color-mix(in srgb, var(--flash-accent) 32%, rgba(15, 23, 42, 0.12));
+  --flash-accent-border: color-mix(in srgb, var(--flash-accent) 42%, rgba(15, 23, 42, 0.2));
+  --flash-accent-subtle: color-mix(in srgb, var(--flash-accent) 10%, rgba(148, 163, 184, 0.16));
   display: flex;
   flex-direction: column;
   gap: var(--pad);
@@ -2155,7 +2214,8 @@ button.builder-pill.builder-pill-outline {
   cursor: pointer;
   border-radius: var(--radius);
   padding: var(--pad-sm);
-  border: 1px solid transparent;
+  border: 1px solid var(--flash-accent-subtle);
+  background: color-mix(in srgb, var(--flash-accent) 8%, rgba(15, 23, 42, 0.04));
   transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
 }
 
@@ -2165,14 +2225,14 @@ button.builder-pill.builder-pill-outline {
 }
 
 .flash-section[data-active="true"] {
-  background: linear-gradient(135deg, rgba(56, 189, 248, 0.24), rgba(192, 132, 252, 0.26));
-  border-color: rgba(56, 189, 248, 0.45);
-  box-shadow: 0 16px 32px rgba(2, 6, 23, 0.32);
+  background: linear-gradient(135deg, var(--flash-accent-soft), var(--flash-accent-strong));
+  border-color: var(--flash-accent-border);
+  box-shadow: 0 14px 28px rgba(2, 6, 23, 0.24);
   color: var(--text);
 }
 
 .flash-section[data-active="true"] .flash-heading {
-  color: #041021;
+  color: color-mix(in srgb, var(--flash-accent) 82%, #041021);
 }
 
 .flash-heading {
@@ -2208,16 +2268,81 @@ button.builder-pill.builder-pill-outline {
 }
 
 .flash-rating-btn {
-  min-width: 84px;
+  min-width: 92px;
+  padding: 8px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid color-mix(in srgb, var(--flash-accent) 18%, rgba(148, 163, 184, 0.32));
+  background: color-mix(in srgb, var(--flash-accent) 6%, rgba(15, 23, 42, 0.05));
+  color: var(--text);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  box-shadow: none;
+}
+
+.flash-rating-btn.danger {
+  border-color: rgba(248, 113, 113, 0.36);
+}
+
+.flash-rating-btn.secondary {
+  border-color: rgba(251, 191, 36, 0.34);
+}
+
+.flash-rating-btn:hover,
+.flash-rating-btn:focus-visible {
+  background: color-mix(in srgb, var(--flash-accent) 12%, rgba(15, 23, 42, 0.08));
+  border-color: color-mix(in srgb, var(--flash-accent) 28%, rgba(148, 163, 184, 0.45));
+  transform: translateY(-1px);
+}
+
+.flash-rating-btn:active {
+  transform: translateY(0);
+  box-shadow: none;
 }
 
 .flash-rating-btn.is-selected {
-  box-shadow: 0 0 0 2px var(--accent);
+  color: #041021;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--flash-accent) 60%, rgba(14, 116, 144, 0.35));
+}
+
+.flash-rating-btn[data-rating="again"].is-selected {
+  background: linear-gradient(135deg, rgba(254, 202, 202, 0.95), rgba(248, 113, 113, 0.88));
+  border-color: rgba(248, 113, 113, 0.6);
+}
+
+.flash-rating-btn[data-rating="hard"].is-selected {
+  background: linear-gradient(135deg, rgba(253, 230, 138, 0.95), rgba(251, 191, 36, 0.86));
+  border-color: rgba(251, 191, 36, 0.58);
+}
+
+.flash-rating-btn[data-rating="good"].is-selected {
+  background: linear-gradient(135deg, rgba(187, 247, 208, 0.96), rgba(134, 239, 172, 0.88));
+  border-color: rgba(134, 239, 172, 0.58);
+}
+
+.flash-rating-btn[data-rating="easy"].is-selected {
+  background: linear-gradient(135deg, rgba(191, 219, 254, 0.96), rgba(165, 180, 252, 0.9));
+  border-color: rgba(165, 180, 252, 0.56);
 }
 
 .flash-rating-status {
   font-size: 0.8rem;
   color: var(--gray);
+}
+
+.flash-rating-status-action {
+  color: color-mix(in srgb, var(--flash-accent) 72%, #0ea5e9);
+  font-style: normal;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+
+.flash-rating-status-action:hover,
+.flash-rating-status-action:focus-visible {
+  color: color-mix(in srgb, var(--flash-accent) 82%, #38bdf8);
 }
 
 .flash-rating-status.is-error {
@@ -2231,6 +2356,20 @@ button.builder-pill.builder-pill-outline {
 .flash-rating.is-saving .flash-rating-btn {
   pointer-events: none;
   opacity: 0.75;
+}
+
+.flash-rating.is-locked .flash-rating-options {
+  display: none;
+}
+
+.flash-rating.is-locked .flash-rating-status {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.flash-rating.is-locked .flash-rating-status.flash-rating-status-action {
+  font-style: normal;
+  color: color-mix(in srgb, var(--flash-accent) 68%, #0284c7);
 }
 
 .flash-empty {


### PR DESCRIPTION
## Summary
- allow flashcard cards to advance without filling every rating, highlight chosen responses, and let review-queued sections reopen from the status chip
- soften flashcard reveals with per-card accent gradients and redesign rating buttons for clearer state feedback
- prevent global button styling from overriding study mode pills and rebuild the bundle with the updated interactions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cde081607c8322a91625cde79d7286