### PR TITLE
Add lecture scheduler with planner settings and tests

### DIFF
--- a/js/lectures/scheduler.js
+++ b/js/lectures/scheduler.js
@@ -1,0 +1,346 @@
+const DAY_MINUTES = 24 * 60;
+const MINUTE_MS = 60 * 1000;
+
+function clone(value) {
+  if (value == null) return value;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function toNumber(value, fallback = 0) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : fallback;
+}
+
+function sanitizeLabel(label, order) {
+  if (typeof label === 'string' && label.trim()) return label.trim();
+  return `Pass ${order}`;
+}
+
+function inferAnchor(offsetMinutes) {
+  if (!Number.isFinite(offsetMinutes)) return 'today';
+  if (offsetMinutes < DAY_MINUTES) return 'today';
+  if (offsetMinutes < DAY_MINUTES * 2) return 'tomorrow';
+  return 'upcoming';
+}
+
+function startOfDay(timestamp) {
+  const date = new Date(timestamp);
+  date.setHours(0, 0, 0, 0);
+  return date.getTime();
+}
+
+function computeAnchoredDue(startAt, step, plannerDefaults) {
+  const offsetMinutes = toNumber(step?.offsetMinutes, 0);
+  const base = startAt + Math.round(offsetMinutes * MINUTE_MS);
+  if (!plannerDefaults || typeof plannerDefaults !== 'object') return base;
+  const anchorName = typeof step?.anchor === 'string' && step.anchor.trim()
+    ? step.anchor.trim()
+    : inferAnchor(offsetMinutes);
+  const anchorOffsets = plannerDefaults.anchorOffsets || {};
+  const anchorMinutes = toNumber(anchorOffsets[anchorName], null);
+  if (anchorMinutes == null) return base;
+  const anchorBase = startOfDay(base) + Math.round(anchorMinutes * MINUTE_MS);
+  if (!Number.isFinite(anchorBase)) return base;
+  if (offsetMinutes >= 0 && anchorBase < base) {
+    return base;
+  }
+  return anchorBase;
+}
+
+export const DEFAULT_PASS_PLAN = {
+  id: 'default',
+  schedule: [
+    { order: 1, label: 'Pass 1', offsetMinutes: 0, anchor: 'today' },
+    { order: 2, label: 'Pass 2', offsetMinutes: 24 * 60, anchor: 'tomorrow' },
+    { order: 3, label: 'Pass 3', offsetMinutes: 72 * 60, anchor: 'upcoming' }
+  ]
+};
+
+export const DEFAULT_PLANNER_DEFAULTS = {
+  anchorOffsets: {
+    today: 8 * 60,
+    tomorrow: 8 * 60,
+    upcoming: 8 * 60
+  },
+  passes: DEFAULT_PASS_PLAN.schedule.map(entry => ({
+    order: entry.order,
+    label: entry.label,
+    offsetMinutes: entry.offsetMinutes,
+    anchor: entry.anchor
+  }))
+};
+
+export function normalizePassPlan(plan) {
+  const source = plan && typeof plan === 'object' ? plan : {};
+  const mergedSchedule = Array.isArray(source.schedule) && source.schedule.length
+    ? source.schedule
+    : DEFAULT_PASS_PLAN.schedule;
+  const normalizedSchedule = mergedSchedule
+    .map((step, index) => {
+      const order = toNumber(step?.order, index + 1);
+      const offsetMinutes = toNumber(step?.offsetMinutes, DEFAULT_PASS_PLAN.schedule[index]?.offsetMinutes ?? 0);
+      const anchor = typeof step?.anchor === 'string' && step.anchor.trim()
+        ? step.anchor.trim()
+        : inferAnchor(offsetMinutes);
+      const label = sanitizeLabel(step?.label, order);
+      return { order, offsetMinutes, anchor, label };
+    })
+    .sort((a, b) => a.order - b.order);
+  return {
+    id: typeof source.id === 'string' && source.id.trim() ? source.id.trim() : DEFAULT_PASS_PLAN.id,
+    schedule: normalizedSchedule
+  };
+}
+
+export function normalizePlannerDefaults(raw) {
+  const source = raw && typeof raw === 'object' ? raw : {};
+  const anchorOffsets = {};
+  const defaultAnchors = DEFAULT_PLANNER_DEFAULTS.anchorOffsets;
+  const incomingAnchors = source.anchorOffsets && typeof source.anchorOffsets === 'object'
+    ? source.anchorOffsets
+    : {};
+  const allKeys = new Set([
+    ...Object.keys(defaultAnchors),
+    ...Object.keys(incomingAnchors)
+  ]);
+  for (const key of allKeys) {
+    const fallback = defaultAnchors[key] ?? 0;
+    const value = incomingAnchors[key];
+    anchorOffsets[key] = toNumber(value, fallback);
+  }
+
+  const passesSource = Array.isArray(source.passes) && source.passes.length
+    ? source.passes
+    : DEFAULT_PLANNER_DEFAULTS.passes;
+  const normalizedPlan = normalizePassPlan({ schedule: passesSource });
+
+  return {
+    anchorOffsets,
+    passes: normalizedPlan.schedule.map(step => ({
+      order: step.order,
+      label: step.label,
+      offsetMinutes: step.offsetMinutes,
+      anchor: step.anchor
+    }))
+  };
+}
+
+function sanitizeAttachments(raw) {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter(att => att != null)
+    .map(att => (typeof att === 'object' ? JSON.parse(JSON.stringify(att)) : att));
+}
+
+export function normalizeLecturePasses({
+  plan,
+  passes,
+  plannerDefaults,
+  startAt,
+  now = Date.now()
+} = {}) {
+  const normalizedPlan = normalizePassPlan(plan || DEFAULT_PASS_PLAN);
+  const schedule = normalizedPlan.schedule;
+  const existingList = Array.isArray(passes) ? passes : [];
+  const existingByOrder = new Map();
+  existingList.forEach((entry, index) => {
+    if (!entry || typeof entry !== 'object') return;
+    const order = toNumber(entry.order, index + 1);
+    if (!existingByOrder.has(order)) {
+      existingByOrder.set(order, entry);
+    }
+  });
+  const planner = normalizePlannerDefaults(plannerDefaults || {});
+  const anchorConfig = {
+    anchorOffsets: planner.anchorOffsets,
+    schedule: planner.passes
+  };
+  const startTimestamp = Number.isFinite(startAt) ? startAt : now;
+  const normalizedPasses = schedule.map((step, index) => {
+    const existing = existingByOrder.get(step.order) || existingList[index] || {};
+    const dueCandidate = Number.isFinite(existing?.due) ? existing.due : null;
+    const due = dueCandidate != null
+      ? dueCandidate
+      : computeAnchoredDue(startTimestamp, step, anchorConfig);
+    const completedAt = Number.isFinite(existing?.completedAt) ? existing.completedAt : null;
+    const label = sanitizeLabel(existing?.label ?? step.label, step.order);
+    const anchor = typeof (existing?.anchor ?? step.anchor) === 'string'
+      ? (existing?.anchor ?? step.anchor)
+      : inferAnchor(step.offsetMinutes);
+    const attachments = sanitizeAttachments(existing.attachments);
+    return {
+      order: step.order,
+      label,
+      offsetMinutes: step.offsetMinutes,
+      anchor,
+      due,
+      completedAt,
+      attachments
+    };
+  });
+  return normalizedPasses;
+}
+
+export function calculateNextDue(passes) {
+  if (!Array.isArray(passes) || !passes.length) return null;
+  const dueTimes = passes
+    .filter(pass => pass && !pass.completedAt)
+    .map(pass => Number.isFinite(pass.due) ? pass.due : null)
+    .filter(due => due != null)
+    .sort((a, b) => a - b);
+  return dueTimes.length ? dueTimes[0] : null;
+}
+
+export function deriveLectureStatus(passes, base = {}) {
+  const total = Array.isArray(passes) ? passes.length : 0;
+  const completed = Array.isArray(passes)
+    ? passes.filter(pass => Number.isFinite(pass?.completedAt)).length
+    : 0;
+  const lastCompletedAt = Array.isArray(passes)
+    ? passes.reduce((max, pass) => {
+        const ts = Number.isFinite(pass?.completedAt) ? pass.completedAt : null;
+        if (ts == null) return max;
+        return max == null ? ts : Math.max(max, ts);
+      }, null)
+    : null;
+  let state = 'pending';
+  if (total === 0) {
+    state = 'unscheduled';
+  } else if (completed === 0) {
+    state = 'pending';
+  } else if (completed < total) {
+    state = 'in-progress';
+  } else {
+    state = 'complete';
+  }
+  const merged = {
+    ...base,
+    completedPasses: completed,
+    lastCompletedAt,
+    state
+  };
+  return merged;
+}
+
+export function markPassCompleted(lecture, passIndex, completedAt = Date.now()) {
+  if (!lecture || typeof lecture !== 'object') return null;
+  const passes = Array.isArray(lecture.passes) ? lecture.passes.map(pass => ({ ...pass })) : [];
+  if (!Number.isFinite(passIndex)) return { ...lecture, passes, nextDueAt: calculateNextDue(passes), status: deriveLectureStatus(passes, lecture.status) };
+  if (passes.length === 0) {
+    return { ...lecture, passes, nextDueAt: calculateNextDue(passes), status: deriveLectureStatus(passes, lecture.status) };
+  }
+  const clamped = Math.floor(passIndex);
+  if (clamped < 0 || clamped >= passes.length) {
+    return { ...lecture, passes, nextDueAt: calculateNextDue(passes), status: deriveLectureStatus(passes, lecture.status) };
+  }
+  if (passes[clamped]) {
+    passes[clamped].completedAt = completedAt;
+  }
+  const status = deriveLectureStatus(passes, lecture.status);
+  const nextDueAt = calculateNextDue(passes);
+  return {
+    ...lecture,
+    passes,
+    status,
+    nextDueAt
+  };
+}
+
+export function shiftLecturePasses(lecture, shiftMinutes, { includeCompleted = false } = {}) {
+  if (!lecture || typeof lecture !== 'object') return null;
+  const shiftMs = Math.round(toNumber(shiftMinutes, 0) * MINUTE_MS);
+  const passes = Array.isArray(lecture.passes)
+    ? lecture.passes.map(pass => {
+        if (!pass || !Number.isFinite(pass.due)) return { ...pass };
+        if (!includeCompleted && Number.isFinite(pass.completedAt)) {
+          return { ...pass };
+        }
+        return { ...pass, due: pass.due + shiftMs };
+      })
+    : [];
+  const status = deriveLectureStatus(passes, lecture.status);
+  const nextDueAt = calculateNextDue(passes);
+  return {
+    ...lecture,
+    passes,
+    status,
+    nextDueAt
+  };
+}
+
+export function recalcLectureSchedule(lecture, { plannerDefaults, startAt, now = Date.now() } = {}) {
+  if (!lecture || typeof lecture !== 'object') return null;
+  const normalizedPlan = normalizePassPlan(lecture.passPlan || DEFAULT_PASS_PLAN);
+  const normalizedPlanner = normalizePlannerDefaults(plannerDefaults || lecture.plannerDefaults || {});
+  const passes = normalizeLecturePasses({
+    plan: normalizedPlan,
+    passes: lecture.passes,
+    plannerDefaults: normalizedPlanner,
+    startAt,
+    now
+  });
+  const status = deriveLectureStatus(passes, lecture.status);
+  const nextDueAt = calculateNextDue(passes);
+  return {
+    ...lecture,
+    passPlan: normalizedPlan,
+    plannerDefaults: normalizedPlanner,
+    passes,
+    status,
+    nextDueAt
+  };
+}
+
+export function groupLectureQueues(lectures, { now = Date.now() } = {}) {
+  const result = {
+    overdue: [],
+    today: [],
+    tomorrow: [],
+    upcoming: []
+  };
+  if (!Array.isArray(lectures) || !lectures.length) return result;
+  const startToday = startOfDay(now);
+  const startTomorrow = startToday + DAY_MINUTES * MINUTE_MS;
+  const startDayAfter = startTomorrow + DAY_MINUTES * MINUTE_MS;
+  const addEntry = (bucket, entry) => {
+    result[bucket].push(entry);
+  };
+  for (const lecture of lectures) {
+    if (!lecture || typeof lecture !== 'object') continue;
+    const passes = Array.isArray(lecture.passes) ? lecture.passes : [];
+    const nextPass = passes.find(pass => pass && !Number.isFinite(pass.completedAt));
+    const due = Number.isFinite(nextPass?.due) ? nextPass.due : null;
+    const entry = { lecture, pass: nextPass || null, due };
+    if (due == null) {
+      addEntry('upcoming', entry);
+      continue;
+    }
+    if (due <= now) {
+      addEntry('overdue', entry);
+    } else if (due < startTomorrow) {
+      addEntry('today', entry);
+    } else if (due < startDayAfter) {
+      addEntry('tomorrow', entry);
+    } else {
+      addEntry('upcoming', entry);
+    }
+  }
+  for (const key of Object.keys(result)) {
+    result[key].sort((a, b) => {
+      if (a.due == null && b.due == null) return 0;
+      if (a.due == null) return 1;
+      if (b.due == null) return -1;
+      return a.due - b.due;
+    });
+  }
+  return result;
+}
+
+export function clonePlannerDefaults() {
+  return clone(DEFAULT_PLANNER_DEFAULTS);
+}
+
+export function clonePassPlan() {
+  return clone(DEFAULT_PASS_PLAN);
+}
+

