### PR TITLE
Refactor navigation layout and add tab regression tests

### DIFF
--- a/js/app-shell.js
+++ b/js/app-shell.js
@@ -1,0 +1,253 @@
+export function createAppShell({
+  state,
+  setTab,
+  setSubtab,
+  setQuery,
+  findItemsByFilter,
+  renderSettings,
+  renderCardList,
+  renderCards,
+  renderBuilder,
+  renderFlashcards,
+  renderReview,
+  renderQuiz,
+  renderBlockMode,
+  renderExams,
+  renderExamRunner,
+  renderMap,
+  createEntryAddControl
+}) {
+  const tabs = ["Block Board","Lists","Lectures","Cards","Study","Exams","Map"];
+
+  const listTabConfig = [
+    { label: 'Diseases', kind: 'disease' },
+    { label: 'Drugs', kind: 'drug' },
+    { label: 'Concepts', kind: 'concept' }
+  ];
+
+  function resolveListKind() {
+    const active = state?.subtab?.Lists;
+    const match = listTabConfig.find(cfg => cfg.label === active);
+    return match ? match.kind : 'disease';
+  }
+
+  async function renderApp() {
+    const root = document.getElementById('app');
+    const activeEl = document.activeElement;
+    const shouldRestoreSearch = activeEl && activeEl.dataset && activeEl.dataset.role === 'global-search';
+    const selectionStart = shouldRestoreSearch && typeof activeEl.selectionStart === 'number' ? activeEl.selectionStart : null;
+    const selectionEnd = shouldRestoreSearch && typeof activeEl.selectionEnd === 'number' ? activeEl.selectionEnd : null;
+
+    root.innerHTML = '';
+
+    const header = document.createElement('header');
+    header.className = 'header';
+
+    const left = document.createElement('div');
+    left.className = 'header-left';
+    const brand = document.createElement('div');
+    brand.className = 'brand';
+    brand.textContent = '✨ Sevenn';
+    left.appendChild(brand);
+
+    const nav = document.createElement('nav');
+    nav.className = 'tabs';
+    nav.setAttribute('aria-label', 'Primary sections');
+    const tabClassMap = {
+      'Block Board': 'tab-block-board',
+      Lists: 'tab-lists',
+      Lectures: 'tab-lectures',
+      Cards: 'tab-cards',
+      Study: 'tab-study',
+      Exams: 'tab-exams',
+      Map: 'tab-map'
+    };
+    tabs.forEach(t => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'tab';
+      if (state.tab === t) btn.classList.add('active');
+      const variant = tabClassMap[t];
+      if (variant) btn.classList.add(variant);
+      btn.textContent = t;
+      btn.addEventListener('click', () => {
+        const wasActive = state.tab === t;
+        if (t === 'Study' && wasActive && state.subtab?.Study === 'Review' && !state.flashSession && !state.quizSession) {
+          setSubtab('Study', 'Builder');
+        }
+        setTab(t);
+        renderApp();
+      });
+      nav.appendChild(btn);
+    });
+    left.appendChild(nav);
+    header.appendChild(left);
+
+    const right = document.createElement('div');
+    right.className = 'header-right';
+
+    const searchField = document.createElement('label');
+    searchField.className = 'search-field';
+    searchField.setAttribute('aria-label', 'Search entries');
+
+    const searchIcon = document.createElement('span');
+    searchIcon.className = 'search-icon';
+    searchIcon.setAttribute('aria-hidden', 'true');
+    searchIcon.innerHTML = '<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M14.5 14.5L18 18" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><circle cx="9" cy="9" r="5.8" stroke="currentColor" stroke-width="1.6"/></svg>';
+    searchField.appendChild(searchIcon);
+
+    const search = document.createElement('input');
+    search.type = 'search';
+    search.placeholder = 'Search entries';
+    search.value = state.query;
+    search.autocomplete = 'off';
+    search.spellcheck = false;
+    search.className = 'search-input';
+    search.dataset.role = 'global-search';
+    search.addEventListener('input', e => {
+      setQuery(e.target.value);
+      renderApp();
+    });
+    search.addEventListener('search', e => {
+      setQuery(e.target.value);
+      renderApp();
+    });
+    searchField.appendChild(search);
+    right.appendChild(searchField);
+
+    const settingsBtn = document.createElement('button');
+    settingsBtn.type = 'button';
+    settingsBtn.className = 'header-settings-btn';
+    if (state.tab === 'Settings') settingsBtn.classList.add('active');
+    settingsBtn.setAttribute('aria-label', 'Settings');
+    settingsBtn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869z" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/><circle cx="12" cy="12" r="2.8" stroke="currentColor" stroke-width="1.6"/></svg>';
+    settingsBtn.addEventListener('click', () => {
+      setTab('Settings');
+      renderApp();
+    });
+    right.appendChild(settingsBtn);
+
+    header.appendChild(right);
+    root.appendChild(header);
+
+    if (shouldRestoreSearch) {
+      requestAnimationFrame(() => {
+        search.focus();
+        if (selectionStart !== null && selectionEnd !== null && search.setSelectionRange) {
+          search.setSelectionRange(selectionStart, selectionEnd);
+        } else {
+          const len = search.value.length;
+          if (search.setSelectionRange) search.setSelectionRange(len, len);
+        }
+      });
+    }
+
+    const main = document.createElement('main');
+    if (state.tab === 'Map') main.className = 'map-main';
+    root.appendChild(main);
+    if (state.tab === 'Settings') {
+      await renderSettings(main);
+    } else if (state.tab === 'Lists') {
+      const kind = resolveListKind();
+      const listMeta = listTabConfig.find(cfg => cfg.kind === kind) || listTabConfig[0];
+      const createTarget = listMeta?.kind || 'disease';
+      main.appendChild(createEntryAddControl(renderApp, createTarget));
+
+      const content = document.createElement('div');
+      content.className = 'tab-content';
+      main.appendChild(content);
+
+      const selector = document.createElement('div');
+      selector.className = 'list-subtabs';
+      selector.setAttribute('role', 'tablist');
+      listTabConfig.forEach(cfg => {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'btn secondary list-subtab';
+        btn.textContent = cfg.label;
+        btn.dataset.listKind = cfg.kind;
+        btn.setAttribute('role', 'tab');
+        if (cfg.kind === kind) btn.classList.add('active');
+        btn.addEventListener('click', () => {
+          if (state.subtab?.Lists === cfg.label) return;
+          setSubtab('Lists', cfg.label);
+          renderApp();
+        });
+        selector.appendChild(btn);
+      });
+      content.appendChild(selector);
+
+      const listHost = document.createElement('div');
+      listHost.className = 'list-host';
+      content.appendChild(listHost);
+
+      const filter = { ...state.filters, types:[kind], query: state.query };
+      const query = findItemsByFilter(filter);
+      await renderCardList(listHost, query, kind, renderApp);
+    } else if (state.tab === 'Block Board') {
+      main.appendChild(createEntryAddControl(renderApp, 'disease'));
+      const content = document.createElement('div');
+      content.className = 'tab-content';
+      main.appendChild(content);
+      renderBlockMode(content, renderApp);
+    } else if (state.tab === 'Lectures') {
+      main.appendChild(createEntryAddControl(renderApp, 'disease'));
+      const content = document.createElement('div');
+      content.className = 'tab-content';
+      main.appendChild(content);
+      const wrap = document.createElement('div');
+      await renderBuilder(wrap, renderApp);
+      content.appendChild(wrap);
+    } else if (state.tab === 'Cards') {
+      main.appendChild(createEntryAddControl(renderApp, 'disease'));
+      const content = document.createElement('div');
+      content.className = 'tab-content';
+      main.appendChild(content);
+      const filter = { ...state.filters, query: state.query };
+      const query = findItemsByFilter(filter);
+      const items = await query.toArray();
+      await renderCards(content, items, renderApp);
+    } else if (state.tab === 'Study') {
+      main.appendChild(createEntryAddControl(renderApp, 'disease'));
+      const content = document.createElement('div');
+      content.className = 'tab-content';
+      main.appendChild(content);
+      if (state.flashSession) {
+        renderFlashcards(content, renderApp);
+      } else if (state.quizSession) {
+        renderQuiz(content, renderApp);
+      } else {
+        const activeStudy = state.subtab.Study === 'Blocks' ? 'Blocks' : (state.subtab.Study || 'Builder');
+        if (activeStudy === 'Review') {
+          await renderReview(content, renderApp);
+        } else if (activeStudy === 'Blocks') {
+          renderBlockMode(content, renderApp);
+        } else {
+          const wrap = document.createElement('div');
+          await renderBuilder(wrap, renderApp);
+          content.appendChild(wrap);
+        }
+      }
+    } else if (state.tab === 'Exams') {
+      main.appendChild(createEntryAddControl(renderApp, 'disease'));
+      const content = document.createElement('div');
+      content.className = 'tab-content';
+      main.appendChild(content);
+      if (state.examSession) {
+        renderExamRunner(content, renderApp);
+      } else {
+        await renderExams(content, renderApp);
+      }
+    } else if (state.tab === 'Map') {
+      main.appendChild(createEntryAddControl(renderApp, 'disease'));
+      const mapHost = document.createElement('div');
+      mapHost.className = 'tab-content map-host';
+      main.appendChild(mapHost);
+      await renderMap(mapHost);
+    } else {
+      main.textContent = `Currently viewing: ${state.tab}`;
+    }
+  }
+
+  return { renderApp, tabs, resolveListKind };
+}

