### PR TITLE
Add lecture pass configuration and streamline block settings

### DIFF
--- a/js/lectures/actions.js
+++ b/js/lectures/actions.js
@@ -1,0 +1,22 @@
+export const LECTURE_PASS_ACTIONS = [
+  'Notes',
+  'Read',
+  'Tape',
+  'Quiz',
+  'Flashcards',
+  'Summarize',
+  'Review',
+  'Active Recall',
+  'Anki',
+  'Practice Questions',
+  'Teach-Back',
+  'Whiteboard',
+  'Mind Map',
+  'Case Review',
+  'Group Study',
+  'Audio Review',
+  'Lecture Rewatch',
+  'Cheat Sheet',
+  'Sketch/Diagram',
+  'Blocks'
+];

--- a/js/lectures/scheduler.js
+++ b/js/lectures/scheduler.js
@@ -16,6 +16,14 @@ function sanitizeLabel(label, order) {
   return `Pass ${order}`;
 }
 
+function sanitizeAction(action) {
+  if (typeof action === 'string') {
+    const trimmed = action.trim();
+    if (trimmed) return trimmed;
+  }
+  return '';
+}
+
 function inferAnchor(offsetMinutes) {
   if (!Number.isFinite(offsetMinutes)) return 'today';
   if (offsetMinutes < DAY_MINUTES) return 'today';
@@ -50,9 +58,9 @@ function computeAnchoredDue(startAt, step, plannerDefaults) {
 export const DEFAULT_PASS_PLAN = {
   id: 'default',
   schedule: [
-    { order: 1, label: 'Pass 1', offsetMinutes: 0, anchor: 'today' },
-    { order: 2, label: 'Pass 2', offsetMinutes: 24 * 60, anchor: 'tomorrow' },
-    { order: 3, label: 'Pass 3', offsetMinutes: 72 * 60, anchor: 'upcoming' }
+    { order: 1, label: 'Pass 1', offsetMinutes: 0, anchor: 'today', action: 'Notes' },
+    { order: 2, label: 'Pass 2', offsetMinutes: 24 * 60, anchor: 'tomorrow', action: 'Review' },
+    { order: 3, label: 'Pass 3', offsetMinutes: 72 * 60, anchor: 'upcoming', action: 'Quiz' }
   ]
 };
 
@@ -83,7 +91,8 @@ export function normalizePassPlan(plan) {
         ? step.anchor.trim()
         : inferAnchor(offsetMinutes);
       const label = sanitizeLabel(step?.label, order);
-      return { order, offsetMinutes, anchor, label };
+      const action = sanitizeAction(step?.action ?? DEFAULT_PASS_PLAN.schedule[index]?.action);
+      return { order, offsetMinutes, anchor, label, action };
     })
     .sort((a, b) => a.order - b.order);
   return {
@@ -120,7 +129,8 @@ export function normalizePlannerDefaults(raw) {
       order: step.order,
       label: step.label,
       offsetMinutes: step.offsetMinutes,
-      anchor: step.anchor
+      anchor: step.anchor,
+      action: step.action
     }))
   };
 }
