### PR TITLE
Add lectures object store and migration helpers

### DIFF
--- a/js/storage/lecture-schema.js
+++ b/js/storage/lecture-schema.js
@@ -1,0 +1,76 @@
+const KEY_SEPARATOR = '|';
+
+function deepClone(value) {
+  if (value == null) return value;
+  return JSON.parse(JSON.stringify(value));
+}
+
+export const DEFAULT_PASS_PLAN = {
+  id: 'default',
+  schedule: [
+    { order: 1, offsetMinutes: 0 },
+    { order: 2, offsetMinutes: 1440 },
+    { order: 3, offsetMinutes: 4320 }
+  ]
+};
+
+export const DEFAULT_LECTURE_STATUS = {
+  state: 'pending',
+  completedPasses: 0,
+  lastCompletedAt: null
+};
+
+export function lectureKey(blockId, lectureId) {
+  return `${blockId}${KEY_SEPARATOR}${lectureId}`;
+}
+
+export function cloneDefaultPassPlan() {
+  return deepClone(DEFAULT_PASS_PLAN);
+}
+
+export function cloneDefaultStatus() {
+  return deepClone(DEFAULT_LECTURE_STATUS);
+}
+
+export function normalizeLectureRecord(blockId, lecture, now = Date.now()) {
+  if (!lecture || blockId == null || lecture.id == null) return null;
+  const key = lecture.key || lectureKey(blockId, lecture.id);
+  const name = typeof lecture.name === 'string' ? lecture.name : '';
+  const weekRaw = lecture.week;
+  let week = null;
+  if (typeof weekRaw === 'number' && Number.isFinite(weekRaw)) {
+    week = weekRaw;
+  } else if (typeof weekRaw === 'string' && weekRaw.trim()) {
+    const parsed = Number(weekRaw);
+    if (!Number.isNaN(parsed)) week = parsed;
+  }
+  const tags = Array.isArray(lecture.tags)
+    ? lecture.tags.filter(tag => typeof tag === 'string' && tag.trim()).map(tag => tag.trim())
+    : [];
+  const passes = Array.isArray(lecture.passes) ? deepClone(lecture.passes) : [];
+  const passPlan = lecture.passPlan
+    ? { ...cloneDefaultPassPlan(), ...lecture.passPlan }
+    : cloneDefaultPassPlan();
+  const status = lecture.status
+    ? { ...cloneDefaultStatus(), ...lecture.status }
+    : cloneDefaultStatus();
+  const nextDueAt = lecture.nextDueAt ?? null;
+  const createdAt = typeof lecture.createdAt === 'number' ? lecture.createdAt : now;
+  const updatedAt = now;
+
+  return {
+    key,
+    blockId,
+    id: lecture.id,
+    name,
+    week,
+    tags,
+    passes,
+    passPlan,
+    status,
+    nextDueAt,
+    createdAt,
+    updatedAt
+  };
+}
+