--- a/js/main.js
+++ b/js/main.js
@@ -12,187 +12,27 @@ import { renderBlockMode } from './ui/components/block-mode.js';
 import { renderExams, renderExamRunner } from './ui/components/exams.js';
 import { renderMap } from './ui/components/map.js';
 import { createEntryAddControl } from './ui/components/entry-controls.js';
+import { createAppShell } from './app-shell.js';
 
-const tabs = ["Diseases","Drugs","Concepts","Cards","Study","Exams","Map"];
-
-async function render() {
-  const root = document.getElementById('app');
-  const activeEl = document.activeElement;
-  const shouldRestoreSearch = activeEl && activeEl.dataset && activeEl.dataset.role === 'global-search';
-  const selectionStart = shouldRestoreSearch && typeof activeEl.selectionStart === 'number' ? activeEl.selectionStart : null;
-  const selectionEnd = shouldRestoreSearch && typeof activeEl.selectionEnd === 'number' ? activeEl.selectionEnd : null;
-
-  root.innerHTML = '';
-
-  const header = document.createElement('header');
-  header.className = 'header';
-
-  const left = document.createElement('div');
-  left.className = 'header-left';
-  const brand = document.createElement('div');
-  brand.className = 'brand';
-  brand.textContent = '✨ Sevenn';
-  left.appendChild(brand);
-
-  const nav = document.createElement('nav');
-  nav.className = 'tabs';
-  nav.setAttribute('aria-label', 'Primary sections');
-  const tabClassMap = {
-    Diseases: 'tab-disease',
-    Drugs: 'tab-drug',
-    Concepts: 'tab-concept',
-    Cards: 'tab-cards',
-    Study: 'tab-study',
-    Exams: 'tab-exams',
-    Map: 'tab-map'
-  };
-  tabs.forEach(t => {
-    const btn = document.createElement('button');
-    btn.type = 'button';
-    btn.className = 'tab';
-    if (state.tab === t) btn.classList.add('active');
-    const variant = tabClassMap[t];
-    if (variant) btn.classList.add(variant);
-    btn.textContent = t;
-    btn.addEventListener('click', () => {
-      const wasActive = state.tab === t;
-      if (t === 'Study' && wasActive && state.subtab?.Study === 'Review' && !state.flashSession && !state.quizSession) {
-        setSubtab('Study', 'Builder');
-      }
-      setTab(t);
-      render();
-    });
-    nav.appendChild(btn);
-  });
-  left.appendChild(nav);
-  header.appendChild(left);
-
-  const right = document.createElement('div');
-  right.className = 'header-right';
-
-  const searchField = document.createElement('label');
-  searchField.className = 'search-field';
-  searchField.setAttribute('aria-label', 'Search entries');
-
-  const searchIcon = document.createElement('span');
-  searchIcon.className = 'search-icon';
-  searchIcon.setAttribute('aria-hidden', 'true');
-  searchIcon.innerHTML = '<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M14.5 14.5L18 18" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><circle cx="9" cy="9" r="5.8" stroke="currentColor" stroke-width="1.6"/></svg>';
-  searchField.appendChild(searchIcon);
-
-  const search = document.createElement('input');
-  search.type = 'search';
-  search.placeholder = 'Search entries';
-  search.value = state.query;
-  search.autocomplete = 'off';
-  search.spellcheck = false;
-  search.className = 'search-input';
-  search.dataset.role = 'global-search';
-  search.addEventListener('input', e => {
-    setQuery(e.target.value);
-    render();
-  });
-  search.addEventListener('search', e => {
-    setQuery(e.target.value);
-    render();
-  });
-  searchField.appendChild(search);
-  right.appendChild(searchField);
-
-  const settingsBtn = document.createElement('button');
-  settingsBtn.type = 'button';
-  settingsBtn.className = 'header-settings-btn';
-  if (state.tab === 'Settings') settingsBtn.classList.add('active');
-  settingsBtn.setAttribute('aria-label', 'Settings');
-  settingsBtn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869z" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/><circle cx="12" cy="12" r="2.8" stroke="currentColor" stroke-width="1.6"/></svg>';
-  settingsBtn.addEventListener('click', () => {
-    setTab('Settings');
-    render();
-  });
-  right.appendChild(settingsBtn);
-
-  header.appendChild(right);
-  root.appendChild(header);
-
-  if (shouldRestoreSearch) {
-    requestAnimationFrame(() => {
-      search.focus();
-      if (selectionStart !== null && selectionEnd !== null && search.setSelectionRange) {
-        search.setSelectionRange(selectionStart, selectionEnd);
-      } else {
-        const len = search.value.length;
-        if (search.setSelectionRange) search.setSelectionRange(len, len);
-      }
-    });
-  }
-
-  const main = document.createElement('main');
-  if (state.tab === 'Map') main.className = 'map-main';
-  root.appendChild(main);
-  if (state.tab === 'Settings') {
-    await renderSettings(main);
-  } else if (['Diseases','Drugs','Concepts'].includes(state.tab)) {
-    const kindMap = { Diseases:'disease', Drugs:'drug', Concepts:'concept' };
-    const kind = kindMap[state.tab];
-    main.appendChild(createEntryAddControl(render, kind));
-
-    const listHost = document.createElement('div');
-    listHost.className = 'tab-content';
-    main.appendChild(listHost);
-
-    const filter = { ...state.filters, types:[kind], query: state.query };
-    const query = findItemsByFilter(filter);
-    await renderCardList(listHost, query, kind, render);
-  } else if (state.tab === 'Cards') {
-    main.appendChild(createEntryAddControl(render, 'disease'));
-    const content = document.createElement('div');
-    content.className = 'tab-content';
-    main.appendChild(content);
-    const filter = { ...state.filters, query: state.query };
-    const query = findItemsByFilter(filter);
-    const items = await query.toArray();
-    await renderCards(content, items, render);
-  } else if (state.tab === 'Study') {
-    main.appendChild(createEntryAddControl(render, 'disease'));
-    const content = document.createElement('div');
-    content.className = 'tab-content';
-    main.appendChild(content);
-    if (state.flashSession) {
-      renderFlashcards(content, render);
-    } else if (state.quizSession) {
-      renderQuiz(content, render);
-    } else {
-      const activeStudy = state.subtab.Study === 'Blocks' ? 'Blocks' : (state.subtab.Study || 'Builder');
-      if (activeStudy === 'Review') {
-        await renderReview(content, render);
-      } else if (activeStudy === 'Blocks') {
-        renderBlockMode(content, render);
-      } else {
-        const wrap = document.createElement('div');
-        await renderBuilder(wrap, render);
-        content.appendChild(wrap);
-      }
-    }
-  } else if (state.tab === 'Exams') {
-    main.appendChild(createEntryAddControl(render, 'disease'));
-    const content = document.createElement('div');
-    content.className = 'tab-content';
-    main.appendChild(content);
-    if (state.examSession) {
-      renderExamRunner(content, render);
-    } else {
-      await renderExams(content, render);
-    }
-  } else if (state.tab === 'Map') {
-    main.appendChild(createEntryAddControl(render, 'disease'));
-    const mapHost = document.createElement('div');
-    mapHost.className = 'tab-content map-host';
-    main.appendChild(mapHost);
-    await renderMap(mapHost);
-  } else {
-    main.textContent = `Currently viewing: ${state.tab}`;
-  }
-}
+const { renderApp, tabs, resolveListKind } = createAppShell({
+  state,
+  setTab,
+  setSubtab,
+  setQuery,
+  findItemsByFilter,
+  renderSettings,
+  renderCardList,
+  renderCards,
+  renderBuilder,
+  renderFlashcards,
+  renderReview,
+  renderQuiz,
+  renderBlockMode,
+  renderExams,
+  renderExamRunner,
+  renderMap,
+  createEntryAddControl
+});
 
 async function bootstrap() {
   try {
@@ -202,7 +42,7 @@ async function bootstrap() {
     } catch (err) {
       console.warn('Failed to prime block catalog', err);
     }
-    render();
+    renderApp();
   } catch (err) {
     const root = document.getElementById('app');
     if (root) root.textContent = 'Failed to load app';
@@ -210,4 +50,8 @@ async function bootstrap() {
   }
 }
 
-bootstrap();
+if (typeof window !== 'undefined' && !globalThis.__SEVENN_TEST__) {
+  bootstrap();
+}
+
+export { renderApp, renderApp as render, tabs, resolveListKind };

--- a/js/state.js
+++ b/js/state.js
@@ -1,9 +1,10 @@
 export const state = {
-  tab: "Diseases",
+  tab: "Block Board",
   subtab: {
     Diseases: "Browse",
     Drugs: "Browse",
     Concepts: "Browse",
+    Lists: "Diseases",
     Study: "Builder",
     Exams: "", // placeholder
     Map: "",

--- a/js/ui/components/builder.js
+++ b/js/ui/components/builder.js
@@ -1,4 +1,4 @@
-import { state, setBuilder, setCohort, resetBlockMode, setBlockMode, setSubtab, setFlashSession, setQuizSession, setStudySelectedMode } from '../../state.js';
+import { state, setBuilder, setCohort, resetBlockMode, setBlockMode, setSubtab, setFlashSession, setQuizSession, setStudySelectedMode, setTab } from '../../state.js';
 import { listItemsByKind } from '../../storage/storage.js';
 import { loadBlockCatalog } from '../../storage/block-catalog.js';
 import { setToggleState } from '../../utils.js';
@@ -475,6 +475,7 @@ function renderModeCard(rerender, redraw) {
       }
       resetBlockMode();
       setSubtab('Study', 'Blocks');
+      setTab('Block Board');
       redraw();
       return;
     }
@@ -490,6 +491,7 @@ function renderModeCard(rerender, redraw) {
       setQuizSession({ idx: 0, score: 0, pool: cohort });
     }
     setSubtab('Study', 'Builder');
+    setTab('Study');
     redraw();
   });
 