@@ -168,6 +178,7 @@ export function normalizeLecturePasses({
       ? (existing?.anchor ?? step.anchor)
       : inferAnchor(step.offsetMinutes);
     const attachments = sanitizeAttachments(existing.attachments);
+    const action = sanitizeAction(existing?.action ?? step.action);
     return {
       order: step.order,
       label,
@@ -175,7 +186,8 @@ export function normalizeLecturePasses({
       anchor,
       due,
       completedAt,
-      attachments
+      attachments,
+      action
     };
   });
   return normalizedPasses;

--- a/js/state.js
+++ b/js/state.js
@@ -14,7 +14,7 @@ export const state = {
   filters: { types:["disease","drug","concept"], block:"", week:"", onlyFav:false, sort:"updated" },
   lectures: { query: '', blockId: '', week: '', status: '', tag: '' },
   entryLayout: { mode: 'list', columns: 3, scale: 1, controlsVisible: false },
-  blockBoard: { collapsedBlocks: [], showDensity: true, showPomodoro: false },
+  blockBoard: { collapsedBlocks: [], showDensity: true },
   builder: {
     blocks:[],
     weeks:[],
@@ -52,7 +52,7 @@ export function setBuilder(patch){ Object.assign(state.builder, patch); }
 export function setBlockBoardState(patch) {
   if (!patch) return;
   if (!state.blockBoard) {
-    state.blockBoard = { collapsedBlocks: [], showDensity: true, showPomodoro: false };
+    state.blockBoard = { collapsedBlocks: [], showDensity: true };
   }
   const current = state.blockBoard;
   if (Array.isArray(patch.collapsedBlocks)) {
@@ -61,9 +61,6 @@ export function setBlockBoardState(patch) {
   }
   if (Object.prototype.hasOwnProperty.call(patch, 'showDensity')) {
     current.showDensity = Boolean(patch.showDensity);
-  }
-  if (Object.prototype.hasOwnProperty.call(patch, 'showPomodoro')) {
-    current.showPomodoro = Boolean(patch.showPomodoro);
   }
 }
 export function setLecturesState(patch) {

--- a/js/ui/components/block-board.js
+++ b/js/ui/components/block-board.js
@@ -32,7 +32,7 @@ const BOARD_DAYS = 14;
 
 function ensureBoardState() {
   if (!state.blockBoard) {
-    state.blockBoard = { collapsedBlocks: [], showDensity: true, showPomodoro: false };
+    state.blockBoard = { collapsedBlocks: [], showDensity: true };
   }
   return state.blockBoard;
 }
@@ -79,8 +79,9 @@ function buildPassElement(entry, onComplete, onDelay) {
   const meta = document.createElement('div');
   meta.className = 'block-board-pass-meta';
   const label = entry?.pass?.label || `Pass ${entry?.pass?.order ?? ''}`;
+  const action = entry?.pass?.action ? ` • ${entry.pass.action}` : '';
   const dueLabel = formatDueTime(entry?.pass?.due);
-  meta.textContent = `${label} • ${dueLabel}`;
+  meta.textContent = `${label}${action ? action : ''} • ${dueLabel}`;
   chip.appendChild(meta);
 
   const actions = document.createElement('div');
@@ -157,8 +158,9 @@ function createPassCard(entry, onDrag) {
   card.dataset.lectureId = entry?.lecture?.id ?? '';
   card.dataset.passOrder = entry?.pass?.order ?? '';
   card.dataset.passDue = Number.isFinite(entry?.pass?.due) ? String(entry.pass.due) : '';
+  const action = entry?.pass?.action ? ` • ${entry.pass.action}` : '';
   card.innerHTML = `<div class="card-title">${entry?.lecture?.name || 'Lecture'}</div>`
-    + `<div class="card-meta">${entry?.pass?.label || ''}</div>`;
+    + `<div class="card-meta">${(entry?.pass?.label || '')}${action}</div>`;
   card.addEventListener('dragstart', (event) => {
     if (!event.dataTransfer) return;
     const payload = {
@@ -243,33 +245,6 @@ function renderUrgentQueues(root, queues, handlers) {
     wrapper.appendChild(group);
   });
   root.appendChild(wrapper);
-}
-
-function renderPomodoroControls(root) {
-  const stateRef = ensureBoardState();
-  const section = document.createElement('section');
-  section.className = 'block-board-pomodoro';
-  const toggle = document.createElement('button');
-  toggle.type = 'button';
-  toggle.className = 'btn secondary';
-  toggle.textContent = stateRef.showPomodoro ? 'Hide Pomodoro' : 'Show Pomodoro';
-  toggle.addEventListener('click', () => {
-    const next = !ensureBoardState().showPomodoro;
-    setBlockBoardState({ showPomodoro: next });
-    renderPomodoroControls(root);
-  });
-  section.appendChild(toggle);
-  if (stateRef.showPomodoro) {
-    const timer = document.createElement('div');
-    timer.className = 'block-board-pomodoro-timer';
-    timer.textContent = 'Pomodoro timer ready';
-    section.appendChild(timer);
-  }
-  if (root.firstChild) {
-    root.replaceChild(section, root.firstChild);
-  } else {
-    root.appendChild(section);
-  }
 }
 
 function buildDayAssignments(blockLectures, days) {
@@ -468,10 +443,6 @@ export async function renderBlockBoard(container, refresh) {
     }
   });
   container.appendChild(urgentHost);
-
-  const pomodoroHost = document.createElement('div');
-  renderPomodoroControls(pomodoroHost);
-  container.appendChild(pomodoroHost);
 
   const blockList = document.createElement('div');
   blockList.className = 'block-board-list';

--- a/style.css
+++ b/style.css
@@ -5794,8 +5794,6 @@ body.map-toolbox-dragging {
 .block-board-pass-meta { font-size: 0.85rem; opacity: 0.8; }
 .block-board-pass-actions { display: flex; gap: 0.5rem; }
 .block-board-empty { font-size: 0.85rem; opacity: 0.7; }
-.block-board-pomodoro { display: flex; flex-direction: column; gap: 0.75rem; }
-.block-board-pomodoro-timer { padding: 1rem; border-radius: 12px; background: var(--surface-2); text-align: center; font-weight: 600; }
 .block-board-list { display: flex; flex-direction: column; gap: 2rem; }
 .block-board-block { display: flex; flex-direction: column; gap: 1rem; }
 .block-board-block-header { display: flex; justify-content: space-between; align-items: center; gap: 1rem; }

--- a/test/ui.block-board.test.js
+++ b/test/ui.block-board.test.js
@@ -30,7 +30,7 @@ describe('block board rendering', () => {
     global.Node = dom.window.Node;
     container = document.createElement('div');
     document.body.appendChild(container);
-    state.blockBoard = { collapsedBlocks: [], showDensity: true, showPomodoro: false };
+    state.blockBoard = { collapsedBlocks: [], showDensity: true };
   });
 
   afterEach(() => {
@@ -80,7 +80,7 @@ describe('block board rendering', () => {
     assert.equal(saveLectureMock.mock.callCount(), 3);
   });
 
-  it('persists density, collapse, and pomodoro state', async () => {
+  it('persists density and collapse state', async () => {
     const data = sampleData();
     setupBoardDeps(data);
     await renderBlockBoard(container, () => {});
@@ -95,12 +95,6 @@ describe('block board rendering', () => {
     collapseBtn.click();
     await renderBlockBoard(container, () => {});
     assert(state.blockBoard.collapsedBlocks.includes('b1'));
-
-    const pomodoroToggle = container.querySelector('.block-board-pomodoro .btn.secondary');
-    assert(pomodoroToggle);
-    pomodoroToggle.click();
-    await Promise.resolve();
-    assert.equal(state.blockBoard.showPomodoro, true);
   });
 
   it('supports drag and drop scheduling updates', async () => {

--- a/test/ui.lectures.test.js
+++ b/test/ui.lectures.test.js
@@ -94,12 +94,28 @@ describe('lectures management UI', () => {
 
     const form = document.querySelector('.lecture-dialog form');
     assert.ok(form, 'lecture dialog form should render');
-    const idInput = form.querySelector('[data-field="id"]');
     const nameInput = form.querySelector('[data-field="name"]');
     const weekInput = form.querySelector('[data-field="week"]');
-    assert.ok(idInput && nameInput && weekInput);
+    assert.ok(nameInput && weekInput);
 
-    idInput.value = '101';
+    const numberInputs = Array.from(form.querySelectorAll('input[type="number"]'));
+    const passCountInput = numberInputs.find(input => !input.dataset.field);
+    assert.ok(passCountInput, 'Pass count input should exist');
+
+    passCountInput.value = '2';
+    passCountInput.dispatchEvent(new window.Event('change', { bubbles: true }));
+
+    let actionSelects = [];
+    await waitFor(() => {
+      actionSelects = Array.from(form.querySelectorAll('.lecture-pass-action'));
+      return actionSelects.length === 2;
+    });
+    assert.equal(actionSelects.length, 2);
+    actionSelects[0].value = 'Notes';
+    actionSelects[0].dispatchEvent(new window.Event('change', { bubbles: true }));
+    actionSelects[1].value = 'Quiz';
+    actionSelects[1].dispatchEvent(new window.Event('change', { bubbles: true }));
+
     nameInput.value = 'Intro to Cardio';
     weekInput.value = '1';
 
@@ -111,6 +127,9 @@ describe('lectures management UI', () => {
     const lectures = await listLecturesByBlock('cardio');
     assert.equal(lectures.length, 1);
     assert.equal(lectures[0].name, 'Intro to Cardio');
+    assert.equal(lectures[0].id, 1);
+    assert.equal(lectures[0].passPlan.schedule.length, 2);
+    assert.equal(lectures[0].passPlan.schedule[1].action, 'Quiz');
 
     const rows = document.querySelectorAll('[data-lecture-row]');
     assert.equal(rows.length, 1);


### PR DESCRIPTION
## Summary
- allow lectures to define a custom number of passes with selected study actions and surface the actions throughout the block board
- generate lecture and block identifiers automatically while simplifying the block settings UI to focus on title, weeks, and color
- remove the unused Pomodoro toggle from the block board state and layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf8fc8dfa08322bdcbfd2b6bc530ab