--- a/js/storage/lectures.js
+++ b/js/storage/lectures.js
@@ -54,6 +54,9 @@ function buildNormalizedLecture(blockId, input, existing, now) {
   const status = input?.status
     ? { ...(existing?.status || {}), ...input.status }
     : existing?.status;
+  const plannerDefaults = input?.plannerDefaults
+    ? { ...(existing?.plannerDefaults || {}), ...input.plannerDefaults }
+    : existing?.plannerDefaults;
   const nextDueAt = input?.nextDueAt !== undefined
     ? input.nextDueAt
     : existing?.nextDueAt;
@@ -67,6 +70,7 @@ function buildNormalizedLecture(blockId, input, existing, now) {
     tags,
     passes,
     passPlan,
+    plannerDefaults,
     status,
     nextDueAt
   };

--- a/js/ui/components/lectures.js
+++ b/js/ui/components/lectures.js
@@ -101,8 +101,14 @@ function formatNextDue(nextDueAt, now = Date.now()) {
 }
 
 function formatPassSummary(lecture) {
-  const total = Array.isArray(lecture?.passPlan?.schedule) ? lecture.passPlan.schedule.length : 0;
-  const completed = lecture?.status?.completedPasses ?? (Array.isArray(lecture?.passes) ? lecture.passes.length : 0);
+  const total = Array.isArray(lecture?.passes)
+    ? lecture.passes.length
+    : Array.isArray(lecture?.passPlan?.schedule)
+      ? lecture.passPlan.schedule.length
+      : 0;
+  const completed = Array.isArray(lecture?.passes)
+    ? lecture.passes.filter(pass => Number.isFinite(pass?.completedAt)).length
+    : lecture?.status?.completedPasses ?? 0;
   const stateLabel = lecture?.status?.state ? lecture.status.state : 'pending';
   return `${completed}/${total} passes • ${stateLabel}`;
 }

--- a/test/lectures.scheduler.test.js
+++ b/test/lectures.scheduler.test.js
@@ -1,0 +1,108 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  DEFAULT_PASS_PLAN,
+  DEFAULT_PLANNER_DEFAULTS,
+  normalizePassPlan,
+  normalizePlannerDefaults,
+  normalizeLecturePasses,
+  calculateNextDue,
+  recalcLectureSchedule,
+  groupLectureQueues,
+  markPassCompleted,
+  shiftLecturePasses
+} from '../js/lectures/scheduler.js';
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+test('default scheduler generates anchored passes', () => {
+  const planner = normalizePlannerDefaults(DEFAULT_PLANNER_DEFAULTS);
+  const plan = normalizePassPlan(DEFAULT_PASS_PLAN);
+  const startAt = Date.UTC(2024, 0, 1, 8, 0, 0);
+  const passes = normalizeLecturePasses({ plan, plannerDefaults: planner, startAt, now: startAt });
+  assert.equal(passes.length, plan.schedule.length, 'pass count matches plan');
+  assert.equal(passes[0].due, startAt, 'first pass anchored to start timestamp');
+  assert.equal(passes[1].due, startAt + DAY, 'second pass scheduled next day');
+  assert.equal(passes[2].due, startAt + DAY * 3, 'third pass scheduled three days later');
+  const nextDue = calculateNextDue(passes);
+  assert.equal(nextDue, passes[0].due, 'next due resolves earliest pending pass');
+});
+
+test('queues group lectures by next due date and shifting respects pending passes', () => {
+  const planner = normalizePlannerDefaults(DEFAULT_PLANNER_DEFAULTS);
+  const startAt = Date.UTC(2024, 0, 1, 8, 0, 0);
+  const now = Date.UTC(2024, 0, 2, 9, 0, 0);
+  const plan = DEFAULT_PASS_PLAN;
+
+  const baseLecture = recalcLectureSchedule({ id: 'base', passPlan: plan }, { plannerDefaults: planner, startAt });
+
+  const futureOffset = now + 26 * HOUR;
+  const overdueLecture = {
+    ...baseLecture,
+    id: 'overdue',
+    passes: baseLecture.passes.map((pass, index) => {
+      if (index === 0) return { ...pass, due: now - HOUR, completedAt: null };
+      if (index === 1) return { ...pass, due: futureOffset };
+      return { ...pass, due: futureOffset + DAY };
+    })
+  };
+
+  const todayLecture = {
+    ...baseLecture,
+    id: 'today',
+    passes: baseLecture.passes.map((pass, index) => {
+      if (index === 0) return { ...pass, due: now + 2 * HOUR, completedAt: null };
+      if (index === 1) return { ...pass, due: futureOffset };
+      return { ...pass, due: futureOffset + DAY };
+    })
+  };
+
+  const completedFirst = markPassCompleted(baseLecture, 0, startAt + HOUR);
+  const tomorrowLecture = {
+    ...completedFirst,
+    id: 'tomorrow',
+    passes: completedFirst.passes.map((pass, index) =>
+      index === 1 ? { ...pass, due: now + DAY, completedAt: null } : { ...pass }
+    )
+  };
+
+  const upcomingLecture = {
+    ...baseLecture,
+    id: 'upcoming',
+    passes: baseLecture.passes.map((pass, index) => {
+      if (index === 0) return { ...pass, due: now + DAY * 3 };
+      if (index === 1) return { ...pass, due: now + DAY * 4 };
+      return { ...pass, due: now + DAY * 5 };
+    })
+  };
+
+  const queues = groupLectureQueues(
+    [overdueLecture, todayLecture, tomorrowLecture, upcomingLecture],
+    { now }
+  );
+
+  assert.equal(queues.overdue.length, 1);
+  assert.equal(queues.overdue[0].lecture.id, 'overdue');
+  assert.equal(queues.today.length, 1);
+  assert.equal(queues.today[0].lecture.id, 'today');
+  assert.equal(queues.tomorrow.length, 1);
+  assert.equal(queues.tomorrow[0].lecture.id, 'tomorrow');
+  assert.equal(queues.upcoming.length, 1);
+  assert.equal(queues.upcoming[0].lecture.id, 'upcoming');
+
+  const shifted = shiftLecturePasses(todayLecture, 60);
+  assert.ok(shifted, 'shift returns lecture');
+  assert.equal(
+    shifted.passes[0].due,
+    todayLecture.passes[0].due + 60 * 60 * 1000,
+    'pending pass shifts by offset'
+  );
+  assert.equal(
+    shifted.passes[1].due,
+    todayLecture.passes[1].due + 60 * 60 * 1000,
+    'all pending passes shift together'
+  );
+  assert.equal(shifted.nextDueAt, shifted.passes[0].due, 'next due updates after shift');
+});