@@ -506,6 +508,7 @@ function renderModeCard(rerender, redraw) {
         setBlockMode(savedEntry.session);
       }
       setSubtab('Study', 'Blocks');
+      setTab('Block Board');
       redraw();
       return;
     }
@@ -517,6 +520,7 @@ function renderModeCard(rerender, redraw) {
       setQuizSession(savedEntry.session);
     }
     setSubtab('Study', 'Builder');
+    setTab('Study');
     redraw();
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,137 @@
       "version": "0.1.0",
       "devDependencies": {
         "esbuild": "^0.25.9",
-        "fake-indexeddb": "^5.0.2"
+        "fake-indexeddb": "^5.0.2",
+        "jsdom": "^24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -454,6 +584,197 @@
         "node": ">=18"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
@@ -505,6 +826,516 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.22",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
+      "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "esbuild": "^0.25.9",
-    "fake-indexeddb": "^5.0.2"
+    "fake-indexeddb": "^5.0.2",
+    "jsdom": "^24.0.0"
   }
 }

--- a/style.css
+++ b/style.css
@@ -361,6 +361,45 @@ button:not(.tab):not(.fab-btn):not(.builder-pill):not(.builder-mode-toggle):hove
   background: linear-gradient(135deg, rgba(134, 239, 172, 0.96), rgba(16, 185, 129, 0.9));
 }
 