--- a/js/storage/lectures.js
+++ b/js/storage/lectures.js
@@ -1,0 +1,162 @@
+import { openDB } from './idb.js';
+import { lectureKey, normalizeLectureRecord } from './lecture-schema.js';
+
+function clone(value) {
+  if (value == null) return value;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function prom(req) {
+  return new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function lectureStore(mode = 'readonly') {
+  const db = await openDB();
+  return db.transaction('lectures', mode).objectStore('lectures');
+}
+
+async function fetchLecturesForBlock(storeRef, blockId) {
+  if (!blockId) return [];
+  try {
+    if (typeof storeRef.index === 'function') {
+      const idx = storeRef.index('by_block');
+      if (idx && typeof idx.getAll === 'function') {
+        const results = await prom(idx.getAll(blockId));
+        return Array.isArray(results) ? results : [];
+      }
+    }
+  } catch (err) {
+    console.warn('Failed to use lecture block index, falling back to scan', err);
+  }
+  const all = await prom(storeRef.getAll());
+  return (Array.isArray(all) ? all : []).filter(entry => entry?.blockId === blockId);
+}
+
+function buildNormalizedLecture(blockId, input, existing, now) {
+  const lectureId = input?.id ?? existing?.id;
+  if (blockId == null || lectureId == null) return null;
+  const tags = Array.isArray(input?.tags)
+    ? input.tags
+    : Array.isArray(existing?.tags)
+      ? existing.tags
+      : undefined;
+  const passes = Array.isArray(input?.passes)
+    ? input.passes
+    : Array.isArray(existing?.passes)
+      ? existing.passes
+      : undefined;
+  const passPlan = input?.passPlan
+    ? { ...(existing?.passPlan || {}), ...input.passPlan }
+    : existing?.passPlan;
+  const status = input?.status
+    ? { ...(existing?.status || {}), ...input.status }
+    : existing?.status;
+  const nextDueAt = input?.nextDueAt !== undefined
+    ? input.nextDueAt
+    : existing?.nextDueAt;
+
+  const composite = {
+    ...(existing || {}),
+    ...(input || {}),
+    blockId,
+    id: lectureId,
+    key: lectureKey(blockId, lectureId),
+    tags,
+    passes,
+    passPlan,
+    status,
+    nextDueAt
+  };
+
+  const normalized = normalizeLectureRecord(blockId, composite, now);
+  if (existing?.createdAt != null) normalized.createdAt = existing.createdAt;
+  if (existing && !input?.passPlan && existing.passPlan) normalized.passPlan = clone(existing.passPlan);
+  if (existing && !input?.status && existing.status) normalized.status = clone(existing.status);
+  if (existing && !Array.isArray(input?.passes) && Array.isArray(existing.passes)) {
+    normalized.passes = clone(existing.passes);
+  }
+  if (existing && !Array.isArray(input?.tags) && Array.isArray(existing.tags)) {
+    normalized.tags = clone(existing.tags);
+  }
+  if (existing && input?.nextDueAt === undefined && existing.nextDueAt !== undefined) {
+    normalized.nextDueAt = existing.nextDueAt ?? null;
+  }
+  return normalized;
+}
+
+export async function listLecturesByBlock(blockId) {
+  try {
+    const store = await lectureStore();
+    const rows = await fetchLecturesForBlock(store, blockId);
+    return rows.map(clone);
+  } catch (err) {
+    console.warn('listLecturesByBlock failed', err);
+    return [];
+  }
+}
+
+export async function saveLecture(lecture) {
+  if (!lecture || lecture.blockId == null || lecture.id == null) {
+    throw new Error('Missing lecture identity for save');
+  }
+  const store = await lectureStore('readwrite');
+  const key = lectureKey(lecture.blockId, lecture.id);
+  const existing = await prom(store.get(key));
+  const now = Date.now();
+  const normalized = buildNormalizedLecture(lecture.blockId, lecture, existing, now);
+  if (!normalized) throw new Error('Failed to normalize lecture payload');
+  await prom(store.put(normalized));
+  return clone(normalized);
+}
+
+export async function deleteLectureRecord(blockId, lectureId) {
+  if (blockId == null || lectureId == null) return;
+  const store = await lectureStore('readwrite');
+  await prom(store.delete(lectureKey(blockId, lectureId)));
+}
+
+export async function removeLecturesForBlock(blockId) {
+  if (!blockId) return;
+  const store = await lectureStore('readwrite');
+  const rows = await fetchLecturesForBlock(store, blockId);
+  for (const row of rows) {
+    await prom(store.delete(row.key));
+  }
+}
+
+export async function bulkUpdateLectureStatus(updates) {
+  if (!Array.isArray(updates) || !updates.length) return;
+  const store = await lectureStore('readwrite');
+  const now = Date.now();
+  for (const update of updates) {
+    if (!update || update.blockId == null || update.lectureId == null) continue;
+    const key = lectureKey(update.blockId, update.lectureId);
+    const existing = await prom(store.get(key));
+    if (!existing) continue;
+    const normalized = buildNormalizedLecture(
+      update.blockId,
+      {
+        id: update.lectureId,
+        status: update.status,
+        passes: update.passes,
+        nextDueAt: update.nextDueAt,
+        passPlan: update.passPlan,
+        tags: update.tags
+      },
+      existing,
+      now
+    );
+    if (!normalized) continue;
+    await prom(store.put(normalized));
+  }
+}
+
+export {
+  DEFAULT_PASS_PLAN,
+  DEFAULT_LECTURE_STATUS,
+  lectureKey
+} from './lecture-schema.js';
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "sevenn",
       "version": "0.1.0",
       "devDependencies": {
-        "esbuild": "^0.25.9"
+        "esbuild": "^0.25.9",
+        "fake-indexeddb": "^5.0.2"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -493,6 +494,16 @@
         "@esbuild/win32-arm64": "0.25.9",
         "@esbuild/win32-ia32": "0.25.9",
         "@esbuild/win32-x64": "0.25.9"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-5.0.2.tgz",
+      "integrity": "sha512-cB507r5T3D55DfclY01GLkninZLfU7HXV/mhVRTnTRm5k2u+fY7Fof2dBkr80p5t7G7dlA/G5dI87QiMdPpMCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "test": "node --test"
   },
   "devDependencies": {
-    "esbuild": "^0.25.9"
+    "esbuild": "^0.25.9",
+    "fake-indexeddb": "^5.0.2"
   }
 }

--- a/test/storage.lectures.test.js
+++ b/test/storage.lectures.test.js
@@ -1,0 +1,116 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import 'fake-indexeddb/auto';
+
+import { openDB } from '../js/storage/idb.js';
+import {
+  listLecturesByBlock,
+  DEFAULT_PASS_PLAN,
+  DEFAULT_LECTURE_STATUS
+} from '../js/storage/lectures.js';
+
+const DB_NAME = 'sevenn-db';
+
+function requestToPromise(req) {
+  return new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function resetDatabase() {
+  if (!globalThis.indexedDB) return;
+  await new Promise((resolve, reject) => {
+    const req = indexedDB.deleteDatabase(DB_NAME);
+    req.onsuccess = () => resolve();
+    req.onerror = () => reject(req.error);
+    req.onblocked = () => resolve();
+  });
+}
+
+async function seedLegacyDatabase() {
+  await resetDatabase();
+  await new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 4);
+    req.onupgradeneeded = event => {
+      const db = event.target.result;
+      const items = db.createObjectStore('items', { keyPath: 'id' });
+      items.createIndex('by_kind', 'kind');
+      items.createIndex('by_updatedAt', 'updatedAt');
+      items.createIndex('by_favorite', 'favorite');
+      items.createIndex('by_blocks', 'blocks', { multiEntry: true });
+      items.createIndex('by_weeks', 'weeks', { multiEntry: true });
+      items.createIndex('by_lecture_ids', 'lectures.id', { multiEntry: true });
+      items.createIndex('by_search', 'tokens');
+
+      const blocks = db.createObjectStore('blocks', { keyPath: 'blockId' });
+      blocks.createIndex('by_title', 'title');
+      blocks.createIndex('by_createdAt', 'createdAt');
+
+      const exams = db.createObjectStore('exams', { keyPath: 'id' });
+      exams.createIndex('by_createdAt', 'createdAt');
+
+      db.createObjectStore('settings', { keyPath: 'id' });
+
+      const examSessions = db.createObjectStore('exam_sessions', { keyPath: 'examId' });
+      examSessions.createIndex('by_updatedAt', 'updatedAt');
+
+      const studySessions = db.createObjectStore('study_sessions', { keyPath: 'mode' });
+      studySessions.createIndex('by_updatedAt', 'updatedAt');
+
+      const blockStore = event.target.transaction.objectStore('blocks');
+      blockStore.put({
+        blockId: 'block-1',
+        title: 'Legacy Block',
+        weeks: 12,
+        lectures: [
+          { id: 1, name: 'Intro', week: 1 },
+          { id: 2, name: 'Deep dive', week: 2 }
+        ],
+        createdAt: 111,
+        updatedAt: 222
+      });
+    };
+    req.onsuccess = () => {
+      req.result.close();
+      resolve();
+    };
+    req.onerror = () => reject(req.error);
+  });
+}
+
+test('lecture migration moves embedded data into dedicated store', async () => {
+  await seedLegacyDatabase();
+  const db = await openDB();
+  const tx = db.transaction('blocks', 'readonly');
+  const blockStore = tx.objectStore('blocks');
+  const migratedBlock = await requestToPromise(blockStore.get('block-1'));
+  assert.ok(migratedBlock, 'block should exist after upgrade');
+  assert.ok(!('lectures' in migratedBlock) || !migratedBlock.lectures || migratedBlock.lectures.length === 0,
+    'legacy lecture arrays should be stripped from blocks');
+
+  const lectures = await listLecturesByBlock('block-1');
+  assert.equal(lectures.length, 2, 'lectures are migrated into dedicated store');
+
+  const intro = lectures.find(l => l.id === 1);
+  const deep = lectures.find(l => l.id === 2);
+  assert.ok(intro, 'first lecture preserved');
+  assert.ok(deep, 'second lecture preserved');
+
+  assert.equal(intro.blockId, 'block-1');
+  assert.equal(intro.name, 'Intro');
+  assert.equal(intro.week, 1);
+
+  assert.equal(deep.blockId, 'block-1');
+  assert.equal(deep.name, 'Deep dive');
+  assert.equal(deep.week, 2);
+
+  assert.deepEqual(intro.passPlan, DEFAULT_PASS_PLAN, 'default pass plan applied');
+  assert.deepEqual(intro.status, DEFAULT_LECTURE_STATUS, 'default status applied');
+  assert.ok(Array.isArray(intro.passes), 'passes array initialized');
+  assert.ok(Array.isArray(intro.tags), 'tags array initialized');
+  assert.equal(intro.nextDueAt, null, 'nextDueAt defaults to null');
+
+  db.close();
+});
+


### PR DESCRIPTION
## Summary
- bump the IndexedDB schema to v5, add a dedicated `lectures` object store, and migrate existing block lecture arrays with default pass/status metadata
- introduce lecture schema/helpers and update the storage module to re-export and rely on the new lecture APIs
- add a regression test that opens a legacy database, upgrades it, and verifies lecture data and pass metadata are preserved

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf0a4857188322b2326beb0c5a6293