--- a/test/storage.lectures.test.js
+++ b/test/storage.lectures.test.js
@@ -108,8 +108,16 @@ test('lecture migration moves embedded data into dedicated store', async () => {
   assert.deepEqual(intro.passPlan, DEFAULT_PASS_PLAN, 'default pass plan applied');
   assert.deepEqual(intro.status, DEFAULT_LECTURE_STATUS, 'default status applied');
   assert.ok(Array.isArray(intro.passes), 'passes array initialized');
+  assert.equal(intro.passes.length, DEFAULT_PASS_PLAN.schedule.length, 'passes match plan count');
+  intro.passes.forEach(pass => {
+    assert.ok(pass.label, 'pass label defined');
+    assert.ok(Number.isFinite(pass.due), 'pass due scheduled');
+    assert.equal(pass.completedAt, null, 'pass completion defaults to null');
+    assert.ok(Array.isArray(pass.attachments), 'pass attachments array');
+  });
+  assert.ok(intro.plannerDefaults, 'planner defaults stored');
   assert.ok(Array.isArray(intro.tags), 'tags array initialized');
-  assert.equal(intro.nextDueAt, null, 'nextDueAt defaults to null');
+  assert.ok(Number.isFinite(intro.nextDueAt), 'nextDueAt scheduled');
 
   db.close();
 });


### PR DESCRIPTION
## Summary
- add a lecture scheduler module that normalizes pass plans, generates queues, and exposes helpers for completion and rescheduling
- persist normalized pass schedules and planner defaults on lecture records and surface planner defaults in app settings
- refresh lecture UI summaries and add scheduler-focused test coverage with updated storage migration checks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf37f472e083228243b98414e7d165