+.tab.tab-block-board {
+  background: rgba(254, 215, 170, 0.22);
+  border-color: rgba(251, 191, 36, 0.42);
+}
+
+.tab.tab-block-board:hover {
+  background: rgba(254, 215, 170, 0.32);
+}
+
+.tab.tab-block-board.active {
+  background: linear-gradient(135deg, rgba(251, 191, 36, 0.92), rgba(251, 146, 60, 0.9));
+}
+
+.tab.tab-lists {
+  background: rgba(191, 219, 254, 0.26);
+  border-color: rgba(96, 165, 250, 0.45);
+}
+
+.tab.tab-lists:hover {
+  background: rgba(191, 219, 254, 0.34);
+}
+
+.tab.tab-lists.active {
+  background: linear-gradient(135deg, rgba(147, 197, 253, 0.96), rgba(96, 165, 250, 0.9));
+}
+
+.tab.tab-lectures {
+  background: rgba(186, 230, 253, 0.24);
+  border-color: rgba(56, 189, 248, 0.42);
+}
+
+.tab.tab-lectures:hover {
+  background: rgba(186, 230, 253, 0.32);
+}
+
+.tab.tab-lectures.active {
+  background: linear-gradient(135deg, rgba(125, 211, 252, 0.96), rgba(14, 165, 233, 0.88));
+}
+
 .tab.tab-cards {
   background: rgba(196, 181, 253, 0.22);
   border-color: rgba(196, 181, 253, 0.4);
@@ -411,6 +450,30 @@ button:not(.tab):not(.fab-btn):not(.builder-pill):not(.builder-mode-toggle):hove
 
 .tab.tab-map.active {
   background: linear-gradient(135deg, rgba(165, 180, 252, 0.96), rgba(129, 140, 248, 0.92));
+}
+
+.list-subtabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: var(--pad-md);
+}
+
+.list-subtab {
+  border-radius: 999px;
+  padding: 6px 14px;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.list-subtab.active {
+  background: linear-gradient(135deg, rgba(191, 219, 254, 0.96), rgba(125, 211, 252, 0.9));
+  border-color: transparent;
+  color: #06283b;
+  box-shadow: 0 12px 26px rgba(14, 116, 144, 0.18);
+}
+
+.list-host {
+  margin-top: var(--pad-sm);
 }
 
 .subtabs {

--- a/test/ui.tabs.test.js
+++ b/test/ui.tabs.test.js
@@ -1,0 +1,168 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mock } from 'node:test';
+import { JSDOM } from 'jsdom';
+
+import { state, setTab, setSubtab, setQuery } from '../js/state.js';
+import { createAppShell } from '../js/app-shell.js';
+
+const renderCardListMock = mock.fn(async (container, _source, kind) => {
+  container.dataset.renderedKind = kind;
+});
+const renderCardsMock = mock.fn(async (container) => {
+  container.dataset.rendered = 'cards';
+});
+const renderBuilderMock = mock.fn(async (container) => {
+  container.dataset.rendered = 'builder';
+});
+const renderFlashcardsMock = mock.fn(() => {});
+const renderReviewMock = mock.fn(async () => {});
+const renderQuizMock = mock.fn(() => {});
+const renderBlockModeMock = mock.fn(() => {});
+const renderExamsMock = mock.fn(async (container) => {
+  container.dataset.rendered = 'exams';
+});
+const renderExamRunnerMock = mock.fn(() => {});
+const renderMapMock = mock.fn(async (container) => {
+  container.dataset.rendered = 'map';
+});
+const renderSettingsMock = mock.fn(async (container) => {
+  container.dataset.rendered = 'settings';
+});
+const createEntryAddControlMock = mock.fn((_redraw, kind) => {
+  const control = document.createElement('div');
+  control.className = 'add-control';
+  control.dataset.kind = kind;
+  return control;
+});
+const findItemsByFilterMock = mock.fn(() => ({
+  async toArray() {
+    return [];
+  }
+}));
+
+const { renderApp, tabs } = createAppShell({
+  state,
+  setTab,
+  setSubtab,
+  setQuery,
+  findItemsByFilter: findItemsByFilterMock,
+  renderSettings: renderSettingsMock,
+  renderCardList: renderCardListMock,
+  renderCards: renderCardsMock,
+  renderBuilder: renderBuilderMock,
+  renderFlashcards: renderFlashcardsMock,
+  renderReview: renderReviewMock,
+  renderQuiz: renderQuizMock,
+  renderBlockMode: renderBlockModeMock,
+  renderExams: renderExamsMock,
+  renderExamRunner: renderExamRunnerMock,
+  renderMap: renderMapMock,
+  createEntryAddControl: createEntryAddControlMock
+});
+
+function resetState() {
+  setTab('Block Board');
+  setQuery('');
+  state.subtab.Lists = 'Diseases';
+  state.subtab.Study = 'Builder';
+  state.flashSession = null;
+  state.quizSession = null;
+  state.examSession = null;
+}
+
+function resetMocks() {
+  renderCardListMock.mock.resetCalls();
+  renderCardsMock.mock.resetCalls();
+  renderBuilderMock.mock.resetCalls();
+  renderFlashcardsMock.mock.resetCalls();
+  renderReviewMock.mock.resetCalls();
+  renderQuizMock.mock.resetCalls();
+  renderBlockModeMock.mock.resetCalls();
+  renderExamsMock.mock.resetCalls();
+  renderExamRunnerMock.mock.resetCalls();
+  renderMapMock.mock.resetCalls();
+  renderSettingsMock.mock.resetCalls();
+  createEntryAddControlMock.mock.resetCalls();
+  findItemsByFilterMock.mock.resetCalls();
+}
+
+describe('tab layout', () => {
+  beforeEach(() => {
+    resetMocks();
+    resetState();
+    const dom = new JSDOM('<!DOCTYPE html><div id="app"></div>');
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.HTMLElement = dom.window.HTMLElement;
+    global.Node = dom.window.Node;
+    global.requestAnimationFrame = (cb) => cb();
+  });
+
+  it('exposes the new navigation order', () => {
+    assert.deepStrictEqual(tabs, ['Block Board','Lists','Lectures','Cards','Study','Exams','Map']);
+  });
+
+  it('renders the lists tab with disease entries by default', async () => {
+    setTab('Lists');
+    await renderApp();
+    assert.equal(renderCardListMock.mock.callCount(), 1);
+    const firstCall = renderCardListMock.mock.calls[0];
+    assert(firstCall);
+    assert.equal(firstCall.arguments[2], 'disease');
+    assert.equal(createEntryAddControlMock.mock.callCount(), 1);
+    const buttons = document.querySelectorAll('.list-subtab');
+    assert.equal(buttons.length, 3);
+    const active = document.querySelector('.list-subtab.active');
+    assert(active);
+    assert.equal(active?.textContent, 'Diseases');
+  });
+
+  it('switches list subtabs when the selector is clicked', async () => {
+    setTab('Lists');
+    await renderApp();
+    const conceptsBtn = Array.from(document.querySelectorAll('.list-subtab')).find(btn => btn.textContent === 'Concepts');
+    assert(conceptsBtn);
+    conceptsBtn.click();
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(state.subtab.Lists, 'Concepts');
+    const lastCall = renderCardListMock.mock.calls.at(-1);
+    assert(lastCall);
+    assert.equal(lastCall.arguments[2], 'concept');
+  });
+
+  it('routes to the block board view', async () => {
+    setTab('Block Board');
+    await renderApp();
+    assert.equal(renderBlockModeMock.mock.callCount(), 1);
+  });
+
+  it('routes to lectures via the builder', async () => {
+    setTab('Lectures');
+    await renderApp();
+    assert.equal(renderBuilderMock.mock.callCount(), 1);
+  });
+
+  it('smoke tests cards, study, exams, and map tabs', async () => {
+    setTab('Cards');
+    await renderApp();
+    assert.equal(renderCardsMock.mock.callCount(), 1);
+
+    setTab('Study');
+    state.flashSession = null;
+    state.quizSession = null;
+    state.subtab.Study = 'Builder';
+    await renderApp();
+    assert.equal(renderBuilderMock.mock.callCount(), 1);
+
+    setTab('Exams');
+    state.examSession = null;
+    await renderApp();
+    assert.equal(renderExamsMock.mock.callCount(), 1);
+
+    setTab('Map');
+    await renderApp();
+    assert.equal(renderMapMock.mock.callCount(), 1);
+  });
+});


### PR DESCRIPTION
## Summary
- refactor the app shell to introduce the Block Board, Lists, and Lectures tabs with a combined Lists selector
- update state defaults, builder navigation, and styles to support the new layout
- add a jsdom-based regression test suite that exercises tab switching

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf1960aee083228c9686c7af79ff6d