### PR TITLE
feat: add block board scheduling ui

### DIFF
--- a/js/app-shell.js
+++ b/js/app-shell.js
@@ -13,6 +13,7 @@ export function createAppShell({
   renderReview,
   renderQuiz,
   renderBlockMode,
+  renderBlockBoard,
   renderExams,
   renderExamRunner,
   renderMap,
@@ -190,7 +191,7 @@ export function createAppShell({
       const content = document.createElement('div');
       content.className = 'tab-content';
       main.appendChild(content);
-      renderBlockMode(content, renderApp);
+      await renderBlockBoard(content, renderApp);
     } else if (state.tab === 'Lectures') {
       const content = document.createElement('div');
       content.className = 'tab-content';

--- a/js/main.js
+++ b/js/main.js
@@ -10,6 +10,7 @@ import { renderFlashcards } from './ui/components/flashcards.js';
 import { renderReview } from './ui/components/review.js';
 import { renderQuiz } from './ui/components/quiz.js';
 import { renderBlockMode } from './ui/components/block-mode.js';
+import { renderBlockBoard } from './ui/components/block-board.js';
 import { renderExams, renderExamRunner } from './ui/components/exams.js';
 import { renderMap } from './ui/components/map.js';
 import { createEntryAddControl } from './ui/components/entry-controls.js';
@@ -30,6 +31,7 @@ const { renderApp, tabs, resolveListKind } = createAppShell({
   renderReview,
   renderQuiz,
   renderBlockMode,
+  renderBlockBoard,
   renderExams,
   renderExamRunner,
   renderMap,

--- a/js/state.js
+++ b/js/state.js
@@ -14,6 +14,7 @@ export const state = {
   filters: { types:["disease","drug","concept"], block:"", week:"", onlyFav:false, sort:"updated" },
   lectures: { query: '', blockId: '', week: '', status: '', tag: '' },
   entryLayout: { mode: 'list', columns: 3, scale: 1, controlsVisible: false },
+  blockBoard: { collapsedBlocks: [], showDensity: true, showPomodoro: false },
   builder: {
     blocks:[],
     weeks:[],
@@ -48,6 +49,23 @@ export function setSubtab(tab, sub){ state.subtab[tab] = sub; }
 export function setQuery(q){ state.query = q; }
 export function setFilters(patch){ Object.assign(state.filters, patch); }
 export function setBuilder(patch){ Object.assign(state.builder, patch); }
+export function setBlockBoardState(patch) {
+  if (!patch) return;
+  if (!state.blockBoard) {
+    state.blockBoard = { collapsedBlocks: [], showDensity: true, showPomodoro: false };
+  }
+  const current = state.blockBoard;
+  if (Array.isArray(patch.collapsedBlocks)) {
+    const unique = Array.from(new Set(patch.collapsedBlocks.map(id => String(id))));
+    current.collapsedBlocks = unique;
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, 'showDensity')) {
+    current.showDensity = Boolean(patch.showDensity);
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, 'showPomodoro')) {
+    current.showPomodoro = Boolean(patch.showPomodoro);
+  }
+}
 export function setLecturesState(patch) {
   if (!patch) return;
   if (!state.lectures) {

--- a/js/storage/storage.js
+++ b/js/storage/storage.js
@@ -10,6 +10,7 @@ import {
 
 export {
   listLecturesByBlock,
+  listAllLectures,
   saveLecture,
   deleteLectureRecord,
   removeLecturesForBlock,

--- a/js/ui/components/block-board.js
+++ b/js/ui/components/block-board.js
@@ -1,0 +1,492 @@
+import { state, setBlockBoardState } from '../../state.js';
+import { loadBlockCatalog } from '../../storage/block-catalog.js';
+import { listAllLectures, saveLecture } from '../../storage/storage.js';
+import {
+  groupLectureQueues,
+  markPassCompleted,
+  shiftLecturePasses,
+  deriveLectureStatus,
+  calculateNextDue
+} from '../../lectures/scheduler.js';
+
+let loadCatalog = loadBlockCatalog;
+let fetchLectures = listAllLectures;
+let persistLecture = saveLecture;
+
+export function __setBlockBoardDeps({ loadBlockCatalog: loadFn, listAllLectures: listFn, saveLecture: saveFn } = {}) {
+  loadCatalog = typeof loadFn === 'function' ? loadFn : loadBlockCatalog;
+  fetchLectures = typeof listFn === 'function' ? listFn : listAllLectures;
+  persistLecture = typeof saveFn === 'function' ? saveFn : saveLecture;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const PASS_COLORS = [
+  'var(--pink)',
+  'var(--blue)',
+  'var(--green)',
+  'var(--orange)',
+  'var(--purple)',
+  'var(--teal)'
+];
+const BOARD_DAYS = 14;
+
+function ensureBoardState() {
+  if (!state.blockBoard) {
+    state.blockBoard = { collapsedBlocks: [], showDensity: true, showPomodoro: false };
+  }
+  return state.blockBoard;
+}
+
+function passColor(order = 1) {
+  if (!Number.isFinite(order)) return PASS_COLORS[0];
+  const idx = Math.max(0, Math.floor(order) - 1) % PASS_COLORS.length;
+  return PASS_COLORS[idx];
+}
+
+function startOfDay(timestamp) {
+  const date = new Date(timestamp);
+  date.setHours(0, 0, 0, 0);
+  return date.getTime();
+}
+
+function formatDay(timestamp) {
+  const date = new Date(Number(timestamp));
+  const formatter = new Intl.DateTimeFormat(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
+  return formatter.format(date);
+}
+
+function formatDueTime(due) {
+  if (!Number.isFinite(due)) return 'Unscheduled';
+  const formatter = new Intl.DateTimeFormat(undefined, { hour: 'numeric', minute: '2-digit' });
+  return formatter.format(new Date(due));
+}
+
+function collectBoardDays(now = Date.now()) {
+  const today = startOfDay(now);
+  const start = today - 2 * DAY_MS;
+  return Array.from({ length: BOARD_DAYS }, (_, idx) => start + idx * DAY_MS);
+}
+
+function buildPassElement(entry, onComplete, onDelay) {
+  const chip = document.createElement('div');
+  chip.className = 'block-board-pass-chip';
+  chip.style.setProperty('--chip-accent', passColor(entry?.pass?.order));
+  const title = document.createElement('div');
+  title.className = 'block-board-pass-title';
+  title.textContent = entry?.lecture?.name || `Lecture ${entry?.lecture?.id}`;
+  chip.appendChild(title);
+
+  const meta = document.createElement('div');
+  meta.className = 'block-board-pass-meta';
+  const label = entry?.pass?.label || `Pass ${entry?.pass?.order ?? ''}`;
+  const dueLabel = formatDueTime(entry?.pass?.due);
+  meta.textContent = `${label} • ${dueLabel}`;
+  chip.appendChild(meta);
+
+  const actions = document.createElement('div');
+  actions.className = 'block-board-pass-actions';
+  const done = document.createElement('button');
+  done.type = 'button';
+  done.className = 'btn tertiary';
+  done.textContent = 'Mark done';
+  done.addEventListener('click', () => onComplete(entry));
+  actions.appendChild(done);
+
+  const delay = document.createElement('button');
+  delay.type = 'button';
+  delay.className = 'btn tertiary';
+  delay.textContent = '+1 day';
+  delay.addEventListener('click', () => onDelay(entry));
+  actions.appendChild(delay);
+
+  chip.appendChild(actions);
+  return chip;
+}
+
+function applyPassDueUpdate(lecture, passOrder, newDue) {
+  const passes = Array.isArray(lecture?.passes)
+    ? lecture.passes.map(pass => ({ ...pass }))
+    : [];
+  const index = passes.findIndex(pass => pass?.order === passOrder);
+  if (index >= 0) {
+    passes[index] = { ...passes[index], due: newDue ?? null };
+    if (!Number.isFinite(newDue)) {
+      passes[index].due = null;
+    }
+    passes[index].completedAt = passes[index].completedAt ?? null;
+    if (passes[index].completedAt && newDue && newDue > passes[index].completedAt) {
+      passes[index].completedAt = null;
+    }
+  }
+  const status = deriveLectureStatus(passes, lecture?.status);
+  const nextDueAt = calculateNextDue(passes);
+  return { ...lecture, passes, status, nextDueAt };
+}
+
+function createDensityBar(dayCount, isToday) {
+  const bar = document.createElement('div');
+  bar.className = 'block-board-density-bar';
+  if (isToday) bar.classList.add('today');
+  bar.style.setProperty('--density-value', String(dayCount));
+  const fill = document.createElement('div');
+  fill.className = 'block-board-density-fill';
+  fill.style.height = `${Math.min(100, dayCount * 12)}%`;
+  bar.appendChild(fill);
+  return bar;
+}
+
+function createDensityLegend(day, count, isToday) {
+  const slot = document.createElement('div');
+  slot.className = 'block-board-density-slot';
+  if (isToday) slot.classList.add('today');
+  const bar = createDensityBar(count, isToday);
+  slot.appendChild(bar);
+  const label = document.createElement('div');
+  label.className = 'block-board-density-label';
+  label.textContent = new Date(day).getDate();
+  slot.appendChild(label);
+  return slot;
+}
+
+function createPassCard(entry, onDrag) {
+  const card = document.createElement('div');
+  card.className = 'block-board-pass-card';
+  card.draggable = true;
+  card.style.setProperty('--card-accent', passColor(entry?.pass?.order));
+  card.dataset.blockId = entry?.lecture?.blockId ?? '';
+  card.dataset.lectureId = entry?.lecture?.id ?? '';
+  card.dataset.passOrder = entry?.pass?.order ?? '';
+  card.dataset.passDue = Number.isFinite(entry?.pass?.due) ? String(entry.pass.due) : '';
+  card.innerHTML = `<div class="card-title">${entry?.lecture?.name || 'Lecture'}</div>`
+    + `<div class="card-meta">${entry?.pass?.label || ''}</div>`;
+  card.addEventListener('dragstart', (event) => {
+    if (!event.dataTransfer) return;
+    const payload = {
+      blockId: card.dataset.blockId,
+      lectureId: card.dataset.lectureId,
+      passOrder: Number(card.dataset.passOrder),
+      due: card.dataset.passDue ? Number(card.dataset.passDue) : null
+    };
+    event.dataTransfer.effectAllowed = 'move';
+    event.dataTransfer.setData('application/json', JSON.stringify(payload));
+    onDrag?.(payload);
+  });
+  return card;
+}
+
+function createDayColumn(dayTs) {
+  const column = document.createElement('div');
+  column.className = 'block-board-day-column';
+  column.dataset.day = String(dayTs);
+  const header = document.createElement('div');
+  header.className = 'block-board-day-header';
+  header.textContent = formatDay(dayTs);
+  if (startOfDay(Date.now()) === dayTs) {
+    column.classList.add('today');
+  }
+  column.appendChild(header);
+  const list = document.createElement('div');
+  list.className = 'block-board-day-list';
+  column.appendChild(list);
+  column.addEventListener('dragover', (event) => {
+    event.preventDefault();
+    column.classList.add('dropping');
+  });
+  column.addEventListener('dragleave', () => {
+    column.classList.remove('dropping');
+  });
+  return column;
+}
+
+async function updateLectureSchedule(lecture, updateFn) {
+  const updated = updateFn(lecture);
+  await persistLecture(updated);
+}
+
+function renderUrgentQueues(root, queues, handlers) {
+  const wrapper = document.createElement('section');
+  wrapper.className = 'block-board-urgent';
+  const config = [
+    { key: 'overdue', label: 'Overdue' },
+    { key: 'today', label: 'Today' },
+    { key: 'tomorrow', label: 'Tomorrow' }
+  ];
+  config.forEach(({ key, label }) => {
+    const group = document.createElement('div');
+    group.className = 'block-board-urgent-group';
+    const header = document.createElement('div');
+    header.className = 'block-board-urgent-header';
+    header.textContent = label;
+    const pushAll = document.createElement('button');
+    pushAll.type = 'button';
+    pushAll.className = 'btn tertiary';
+    pushAll.textContent = 'Push all +1 day';
+    pushAll.addEventListener('click', () => handlers.onPushAll(key));
+    header.appendChild(pushAll);
+    group.appendChild(header);
+
+    const list = document.createElement('div');
+    list.className = 'block-board-urgent-list';
+    const entries = queues[key] || [];
+    if (!entries.length) {
+      const empty = document.createElement('div');
+      empty.className = 'block-board-empty';
+      empty.textContent = 'Nothing queued.';
+      list.appendChild(empty);
+    } else {
+      entries.forEach(entry => {
+        const chip = buildPassElement(entry, handlers.onComplete, handlers.onDelay);
+        list.appendChild(chip);
+      });
+    }
+    group.appendChild(list);
+    wrapper.appendChild(group);
+  });
+  root.appendChild(wrapper);
+}
+
+function renderPomodoroControls(root) {
+  const stateRef = ensureBoardState();
+  const section = document.createElement('section');
+  section.className = 'block-board-pomodoro';
+  const toggle = document.createElement('button');
+  toggle.type = 'button';
+  toggle.className = 'btn secondary';
+  toggle.textContent = stateRef.showPomodoro ? 'Hide Pomodoro' : 'Show Pomodoro';
+  toggle.addEventListener('click', () => {
+    const next = !ensureBoardState().showPomodoro;
+    setBlockBoardState({ showPomodoro: next });
+    renderPomodoroControls(root);
+  });
+  section.appendChild(toggle);
+  if (stateRef.showPomodoro) {
+    const timer = document.createElement('div');
+    timer.className = 'block-board-pomodoro-timer';
+    timer.textContent = 'Pomodoro timer ready';
+    section.appendChild(timer);
+  }
+  if (root.firstChild) {
+    root.replaceChild(section, root.firstChild);
+  } else {
+    root.appendChild(section);
+  }
+}
+
+function buildDayAssignments(blockLectures, days) {
+  const assignments = new Map();
+  blockLectures.forEach(lecture => {
+    const passes = Array.isArray(lecture?.passes) ? lecture.passes : [];
+    passes.forEach(pass => {
+      if (!pass || Number.isFinite(pass.completedAt)) return;
+      const due = Number.isFinite(pass.due) ? startOfDay(pass.due) : null;
+      const key = due != null ? due : 'unscheduled';
+      if (!assignments.has(key)) assignments.set(key, []);
+      assignments.get(key).push({ lecture, pass });
+    });
+  });
+  days.forEach(day => {
+    if (!assignments.has(day)) assignments.set(day, []);
+  });
+  if (!assignments.has('unscheduled')) assignments.set('unscheduled', []);
+  return assignments;
+}
+
+function attachDropHandlers(column, blockEntries, refresh) {
+  column.addEventListener('drop', async (event) => {
+    event.preventDefault();
+    column.classList.remove('dropping');
+    const payloadRaw = event.dataTransfer?.getData('application/json');
+    if (!payloadRaw) return;
+    let payload;
+    try {
+      payload = JSON.parse(payloadRaw);
+    } catch (err) {
+      return;
+    }
+    const { lectureId, passOrder } = payload || {};
+    const lecture = blockEntries.find(item => String(item.lecture?.id) === String(lectureId))?.lecture;
+    if (!lecture) return;
+    const dayValue = column.dataset.day;
+    const targetDay = dayValue ? Number(dayValue) : null;
+    const newDue = targetDay != null ? targetDay + (payload?.due != null ? (payload.due % DAY_MS) : 9 * 60 * 60 * 1000) : null;
+    await updateLectureSchedule(lecture, lec => applyPassDueUpdate(lec, passOrder, newDue));
+    await refresh();
+  });
+}
+
+function renderBlockBoardBlock(container, block, blockLectures, days, refresh) {
+  const boardState = ensureBoardState();
+  const wrapper = document.createElement('section');
+  wrapper.className = 'block-board-block';
+  wrapper.dataset.blockId = String(block?.blockId ?? '');
+
+  const header = document.createElement('div');
+  header.className = 'block-board-block-header';
+  const title = document.createElement('h2');
+  title.textContent = block?.title || block?.name || `Block ${block?.blockId}`;
+  header.appendChild(title);
+  const controls = document.createElement('div');
+  controls.className = 'block-board-block-controls';
+  const collapseBtn = document.createElement('button');
+  collapseBtn.type = 'button';
+  collapseBtn.className = 'btn secondary';
+  const isCollapsed = boardState.collapsedBlocks.includes(String(block?.blockId));
+  collapseBtn.textContent = isCollapsed ? 'Expand' : 'Collapse';
+  collapseBtn.addEventListener('click', () => {
+    const current = ensureBoardState();
+    const nextCollapsed = new Set(current.collapsedBlocks.map(String));
+    if (nextCollapsed.has(String(block.blockId))) {
+      nextCollapsed.delete(String(block.blockId));
+    } else {
+      nextCollapsed.add(String(block.blockId));
+    }
+    setBlockBoardState({ collapsedBlocks: Array.from(nextCollapsed) });
+    refresh();
+  });
+  controls.appendChild(collapseBtn);
+  const densityBtn = document.createElement('button');
+  densityBtn.type = 'button';
+  densityBtn.className = 'btn secondary';
+  densityBtn.textContent = boardState.showDensity ? 'Hide density' : 'Show density';
+  densityBtn.addEventListener('click', () => {
+    setBlockBoardState({ showDensity: !ensureBoardState().showDensity });
+    refresh();
+  });
+  controls.appendChild(densityBtn);
+  header.appendChild(controls);
+  wrapper.appendChild(header);
+
+  if (boardState.showDensity) {
+    const density = document.createElement('div');
+    density.className = 'block-board-density';
+    const counts = days.map(day => {
+      const start = day;
+      const end = day + DAY_MS;
+      let total = 0;
+      blockLectures.forEach(lecture => {
+        const passes = Array.isArray(lecture?.passes) ? lecture.passes : [];
+        passes.forEach(pass => {
+          if (Number.isFinite(pass?.completedAt)) return;
+          if (!Number.isFinite(pass?.due)) return;
+          if (pass.due >= start && pass.due < end) total += 1;
+        });
+      });
+      return total;
+    });
+    counts.forEach((count, idx) => {
+      const day = days[idx];
+      const slot = createDensityLegend(day, count, startOfDay(Date.now()) === day);
+      density.appendChild(slot);
+    });
+    wrapper.appendChild(density);
+  }
+
+  if (isCollapsed) {
+    container.appendChild(wrapper);
+    return;
+  }
+
+  const assignments = buildDayAssignments(blockLectures, days);
+  const board = document.createElement('div');
+  board.className = 'block-board-grid';
+
+  const unscheduled = document.createElement('div');
+  unscheduled.className = 'block-board-unscheduled';
+  const unscheduledHeader = document.createElement('div');
+  unscheduledHeader.className = 'block-board-day-header';
+  unscheduledHeader.textContent = 'Unscheduled';
+  unscheduled.appendChild(unscheduledHeader);
+  const unscheduledList = document.createElement('div');
+  unscheduledList.className = 'block-board-day-list';
+  (assignments.get('unscheduled') || []).forEach(entry => {
+    const card = createPassCard(entry);
+    unscheduledList.appendChild(card);
+  });
+  unscheduled.appendChild(unscheduledList);
+  board.appendChild(unscheduled);
+
+  const blockEntries = [];
+  assignments.forEach(entries => {
+    entries.forEach(entry => blockEntries.push(entry));
+  });
+
+  days.forEach(day => {
+    const column = createDayColumn(day);
+    const entries = assignments.get(day) || [];
+    entries.forEach(entry => {
+      const card = createPassCard(entry);
+      column.querySelector('.block-board-day-list').appendChild(card);
+    });
+    attachDropHandlers(column, blockEntries, refresh);
+    board.appendChild(column);
+  });
+
+  wrapper.appendChild(board);
+  container.appendChild(wrapper);
+}
+
+export async function renderBlockBoard(container, refresh) {
+  container.innerHTML = '';
+  container.classList.add('block-board-container');
+
+  const { blocks } = await loadCatalog();
+  const lectures = await fetchLectures();
+  const days = collectBoardDays();
+
+  const queues = groupLectureQueues(lectures);
+
+  const urgentHost = document.createElement('div');
+  renderUrgentQueues(urgentHost, queues, {
+    onComplete: async (entry) => {
+      const passOrder = entry?.pass?.order;
+      const lecture = entry?.lecture;
+      if (!lecture || !Number.isFinite(passOrder)) return;
+      const passIndex = Array.isArray(lecture.passes)
+        ? lecture.passes.findIndex(pass => pass?.order === passOrder)
+        : -1;
+      if (passIndex < 0) return;
+      await updateLectureSchedule(lecture, lec => markPassCompleted(lec, passIndex));
+      await renderBlockBoard(container, refresh);
+    },
+    onDelay: async (entry) => {
+      const lecture = entry?.lecture;
+      if (!lecture) return;
+      await updateLectureSchedule(lecture, lec => shiftLecturePasses(lec, 24 * 60));
+      await renderBlockBoard(container, refresh);
+    },
+    onPushAll: async (bucket) => {
+      const entries = queues[bucket] || [];
+      const affected = new Set();
+      for (const entry of entries) {
+        if (!entry?.lecture) continue;
+        const key = `${entry.lecture.blockId}-${entry.lecture.id}`;
+        if (affected.has(key)) continue;
+        affected.add(key);
+        await updateLectureSchedule(entry.lecture, lec => shiftLecturePasses(lec, 24 * 60));
+      }
+      await renderBlockBoard(container, refresh);
+    }
+  });
+  container.appendChild(urgentHost);
+
+  const pomodoroHost = document.createElement('div');
+  renderPomodoroControls(pomodoroHost);
+  container.appendChild(pomodoroHost);
+
+  const blockList = document.createElement('div');
+  blockList.className = 'block-board-list';
+  const refreshBoard = async () => {
+    await renderBlockBoard(container, refresh);
+  };
+  const lecturesByBlock = new Map();
+  lectures.forEach(lecture => {
+    const key = String(lecture?.blockId ?? '');
+    if (!lecturesByBlock.has(key)) lecturesByBlock.set(key, []);
+    lecturesByBlock.get(key).push(lecture);
+  });
+  blocks.forEach(block => {
+    const blockLectures = lecturesByBlock.get(String(block.blockId)) || [];
+    renderBlockBoardBlock(blockList, block, blockLectures, days, refreshBoard);
+  });
+  container.appendChild(blockList);
+}

--- a/style.css
+++ b/style.css
@@ -5783,3 +5783,34 @@ body.map-toolbox-dragging {
   color: var(--gray);
   padding: var(--pad-lg);
 }
+
+.block-board-container { display: flex; flex-direction: column; gap: 1.5rem; }
+.block-board-urgent { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; }
+.block-board-urgent-group { background: var(--surface-2); border-radius: 12px; padding: 1rem; display: flex; flex-direction: column; gap: 0.75rem; }
+.block-board-urgent-header { font-weight: 600; display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; }
+.block-board-urgent-list { display: flex; flex-direction: column; gap: 0.5rem; }
+.block-board-pass-chip { background: color-mix(in srgb, var(--chip-accent) 16%, var(--surface-1)); border: 1px solid color-mix(in srgb, var(--chip-accent) 40%, transparent); border-radius: 10px; padding: 0.75rem; display: flex; flex-direction: column; gap: 0.5rem; }
+.block-board-pass-title { font-weight: 600; }
+.block-board-pass-meta { font-size: 0.85rem; opacity: 0.8; }
+.block-board-pass-actions { display: flex; gap: 0.5rem; }
+.block-board-empty { font-size: 0.85rem; opacity: 0.7; }
+.block-board-pomodoro { display: flex; flex-direction: column; gap: 0.75rem; }
+.block-board-pomodoro-timer { padding: 1rem; border-radius: 12px; background: var(--surface-2); text-align: center; font-weight: 600; }
+.block-board-list { display: flex; flex-direction: column; gap: 2rem; }
+.block-board-block { display: flex; flex-direction: column; gap: 1rem; }
+.block-board-block-header { display: flex; justify-content: space-between; align-items: center; gap: 1rem; }
+.block-board-block-controls { display: flex; gap: 0.5rem; }
+.block-board-density { display: grid; grid-template-columns: repeat(auto-fit, minmax(20px, 1fr)); gap: 0.25rem; align-items: end; }
+.block-board-density-slot { display: flex; flex-direction: column; align-items: center; gap: 0.35rem; font-size: 0.7rem; opacity: 0.8; }
+.block-board-density-slot.today { font-weight: 600; opacity: 1; }
+.block-board-density-bar { width: 100%; background: var(--surface-1); border-radius: 8px; height: 60px; display: flex; align-items: flex-end; justify-content: center; overflow: hidden; }
+.block-board-density-fill { width: 100%; background: color-mix(in srgb, var(--accent) 55%, transparent); border-radius: 8px; transition: height 0.2s ease; }
+.block-board-grid { display: grid; grid-auto-flow: column; grid-auto-columns: minmax(200px, 1fr); gap: 1rem; overflow-x: auto; padding-bottom: 0.5rem; }
+.block-board-day-column, .block-board-unscheduled { background: var(--surface-2); border-radius: 12px; display: flex; flex-direction: column; }
+.block-board-day-header { font-weight: 600; padding: 0.75rem 1rem; border-bottom: 1px solid var(--surface-3); }
+.block-board-day-list { display: flex; flex-direction: column; gap: 0.5rem; padding: 0.75rem 1rem 1rem; }
+.block-board-day-column.today .block-board-day-header { color: var(--accent); }
+.block-board-day-column.dropping { outline: 2px dashed var(--accent); }
+.block-board-pass-card { border-radius: 12px; border: 1px solid color-mix(in srgb, var(--card-accent) 45%, transparent); padding: 0.75rem; background: color-mix(in srgb, var(--card-accent) 12%, var(--surface-1)); display: flex; flex-direction: column; gap: 0.35rem; cursor: grab; }
+.block-board-pass-card .card-title { font-weight: 600; }
+.block-board-pass-card .card-meta { font-size: 0.8rem; opacity: 0.75; }

--- a/test/ui.block-board.test.js
+++ b/test/ui.block-board.test.js
@@ -1,0 +1,128 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mock } from 'node:test';
+import { JSDOM } from 'jsdom';
+
+import { state } from '../js/state.js';
+import { renderBlockBoard, __setBlockBoardDeps } from '../js/ui/components/block-board.js';
+
+const BASE_TIME = Date.now() - 60 * 60 * 1000;
+
+function setupBoardDeps({ blocks, lectures }) {
+  const loadBlockCatalogMock = mock.fn(async () => ({ blocks }));
+  const listAllLecturesMock = mock.fn(async () => lectures);
+  const saveLectureMock = mock.fn(async (payload) => payload);
+  __setBlockBoardDeps({
+    loadBlockCatalog: loadBlockCatalogMock,
+    listAllLectures: listAllLecturesMock,
+    saveLecture: saveLectureMock
+  });
+  return { loadBlockCatalogMock, listAllLecturesMock, saveLectureMock };
+}
+
+describe('block board rendering', () => {
+  let container;
+  beforeEach(() => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>');
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.HTMLElement = dom.window.HTMLElement;
+    global.Node = dom.window.Node;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    state.blockBoard = { collapsedBlocks: [], showDensity: true, showPomodoro: false };
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    __setBlockBoardDeps({});
+    mock.restoreAll();
+  });
+
+  function sampleData() {
+    return {
+      blocks: [{ blockId: 'b1', title: 'Cardiology' }],
+      lectures: [
+        {
+          blockId: 'b1',
+          id: 'L1',
+          name: 'Intro lecture',
+          passes: [
+            { order: 1, label: 'Pass 1', due: BASE_TIME, completedAt: null }
+          ]
+        }
+      ]
+    };
+  }
+
+  it('renders urgent queues and wires action buttons', async () => {
+    const data = sampleData();
+    const { saveLectureMock } = setupBoardDeps(data);
+    await renderBlockBoard(container, () => {});
+    const urgentHeaders = container.querySelectorAll('.block-board-urgent-header');
+    assert.equal(urgentHeaders.length, 3);
+    const markBtn = Array.from(container.querySelectorAll('.block-board-pass-actions button')).find(btn => btn.textContent?.includes('Mark done'));
+    assert(markBtn);
+    markBtn.click();
+    await renderBlockBoard(container, () => {});
+    assert.equal(saveLectureMock.mock.callCount(), 1);
+
+    const delayBtn = Array.from(container.querySelectorAll('.block-board-pass-actions button')).find(btn => btn.textContent?.includes('+1 day'));
+    assert(delayBtn);
+    delayBtn.click();
+    await renderBlockBoard(container, () => {});
+    assert.equal(saveLectureMock.mock.callCount(), 2);
+
+    const pushAllBtn = Array.from(container.querySelectorAll('.block-board-urgent-header .btn.tertiary')).find(btn => btn.textContent?.includes('Push all'));
+    assert(pushAllBtn);
+    pushAllBtn.click();
+    await renderBlockBoard(container, () => {});
+    assert.equal(saveLectureMock.mock.callCount(), 3);
+  });
+
+  it('persists density, collapse, and pomodoro state', async () => {
+    const data = sampleData();
+    setupBoardDeps(data);
+    await renderBlockBoard(container, () => {});
+    const densityBtn = Array.from(container.querySelectorAll('.block-board-block-controls .btn.secondary')).find(btn => btn.textContent?.toLowerCase().includes('density'));
+    assert(densityBtn);
+    densityBtn.click();
+    await renderBlockBoard(container, () => {});
+    assert.equal(state.blockBoard.showDensity, false);
+
+    const collapseBtn = Array.from(container.querySelectorAll('.block-board-block-controls .btn.secondary')).find(btn => btn.textContent?.toLowerCase().includes('collapse'));
+    assert(collapseBtn);
+    collapseBtn.click();
+    await renderBlockBoard(container, () => {});
+    assert(state.blockBoard.collapsedBlocks.includes('b1'));
+
+    const pomodoroToggle = container.querySelector('.block-board-pomodoro .btn.secondary');
+    assert(pomodoroToggle);
+    pomodoroToggle.click();
+    await Promise.resolve();
+    assert.equal(state.blockBoard.showPomodoro, true);
+  });
+
+  it('supports drag and drop scheduling updates', async () => {
+    const data = sampleData();
+    const { saveLectureMock } = setupBoardDeps(data);
+    await renderBlockBoard(container, () => {});
+    const columns = container.querySelectorAll('.block-board-day-column');
+    assert(columns.length > 1);
+    const targetColumn = columns[1];
+    const payload = {
+      blockId: 'b1',
+      lectureId: 'L1',
+      passOrder: 1,
+      due: BASE_TIME
+    };
+    const dropEvent = new window.Event('drop', { bubbles: true, cancelable: true });
+    dropEvent.dataTransfer = {
+      getData: () => JSON.stringify(payload)
+    };
+    targetColumn.dispatchEvent(dropEvent);
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(saveLectureMock.mock.callCount(), 1);
+  });
+});

--- a/test/ui.tabs.test.js
+++ b/test/ui.tabs.test.js
@@ -22,6 +22,9 @@ const renderFlashcardsMock = mock.fn(() => {});
 const renderReviewMock = mock.fn(async () => {});
 const renderQuizMock = mock.fn(() => {});
 const renderBlockModeMock = mock.fn(() => {});
+const renderBlockBoardMock = mock.fn(async (container) => {
+  container.dataset.rendered = 'block-board';
+});
 const renderExamsMock = mock.fn(async (container) => {
   container.dataset.rendered = 'exams';
 });
@@ -59,6 +62,7 @@ const { renderApp, tabs } = createAppShell({
   renderReview: renderReviewMock,
   renderQuiz: renderQuizMock,
   renderBlockMode: renderBlockModeMock,
+  renderBlockBoard: renderBlockBoardMock,
   renderExams: renderExamsMock,
   renderExamRunner: renderExamRunnerMock,
   renderMap: renderMapMock,
@@ -84,6 +88,7 @@ function resetMocks() {
   renderReviewMock.mock.resetCalls();
   renderQuizMock.mock.resetCalls();
   renderBlockModeMock.mock.resetCalls();
+  renderBlockBoardMock.mock.resetCalls();
   renderExamsMock.mock.resetCalls();
   renderExamRunnerMock.mock.resetCalls();
   renderMapMock.mock.resetCalls();
@@ -140,7 +145,7 @@ describe('tab layout', () => {
   it('routes to the block board view', async () => {
     setTab('Block Board');
     await renderApp();
-    assert.equal(renderBlockModeMock.mock.callCount(), 1);
+    assert.equal(renderBlockBoardMock.mock.callCount(), 1);
   });
 
   it('routes to lectures via the builder', async () => {


### PR DESCRIPTION
## Summary
- implement a block board component with urgent queues, drag-and-drop scheduling, and pomodoro controls
- persist block board view state, wire the tab into the app shell, and expose lecture listing helpers
- style the new board and add DOM-driven integration tests for block scheduling and tab routing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf43ae1de0832287dd61552d48895f