### PR TITLE
Refactor block loading with shared catalog cache

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,6 @@
 import { state, setTab, setSubtab, setQuery } from './state.js';
 import { initDB, findItemsByFilter } from './storage/storage.js';
+import { loadBlockCatalog } from './storage/block-catalog.js';
 import { renderSettings } from './ui/settings.js';
 import { renderCardList } from './ui/components/cardlist.js';
 import { renderCards } from './ui/components/cards.js';
@@ -196,6 +197,11 @@ async function render() {
 async function bootstrap() {
   try {
     await initDB();
+    try {
+      await loadBlockCatalog();
+    } catch (err) {
+      console.warn('Failed to prime block catalog', err);
+    }
     render();
   } catch (err) {
     const root = document.getElementById('app');

--- a/js/storage/block-catalog.js
+++ b/js/storage/block-catalog.js
@@ -1,0 +1,96 @@
+import { listBlocks } from './storage.js';
+
+let cache = null;
+let pending = null;
+
+function cloneBlock(block) {
+  if (!block || typeof block !== 'object') return block;
+  return { ...block };
+}
+
+function cloneLecture(lecture) {
+  if (!lecture || typeof lecture !== 'object') return lecture;
+  return { ...lecture };
+}
+
+function cloneLectureIndex(index) {
+  const copy = {};
+  for (const [blockId, lectures] of Object.entries(index || {})) {
+    const next = {};
+    for (const [lectureId, lecture] of Object.entries(lectures || {})) {
+      next[lectureId] = cloneLecture(lecture);
+    }
+    copy[blockId] = next;
+  }
+  return copy;
+}
+
+function sortLectures(a, b) {
+  const aw = a?.week ?? 0;
+  const bw = b?.week ?? 0;
+  if (aw !== bw) return aw - bw;
+  const an = (a?.name || '').toLowerCase();
+  const bn = (b?.name || '').toLowerCase();
+  if (an !== bn) return an.localeCompare(bn);
+  const ai = a?.id ?? 0;
+  const bi = b?.id ?? 0;
+  return ai - bi;
+}
+
+function buildLectureLists(index) {
+  const map = {};
+  for (const [blockId, lectures] of Object.entries(index || {})) {
+    const list = Object.values(lectures || {}).map(cloneLecture);
+    list.sort(sortLectures);
+    map[blockId] = list;
+  }
+  return map;
+}
+
+function snapshotCatalog(source) {
+  return {
+    blocks: (source?.blocks || []).map(cloneBlock),
+    lectureIndex: cloneLectureIndex(source?.lectureIndex || {}),
+    lectureLists: Object.fromEntries(
+      Object.entries(source?.lectureLists || {}).map(([blockId, list]) => [
+        blockId,
+        list.map(cloneLecture)
+      ])
+    )
+  };
+}
+
+export async function loadBlockCatalog(options = {}) {
+  if (!pending || options.force) {
+    pending = (async () => {
+      const { blocks, lectureIndex } = await listBlocks();
+      const normalizedBlocks = (blocks || []).map(cloneBlock);
+      const normalizedIndex = cloneLectureIndex(lectureIndex || {});
+      const lectureLists = buildLectureLists(normalizedIndex);
+      cache = { blocks: normalizedBlocks, lectureIndex: normalizedIndex, lectureLists };
+      return snapshotCatalog(cache);
+    })();
+  }
+  return pending;
+}
+
+export function getBlockCatalog() {
+  if (!cache) return { blocks: [], lectureIndex: {}, lectureLists: {} };
+  return snapshotCatalog(cache);
+}
+
+export function getLecturesForBlock(blockId) {
+  if (!cache) return [];
+  const list = cache.lectureLists?.[blockId];
+  return Array.isArray(list) ? list.map(cloneLecture) : [];
+}
+
+export function getLectureIndex() {
+  if (!cache) return {};
+  return cloneLectureIndex(cache.lectureIndex || {});
+}
+
+export function invalidateBlockCatalog() {
+  cache = null;
+  pending = null;
+}

--- a/js/storage/lectures.js
+++ b/js/storage/lectures.js
@@ -98,6 +98,17 @@ export async function listLecturesByBlock(blockId) {
   }
 }
 
+export async function listAllLectures() {
+  try {
+    const store = await lectureStore();
+    const rows = await prom(store.getAll());
+    return Array.isArray(rows) ? rows.map(clone) : [];
+  } catch (err) {
+    console.warn('listAllLectures failed', err);
+    return [];
+  }
+}
+
 export async function saveLecture(lecture) {
   if (!lecture || lecture.blockId == null || lecture.id == null) {
     throw new Error('Missing lecture identity for save');

--- a/js/ui/components/cardlist.js
+++ b/js/ui/components/cardlist.js
@@ -1,4 +1,5 @@
-import { listBlocks, upsertItem, deleteItem } from '../../storage/storage.js';
+import { upsertItem, deleteItem } from '../../storage/storage.js';
+import { loadBlockCatalog } from '../../storage/block-catalog.js';
 import { state, setEntryLayout } from '../../state.js';
 import { setToggleState } from '../../utils.js';
 import { openEditor } from './editor.js';
@@ -302,7 +303,7 @@ export async function renderCardList(container, itemSource, kind, onChange){
       items.push(...itemSource);
     }
   }
-  const blocks = await listBlocks();
+  const { blocks } = await loadBlockCatalog();
   const blockTitle = id => blocks.find(b => b.blockId === id)?.title || id;
   const orderMap = new Map(blocks.map((b,i)=>[b.blockId,i]));
   const groups = new Map();

--- a/js/ui/components/cards.js
+++ b/js/ui/components/cards.js
@@ -1,6 +1,6 @@
-import { listBlocks } from '../../storage/storage.js';
 import { state, setCardsState } from '../../state.js';
 import { renderRichText } from './rich-text.js';
+import { loadBlockCatalog } from '../../storage/block-catalog.js';
 
 const UNASSIGNED_BLOCK_KEY = '__unassigned__';
 const MISC_LECTURE_KEY = '__misc__';
@@ -146,7 +146,7 @@ export async function renderCards(container, items, onChange) {
   container.innerHTML = '';
   container.classList.add('cards-tab');
 
-  const blockDefs = await listBlocks();
+  const { blocks: blockDefs } = await loadBlockCatalog();
   const blockLookup = new Map(blockDefs.map(def => [def.blockId, def]));
   const blockOrder = new Map(blockDefs.map((def, idx) => [def.blockId, idx]));
 

--- a/js/ui/components/editor.js
+++ b/js/ui/components/editor.js
@@ -1,5 +1,6 @@
 import { uid, setToggleState } from '../../utils.js';
-import { upsertItem, listBlocks } from '../../storage/storage.js';
+import { upsertItem } from '../../storage/storage.js';
+import { loadBlockCatalog } from '../../storage/block-catalog.js';
 import { createFloatingWindow } from './window-manager.js';
 import { createRichTextEditor } from './rich-text.js';
 import { confirmModal } from './confirm.js';
@@ -222,7 +223,11 @@ export async function openEditor(kind, onSave, existing = null) {
   form.appendChild(colorLabel);
   colorInput.addEventListener('input', markDirty);
 
-  const blocks = await listBlocks();
+  const catalog = await loadBlockCatalog();
+  const blocks = (catalog.blocks || []).map(block => ({
+    ...block,
+    lectures: (catalog.lectureLists?.[block.blockId] || []).map(lecture => ({ ...lecture }))
+  }));
   const blockMap = new Map(blocks.map(b => [b.blockId, b]));
   const blockSet = new Set(existing?.blocks || []);
   const weekSet = new Set();

--- a/js/ui/components/map.js
+++ b/js/ui/components/map.js
@@ -1,4 +1,5 @@
-import { listItemsByKind, getItem, upsertItem, getMapConfig, saveMapConfig, listBlocks } from '../../storage/storage.js';
+import { listItemsByKind, getItem, upsertItem, getMapConfig, saveMapConfig } from '../../storage/storage.js';
+import { loadBlockCatalog } from '../../storage/block-catalog.js';
 import { uid } from '../../utils.js';
 import { showPopup } from './popup.js';
 import { openEditor } from './editor.js';
@@ -942,7 +943,11 @@ export async function renderMap(root) {
   ensureListeners();
 
   await ensureMapConfig();
-  mapState.blocks = await listBlocks();
+  const catalog = await loadBlockCatalog();
+  mapState.blocks = (catalog.blocks || []).map(block => ({
+    ...block,
+    lectures: (catalog.lectureLists?.[block.blockId] || []).map(lecture => ({ ...lecture }))
+  }));
 
   const items = [
     ...(await listItemsByKind('disease')),

--- a/js/ui/components/review.js
+++ b/js/ui/components/review.js
@@ -1,7 +1,7 @@
 
 import { setFlashSession, setSubtab, setCohort } from '../../state.js';
 import { collectDueSections, collectUpcomingSections } from '../../review/scheduler.js';
-import { listBlocks } from '../../storage/storage.js';
+import { loadBlockCatalog } from '../../storage/block-catalog.js';
 import { getSectionLabel } from './section-utils.js';
 import { hydrateStudySessions, getStudySessionEntry, removeStudySession } from '../../study/study-sessions.js';
 import { loadReviewSourceItems } from '../../review/pool.js';
@@ -273,7 +273,7 @@ export async function renderReview(root, redraw) {
   const now = Date.now();
   const dueEntries = collectDueSections(cohort, { now });
   const upcomingEntries = collectUpcomingSections(cohort, { now, limit: 50 });
-  const blocks = await listBlocks();
+  const { blocks } = await loadBlockCatalog();
   const blockTitles = ensureBlockTitleMap(blocks);
 
   const savedEntry = getStudySessionEntry('review');

--- a/js/ui/components/table.js
+++ b/js/ui/components/table.js
@@ -1,4 +1,4 @@
-import { listBlocks } from '../../storage/storage.js';
+import { loadBlockCatalog } from '../../storage/block-catalog.js';
 import { createTitleCell } from './titlecell.js';
 import { renderRichText } from './rich-text.js';
 
@@ -56,7 +56,7 @@ function collectExtras(item) {
 }
 
 export async function renderTable(container, items, kind, onChange) {
-  const blocks = await listBlocks();
+  const { blocks } = await loadBlockCatalog();
   const blockTitle = (id) => blocks.find(b => b.blockId === id)?.title || id;
   const orderMap = new Map(blocks.map((b,i)=>[b.blockId,i]));
   const groups = new Map(); // block -> week -> items

--- a/test/block-catalog.test.js
+++ b/test/block-catalog.test.js
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import 'fake-indexeddb/auto';
+
+import {
+  initDB,
+  saveLecture,
+  listBlocks
+} from '../js/storage/storage.js';
+import { openDB } from '../js/storage/idb.js';
+import {
+  loadBlockCatalog,
+  getBlockCatalog,
+  getLecturesForBlock,
+  invalidateBlockCatalog
+} from '../js/storage/block-catalog.js';
+
+async function seedBlocks() {
+  await initDB();
+  const db = await openDB();
+  const clearStore = (storeName) => new Promise((resolve, reject) => {
+    const tx = db.transaction(storeName, 'readwrite');
+    const store = tx.objectStore(storeName);
+    const req = store.clear();
+    req.onerror = () => reject(req.error);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error);
+  });
+  await clearStore('lectures');
+  await clearStore('blocks');
+  invalidateBlockCatalog();
+  const putBlock = (record) => new Promise((resolve, reject) => {
+    const tx = db.transaction('blocks', 'readwrite');
+    const store = tx.objectStore('blocks');
+    const req = store.put(record);
+    req.onerror = () => reject(req.error);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error);
+  });
+
+  const now = Date.now();
+  await putBlock({ blockId: 'cardio', title: 'Cardiology', color: '#ff0000', weeks: 4, order: now + 2, createdAt: now + 2 });
+  await putBlock({ blockId: 'neuro', title: 'Neurology', color: '#0000ff', weeks: 6, order: now + 1, createdAt: now + 1 });
+
+  await saveLecture({ blockId: 'cardio', id: 2, name: 'Vascular', week: 3 });
+  await saveLecture({ blockId: 'cardio', id: 1, name: 'Basics', week: 1 });
+  await saveLecture({ blockId: 'neuro', id: 7, name: 'Motor pathways', week: 4 });
+}
+
+test('block catalog normalizes lecture data and refreshes snapshots', async () => {
+  await seedBlocks();
+  const { blocks, lectureIndex } = await listBlocks();
+
+  assert.equal(blocks.length, 2);
+  assert.ok(!('lectures' in blocks[0]), 'blocks should not embed lecture arrays');
+  assert.ok(lectureIndex.cardio, 'lecture index contains cardio block');
+  assert.ok(lectureIndex.neuro, 'lecture index contains neuro block');
+  assert.equal(Object.keys(lectureIndex.cardio).length, 2);
+  assert.equal(lectureIndex.cardio[1].name, 'Basics');
+  assert.equal(lectureIndex.cardio[1].week, 1);
+  assert.equal(lectureIndex.cardio[2].week, 3);
+
+  const catalog = await loadBlockCatalog();
+  const cardioLectures = catalog.lectureLists.cardio || [];
+  assert.deepEqual(cardioLectures.map(l => l.id), [1, 2], 'lectures sorted by week and id');
+
+  const snapshot = getBlockCatalog();
+  assert.equal(snapshot.blocks.length, 2);
+  assert.equal(snapshot.lectureIndex.cardio['1'].name, 'Basics');
+
+  const lectureSlice = getLecturesForBlock('cardio');
+  assert.deepEqual(lectureSlice.map(l => l.id), [1, 2]);
+  lectureSlice[0].name = 'Mutated';
+  const secondRead = getLecturesForBlock('cardio');
+  assert.equal(secondRead[0].name, 'Basics', 'lecture snapshots are cloned per read');
+
+  await saveLecture({ blockId: 'cardio', id: 3, name: 'Arrhythmias', week: 4 });
+  invalidateBlockCatalog();
+  const refreshed = await loadBlockCatalog();
+  assert.equal(refreshed.lectureLists.cardio.length, 3, 'catalog refresh picks up new lectures');
+});


### PR DESCRIPTION
## Summary
- update `listBlocks` to return normalized block data with a lecture index and add a shared block catalog cache
- migrate builder and other UI components to consume cached block/lecture metadata instead of querying IndexedDB repeatedly
- refresh block settings invalidation and add unit tests covering the catalog snapshot behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf14ff6fa48322840aaf6385f8345f