### PR TITLE
Revamp block board and lectures UI with block date settings

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -1681,6 +1681,26 @@ var Sevenn = (() => {
       }
     }
   }
+  function normalizeDateInput(value) {
+    if (value == null) return null;
+    if (value instanceof Date) {
+      if (Number.isNaN(value.getTime())) return null;
+      return value.toISOString().slice(0, 10);
+    }
+    if (typeof value === "number") {
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime())) return null;
+      return date.toISOString().slice(0, 10);
+    }
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (!trimmed) return null;
+      const date = new Date(trimmed);
+      if (Number.isNaN(date.getTime())) return null;
+      return date.toISOString().slice(0, 10);
+    }
+    return null;
+  }
   async function upsertBlock(def) {
     const title = typeof def?.title === "string" ? def.title : "";
     let blockId = typeof def?.blockId === "string" && def.blockId.trim() ? def.blockId.trim() : "";
@@ -1741,7 +1761,9 @@ var Sevenn = (() => {
       order: def.order || existing?.order || now,
       createdAt: existing?.createdAt || now,
       updatedAt: now,
-      weeks: typeof def.weeks === "number" ? def.weeks : existing?.weeks
+      weeks: typeof def.weeks === "number" ? def.weeks : existing?.weeks,
+      startDate: def.startDate !== void 0 ? normalizeDateInput(def.startDate) : existing?.startDate ? normalizeDateInput(existing.startDate) : null,
+      endDate: def.endDate !== void 0 ? normalizeDateInput(def.endDate) : existing?.endDate ? normalizeDateInput(existing.endDate) : null
     };
     delete next.lectures;
     const writeStore = await store("blocks", "readwrite");
@@ -2178,9 +2200,57 @@ var Sevenn = (() => {
     empty.textContent = "No blocks yet. Use \u201CAdd block\u201D to create one.";
     return empty;
   }
-  function formatWeeks(weeks) {
-    if (!Number.isFinite(weeks)) return "Weeks: \u2014";
-    return `Weeks: ${weeks}`;
+  var DAY_MS = 24 * 60 * 60 * 1e3;
+  function formatWeekCount(weeks) {
+    if (!Number.isFinite(weeks) || weeks <= 0) return null;
+    const rounded = Math.max(1, Math.round(weeks));
+    return `${rounded} week${rounded === 1 ? "" : "s"}`;
+  }
+  function parseBlockDate(value) {
+    if (!value) return null;
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return null;
+    return date;
+  }
+  function formatBlockDate(value, options = { month: "short", day: "numeric", year: "numeric" }) {
+    const date = parseBlockDate(value);
+    if (!date) return null;
+    const formatter = new Intl.DateTimeFormat(void 0, options);
+    return formatter.format(date);
+  }
+  function formatDateRange(start, end) {
+    const startDate = parseBlockDate(start);
+    const endDate = parseBlockDate(end);
+    if (!startDate && !endDate) return null;
+    if (startDate && endDate) {
+      const formatter = new Intl.DateTimeFormat(void 0, { month: "short", day: "numeric", year: "numeric" });
+      return `${formatter.format(startDate)} \u2192 ${formatter.format(endDate)}`;
+    }
+    if (startDate) {
+      const formatted2 = formatBlockDate(startDate);
+      return formatted2 ? `Starts ${formatted2}` : null;
+    }
+    const formatted = formatBlockDate(endDate);
+    return formatted ? `Ends ${formatted}` : null;
+  }
+  function computeSpanDays(start, end) {
+    const startDate = parseBlockDate(start);
+    const endDate = parseBlockDate(end);
+    if (!startDate || !endDate) return null;
+    const diff = endDate.getTime() - startDate.getTime();
+    if (diff < 0) return null;
+    return Math.round(diff / DAY_MS) + 1;
+  }
+  function formatBlockMeta(block) {
+    if (!block) return "No block data";
+    const parts = [];
+    const weeks = formatWeekCount(Number(block.weeks));
+    if (weeks) parts.push(weeks);
+    const range = formatDateRange(block.startDate, block.endDate);
+    if (range) parts.push(range);
+    const spanDays = computeSpanDays(block.startDate, block.endDate);
+    if (spanDays) parts.push(`${spanDays} day${spanDays === 1 ? "" : "s"}`);
+    return parts.join(" \u2022 ") || "Block details unavailable";
   }
   async function renderSettings(root) {
     root.innerHTML = "";
@@ -2219,6 +2289,10 @@ var Sevenn = (() => {
       if (!block) return;
       const wrap = document.createElement("div");
       wrap.className = "settings-block-row";
+      if (block.color) {
+        wrap.style.setProperty("--block-accent", block.color);
+        wrap.classList.add("has-accent");
+      }
       const header = document.createElement("div");
       header.className = "settings-block-header";
       const title = document.createElement("h3");
@@ -2231,9 +2305,8 @@ var Sevenn = (() => {
       header.appendChild(title);
       const meta = document.createElement("div");
       meta.className = "settings-block-meta";
-      meta.textContent = formatWeeks(Number(block.weeks));
+      meta.textContent = formatBlockMeta(block);
       header.appendChild(meta);
-      wrap.appendChild(header);
       const controls = document.createElement("div");
       controls.className = "settings-block-controls";
       const upBtn = document.createElement("button");
@@ -2286,7 +2359,28 @@ var Sevenn = (() => {
         await renderSettings(root);
       });
       controls.appendChild(deleteBtn);
-      wrap.appendChild(controls);
+      header.appendChild(controls);
+      wrap.appendChild(header);
+      const detailGrid = document.createElement("div");
+      detailGrid.className = "settings-block-detail-grid";
+      const startDetail = document.createElement("div");
+      startDetail.className = "settings-block-detail";
+      startDetail.innerHTML = `<span>Start</span><strong>${formatBlockDate(block.startDate) || "\u2014"}</strong>`;
+      detailGrid.appendChild(startDetail);
+      const endDetail = document.createElement("div");
+      endDetail.className = "settings-block-detail";
+      endDetail.innerHTML = `<span>End</span><strong>${formatBlockDate(block.endDate) || "\u2014"}</strong>`;
+      detailGrid.appendChild(endDetail);
+      const weeksDetail = document.createElement("div");
+      weeksDetail.className = "settings-block-detail";
+      weeksDetail.innerHTML = `<span>Weeks</span><strong>${formatWeekCount(Number(block.weeks)) || "\u2014"}</strong>`;
+      detailGrid.appendChild(weeksDetail);
+      const spanDays = computeSpanDays(block.startDate, block.endDate);
+      const daysDetail = document.createElement("div");
+      daysDetail.className = "settings-block-detail";
+      daysDetail.innerHTML = `<span>Span</span><strong>${spanDays ? `${spanDays} day${spanDays === 1 ? "" : "s"}` : "\u2014"}</strong>`;
+      detailGrid.appendChild(daysDetail);
+      wrap.appendChild(detailGrid);
       const editForm = document.createElement("form");
       editForm.className = "settings-block-edit";
       editForm.hidden = true;
@@ -2301,6 +2395,14 @@ var Sevenn = (() => {
       weeksInput2.required = true;
       weeksInput2.className = "input";
       weeksInput2.value = block.weeks != null ? String(block.weeks) : "1";
+      const startInput2 = document.createElement("input");
+      startInput2.type = "date";
+      startInput2.className = "input";
+      startInput2.value = block.startDate || "";
+      const endInput2 = document.createElement("input");
+      endInput2.type = "date";
+      endInput2.className = "input";
+      endInput2.value = block.endDate || "";
       const colorInput2 = document.createElement("input");
       colorInput2.type = "color";
       colorInput2.className = "input";
@@ -2316,7 +2418,7 @@ var Sevenn = (() => {
       cancelBtn.addEventListener("click", () => {
         editForm.hidden = true;
       });
-      editForm.append(titleInput2, weeksInput2, colorInput2, saveBtn, cancelBtn);
+      editForm.append(titleInput2, startInput2, endInput2, weeksInput2, colorInput2, saveBtn, cancelBtn);
       editForm.addEventListener("submit", async (event) => {
         event.preventDefault();
         const titleValue = titleInput2.value.trim();
@@ -2324,11 +2426,24 @@ var Sevenn = (() => {
         if (!titleValue || !Number.isFinite(weeksValue) || weeksValue <= 0) {
           return;
         }
+        let startValue = startInput2.value || null;
+        let endValue = endInput2.value || null;
+        if (startValue && endValue) {
+          const startDate = new Date(startValue);
+          const endDate = new Date(endValue);
+          if (!Number.isNaN(startDate.getTime()) && !Number.isNaN(endDate.getTime()) && startDate > endDate) {
+            const swap = startValue;
+            startValue = endValue;
+            endValue = swap;
+          }
+        }
         const payload = {
           ...block,
           title: titleValue,
           weeks: weeksValue,
-          color: colorInput2.value || null
+          color: colorInput2.value || null,
+          startDate: startValue,
+          endDate: endValue
         };
         await upsertBlock(payload);
         invalidateBlockCatalog();
@@ -2347,6 +2462,16 @@ var Sevenn = (() => {
     titleInput.required = true;
     titleInput.placeholder = "Block title";
     titleInput.className = "input";
+    const startInput = document.createElement("input");
+    startInput.type = "date";
+    startInput.className = "input";
+    startInput.placeholder = "Start date";
+    startInput.setAttribute("aria-label", "Block start date");
+    const endInput = document.createElement("input");
+    endInput.type = "date";
+    endInput.className = "input";
+    endInput.placeholder = "End date";
+    endInput.setAttribute("aria-label", "Block end date");
     const weeksInput = document.createElement("input");
     weeksInput.type = "number";
     weeksInput.min = "1";
@@ -2361,8 +2486,8 @@ var Sevenn = (() => {
     const submitBtn = document.createElement("button");
     submitBtn.type = "submit";
     submitBtn.className = "btn";
-    submitBtn.textContent = "Add block";
-    form.append(titleInput, weeksInput, colorInput, submitBtn);
+    submitBtn.textContent = "Add block (top)";
+    form.append(titleInput, startInput, endInput, weeksInput, colorInput, submitBtn);
     form.addEventListener("submit", async (event) => {
       event.preventDefault();
       const titleValue = titleInput.value.trim();
@@ -2370,12 +2495,27 @@ var Sevenn = (() => {
       if (!titleValue || !Number.isFinite(weeksValue) || weeksValue <= 0) {
         return;
       }
+      let startValue = startInput.value || null;
+      let endValue = endInput.value || null;
+      if (startValue && endValue) {
+        const startDate = new Date(startValue);
+        const endDate = new Date(endValue);
+        if (!Number.isNaN(startDate.getTime()) && !Number.isNaN(endDate.getTime()) && startDate > endDate) {
+          const swap = startValue;
+          startValue = endValue;
+          endValue = swap;
+        }
+      }
       await upsertBlock({
         title: titleValue,
         weeks: weeksValue,
-        color: colorInput.value || null
+        color: colorInput.value || null,
+        startDate: startValue,
+        endDate: endValue
       });
       titleInput.value = "";
+      startInput.value = "";
+      endInput.value = "";
       weeksInput.value = "1";
       colorInput.value = "#ffffff";
       invalidateBlockCatalog();
@@ -6470,6 +6610,107 @@ var Sevenn = (() => {
     const months = minutes / (60 * 24 * 30);
     return `${Math.round(months)}mo`;
   }
+  var PASS_ACCENTS = [
+    "var(--pink)",
+    "var(--blue)",
+    "var(--green)",
+    "var(--orange)",
+    "var(--purple)",
+    "var(--teal)",
+    "var(--yellow)",
+    "var(--rose)",
+    "var(--indigo)",
+    "var(--cyan)"
+  ];
+  var PASS_DUE_FORMAT = new Intl.DateTimeFormat(void 0, {
+    month: "short",
+    day: "numeric"
+  });
+  var PASS_TIME_FORMAT = new Intl.DateTimeFormat(void 0, {
+    hour: "numeric",
+    minute: "2-digit"
+  });
+  function passAccent(order = 1) {
+    if (!Number.isFinite(order)) return PASS_ACCENTS[0];
+    const idx = Math.max(0, Math.floor(order) - 1) % PASS_ACCENTS.length;
+    return PASS_ACCENTS[idx];
+  }
+  function formatPassDueTimestamp(due) {
+    if (!Number.isFinite(due)) return "";
+    const date = new Date(due);
+    return `${PASS_DUE_FORMAT.format(date)} \u2022 ${PASS_TIME_FORMAT.format(date)}`;
+  }
+  function buildPassDisplayList(lecture) {
+    const scheduleList = Array.isArray(lecture?.passPlan?.schedule) ? lecture.passPlan.schedule : [];
+    const scheduleByOrder = /* @__PURE__ */ new Map();
+    scheduleList.forEach((step, index) => {
+      const order = Number.isFinite(step?.order) ? step.order : index + 1;
+      scheduleByOrder.set(order, { ...step, order });
+    });
+    const passes = Array.isArray(lecture?.passes) ? lecture.passes : [];
+    const passByOrder = /* @__PURE__ */ new Map();
+    passes.forEach((pass) => {
+      const order = Number(pass?.order);
+      if (Number.isFinite(order)) {
+        passByOrder.set(order, pass);
+      }
+    });
+    const orders = /* @__PURE__ */ new Set([
+      ...scheduleByOrder.keys(),
+      ...passByOrder.keys()
+    ]);
+    if (!orders.size) {
+      const planLength = scheduleList.length;
+      for (let i = 1; i <= planLength; i += 1) {
+        orders.add(i);
+      }
+    }
+    return Array.from(orders).filter((order) => Number.isFinite(order)).sort((a, b) => a - b).map((order) => {
+      const schedule = scheduleByOrder.get(order) || {};
+      const pass = passByOrder.get(order) || {};
+      return {
+        order,
+        label: schedule.label || pass.label || `Pass ${order}`,
+        action: schedule.action || pass.action || "",
+        due: Number.isFinite(pass?.due) ? pass.due : null,
+        completedAt: Number.isFinite(pass?.completedAt) ? pass.completedAt : null
+      };
+    });
+  }
+  function createPassChipDisplay(info, now = Date.now()) {
+    const chip = document.createElement("div");
+    chip.className = "lecture-pass-chip";
+    chip.style.setProperty("--chip-accent", passAccent(info?.order));
+    chip.dataset.passOrder = String(info?.order ?? "");
+    if (Number.isFinite(info?.completedAt)) chip.classList.add("is-complete");
+    if (!Number.isFinite(info?.completedAt) && Number.isFinite(info?.due) && info.due < now) {
+      chip.classList.add("is-overdue");
+    }
+    const header = document.createElement("div");
+    header.className = "lecture-pass-chip-header";
+    const badge = document.createElement("span");
+    badge.className = "lecture-pass-chip-order";
+    badge.textContent = `P${info?.order ?? ""}`;
+    header.appendChild(badge);
+    const label = document.createElement("span");
+    label.className = "lecture-pass-chip-label";
+    label.textContent = info?.action || info?.label || `Pass ${info?.order ?? ""}`;
+    header.appendChild(label);
+    chip.appendChild(header);
+    const meta = document.createElement("div");
+    meta.className = "lecture-pass-chip-meta";
+    let metaText = "";
+    if (Number.isFinite(info?.completedAt)) {
+      metaText = "Completed";
+    } else if (Number.isFinite(info?.due)) {
+      metaText = formatPassDueTimestamp(info.due);
+    } else {
+      metaText = "Unscheduled";
+    }
+    meta.textContent = metaText;
+    chip.appendChild(meta);
+    return chip;
+  }
   var MAX_PASS_COUNT = 20;
   var DAY_MINUTES2 = 24 * 60;
   function defaultActionForIndex(index) {
@@ -6588,11 +6829,17 @@ var Sevenn = (() => {
     const days = Math.round(hours / 24);
     return `due in ${days} day${days === 1 ? "" : "s"}`;
   }
-  function formatNextDue(nextDueAt, now = Date.now()) {
-    if (nextDueAt == null) return "Not scheduled";
-    if (!Number.isFinite(nextDueAt)) return "\u2014";
-    if (nextDueAt <= now) return formatOverdue(nextDueAt, now);
-    return formatTimeUntil(nextDueAt, now);
+  function formatNextDueDescriptor(nextDueAt, now = Date.now()) {
+    if (nextDueAt == null || !Number.isFinite(nextDueAt)) return "Not scheduled";
+    const date = new Date(nextDueAt);
+    const dateLabel = new Intl.DateTimeFormat(void 0, {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit"
+    }).format(date);
+    const relative = nextDueAt <= now ? formatOverdue(nextDueAt, now) : formatTimeUntil(nextDueAt, now);
+    return `${dateLabel} \u2022 ${relative}`;
   }
   function formatPassSummary(lecture) {
     const total = Array.isArray(lecture?.passes) ? lecture.passes.length : Array.isArray(lecture?.passPlan?.schedule) ? lecture.passPlan.schedule.length : 0;
@@ -6606,58 +6853,96 @@ var Sevenn = (() => {
     empty.textContent = "No lectures found. Use \u201CAdd Lecture\u201D to create one.";
     return empty;
   }
-  function renderLectureRow(lecture, blockMap, onEdit, onDelete) {
+  function renderLectureRow(lecture, blockMap, onEdit, onDelete, now = Date.now()) {
     const row = document.createElement("tr");
     row.dataset.lectureRow = "true";
     row.dataset.lectureId = String(lecture.id);
     row.dataset.blockId = String(lecture.blockId ?? "");
     const lectureCell = document.createElement("td");
     lectureCell.className = "lecture-cell";
-    const blockBadge = document.createElement("div");
-    blockBadge.className = "lecture-block";
     const block = blockMap.get(lecture.blockId);
+    const header = document.createElement("div");
+    header.className = "lecture-cell-header";
+    const blockBadge = document.createElement("span");
+    blockBadge.className = "lecture-block";
     blockBadge.textContent = block?.title || lecture.blockId || "Unknown block";
     if (block?.color) {
-      blockBadge.style.background = block.color;
+      blockBadge.style.setProperty("--block-accent", block.color);
+      blockBadge.classList.add("has-accent");
     }
-    lectureCell.appendChild(blockBadge);
+    header.appendChild(blockBadge);
     const name = document.createElement("div");
     name.className = "lecture-name";
     name.textContent = lecture.name || `Lecture ${lecture.id}`;
-    lectureCell.appendChild(name);
+    header.appendChild(name);
+    lectureCell.appendChild(header);
     const positionValue = lecture.position ?? lecture.id;
     if (positionValue != null) {
-      const position = document.createElement("div");
-      position.className = "lecture-position";
-      position.textContent = `Position: ${positionValue}`;
-      lectureCell.appendChild(position);
+      const meta = document.createElement("div");
+      meta.className = "lecture-position";
+      meta.textContent = `Position: ${positionValue}`;
+      lectureCell.appendChild(meta);
     }
     const tags = Array.isArray(lecture.tags) ? lecture.tags.filter(Boolean) : [];
     if (tags.length) {
       const tagList = document.createElement("div");
       tagList.className = "lecture-tags";
-      tagList.textContent = tags.join(", ");
+      tags.forEach((tag) => {
+        const chip = document.createElement("span");
+        chip.className = "lecture-tag";
+        chip.textContent = tag;
+        tagList.appendChild(chip);
+      });
       lectureCell.appendChild(tagList);
     }
     row.appendChild(lectureCell);
-    const weekCell = document.createElement("td");
-    weekCell.className = "lecture-week";
-    weekCell.textContent = formatWeekLabel3(lecture.week);
-    row.appendChild(weekCell);
+    const scheduleCell = document.createElement("td");
+    scheduleCell.className = "lecture-schedule";
+    const week = document.createElement("div");
+    week.className = "lecture-week";
+    week.textContent = formatWeekLabel3(lecture.week);
+    scheduleCell.appendChild(week);
+    const statusRow = document.createElement("div");
+    statusRow.className = "lecture-status-row";
+    const statusBadge = document.createElement("span");
+    statusBadge.className = "lecture-status-pill";
+    const statusLabel = lecture?.status?.state || "pending";
+    statusBadge.textContent = statusLabel;
+    statusBadge.dataset.status = statusLabel;
+    statusRow.appendChild(statusBadge);
+    scheduleCell.appendChild(statusRow);
+    const nextDue = document.createElement("div");
+    nextDue.className = "lecture-next-due";
+    nextDue.textContent = formatNextDueDescriptor(lecture.nextDueAt, now);
+    scheduleCell.appendChild(nextDue);
+    row.appendChild(scheduleCell);
     const passesCell = document.createElement("td");
     passesCell.className = "lecture-passes";
     const summary = document.createElement("div");
     summary.className = "lecture-pass-summary";
     summary.textContent = formatPassSummary(lecture);
     passesCell.appendChild(summary);
-    const plan = document.createElement("div");
-    plan.className = "lecture-pass-plan";
-    plan.textContent = formatPassPlan(lecture.passPlan);
-    passesCell.appendChild(plan);
-    const due = document.createElement("div");
-    due.className = "lecture-pass-due";
-    due.textContent = formatNextDue(lecture.nextDueAt);
-    passesCell.appendChild(due);
+    const passList = buildPassDisplayList(lecture);
+    const chips = document.createElement("div");
+    chips.className = "lecture-pass-chips";
+    if (passList.length) {
+      passList.forEach((info) => {
+        chips.appendChild(createPassChipDisplay(info, now));
+      });
+    } else {
+      const empty = document.createElement("div");
+      empty.className = "lecture-pass-empty";
+      empty.textContent = "No passes scheduled";
+      chips.appendChild(empty);
+    }
+    passesCell.appendChild(chips);
+    const planText = formatPassPlan(lecture.passPlan);
+    if (planText) {
+      const plan = document.createElement("div");
+      plan.className = "lecture-pass-plan";
+      plan.textContent = planText;
+      passesCell.appendChild(plan);
+    }
     row.appendChild(passesCell);
     const actions = document.createElement("td");
     actions.className = "lecture-actions";
@@ -6685,7 +6970,7 @@ var Sevenn = (() => {
     table.className = "table lectures-table";
     const thead = document.createElement("thead");
     const headerRow = document.createElement("tr");
-    ["Lecture", "Week", "Passes", "Actions"].forEach((label) => {
+    ["Lecture", "Schedule", "Pass plan", "Actions"].forEach((label) => {
       const th = document.createElement("th");
       th.textContent = label;
       headerRow.appendChild(th);
@@ -6717,12 +7002,9 @@ var Sevenn = (() => {
         { ...lecture, nextDueAt: lecture.nextDueAt ?? null, status: lecture.status, passPlan: lecture.passPlan },
         blockMap,
         onEdit,
-        onDelete
+        onDelete,
+        now
       );
-      const dueEl = row.querySelector(".lecture-pass-due");
-      if (dueEl && lecture.nextDueAt != null) {
-        dueEl.textContent = formatNextDue(lecture.nextDueAt, now);
-      }
       tbody.appendChild(row);
     });
     table.appendChild(tbody);
@@ -8758,16 +9040,33 @@ var Sevenn = (() => {
   var loadCatalog = loadBlockCatalog;
   var fetchLectures = listAllLectures;
   var persistLecture = saveLecture;
-  var DAY_MS = 24 * 60 * 60 * 1e3;
+  var DAY_MS2 = 24 * 60 * 60 * 1e3;
   var PASS_COLORS = [
     "var(--pink)",
     "var(--blue)",
     "var(--green)",
     "var(--orange)",
     "var(--purple)",
-    "var(--teal)"
+    "var(--teal)",
+    "var(--yellow)",
+    "var(--rose)",
+    "var(--indigo)",
+    "var(--cyan)"
   ];
   var BOARD_DAYS = 14;
+  var BLOCK_RANGE_FORMAT = new Intl.DateTimeFormat(void 0, {
+    month: "short",
+    day: "numeric",
+    year: "numeric"
+  });
+  var PASS_DUE_FORMAT2 = new Intl.DateTimeFormat(void 0, {
+    month: "short",
+    day: "numeric"
+  });
+  var PASS_TIME_FORMAT2 = new Intl.DateTimeFormat(void 0, {
+    hour: "numeric",
+    minute: "2-digit"
+  });
   function ensureBoardState() {
     if (!state.blockBoard) {
       state.blockBoard = { collapsedBlocks: [], showDensity: true };
@@ -8789,20 +9088,50 @@ var Sevenn = (() => {
     const formatter = new Intl.DateTimeFormat(void 0, { weekday: "short", month: "short", day: "numeric" });
     return formatter.format(date);
   }
-  function formatDueTime(due) {
-    if (!Number.isFinite(due)) return "Unscheduled";
-    const formatter = new Intl.DateTimeFormat(void 0, { hour: "numeric", minute: "2-digit" });
-    return formatter.format(new Date(due));
+  function parseBlockDate2(value) {
+    if (!value) return null;
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return null;
+    return date;
+  }
+  function formatBlockDate2(value) {
+    const date = parseBlockDate2(value);
+    if (!date) return null;
+    return BLOCK_RANGE_FORMAT.format(date);
+  }
+  function blockRangeLabel(block) {
+    const start = formatBlockDate2(block?.startDate);
+    const end = formatBlockDate2(block?.endDate);
+    if (start && end) return `${start} \u2192 ${end}`;
+    if (start) return `Starts ${start}`;
+    if (end) return `Ends ${end}`;
+    return null;
+  }
+  function blockSpanDays(block) {
+    const start = parseBlockDate2(block?.startDate);
+    const end = parseBlockDate2(block?.endDate);
+    if (!start || !end) return null;
+    const diff = end.getTime() - start.getTime();
+    if (diff < 0) return null;
+    return Math.round(diff / DAY_MS2) + 1;
+  }
+  function formatPassDueLabel(due) {
+    if (!Number.isFinite(due)) return "";
+    const date = new Date(due);
+    const datePart = PASS_DUE_FORMAT2.format(date);
+    const timePart = PASS_TIME_FORMAT2.format(date);
+    return `${datePart} \u2022 ${timePart}`;
   }
   function collectBoardDays(now = Date.now()) {
     const today = startOfDay2(now);
-    const start = today - 2 * DAY_MS;
-    return Array.from({ length: BOARD_DAYS }, (_, idx) => start + idx * DAY_MS);
+    const start = today - 2 * DAY_MS2;
+    return Array.from({ length: BOARD_DAYS }, (_, idx) => start + idx * DAY_MS2);
   }
   function buildPassElement(entry, onComplete, onDelay) {
     const chip = document.createElement("div");
     chip.className = "block-board-pass-chip";
     chip.style.setProperty("--chip-accent", passColor(entry?.pass?.order));
+    chip.dataset.passOrder = String(entry?.pass?.order ?? "");
     const title = document.createElement("div");
     title.className = "block-board-pass-title";
     title.textContent = entry?.lecture?.name || `Lecture ${entry?.lecture?.id}`;
@@ -8810,9 +9139,12 @@ var Sevenn = (() => {
     const meta = document.createElement("div");
     meta.className = "block-board-pass-meta";
     const label = entry?.pass?.label || `Pass ${entry?.pass?.order ?? ""}`;
-    const action = entry?.pass?.action ? ` \u2022 ${entry.pass.action}` : "";
-    const dueLabel = formatDueTime(entry?.pass?.due);
-    meta.textContent = `${label}${action ? action : ""} \u2022 ${dueLabel}`;
+    const action = entry?.pass?.action ? entry.pass.action : "";
+    const dueLabel = Number.isFinite(entry?.pass?.due) ? formatPassDueLabel(entry.pass.due) : "Unscheduled";
+    const parts = [label];
+    if (action) parts.push(action);
+    if (dueLabel) parts.push(dueLabel);
+    meta.textContent = parts.join(" \u2022 ");
     chip.appendChild(meta);
     const actions = document.createElement("div");
     actions.className = "block-board-pass-actions";
@@ -8848,26 +9180,50 @@ var Sevenn = (() => {
     const nextDueAt = calculateNextDue(passes);
     return { ...lecture, passes, status, nextDueAt };
   }
-  function createDensityBar(dayCount, isToday) {
+  function buildDensityGradient(byOrder, total) {
+    if (!total) return "linear-gradient(to top, var(--accent) 0% 100%)";
+    const entries = Array.from(byOrder.entries()).filter(([, count]) => Number.isFinite(count) && count > 0).sort(([a], [b]) => Number(a) - Number(b));
+    if (!entries.length) {
+      return "linear-gradient(to top, var(--accent) 0% 100%)";
+    }
+    let traversed = 0;
+    const segments = entries.map(([order, count]) => {
+      const start = traversed / total * 100;
+      traversed += count;
+      const end = traversed / total * 100;
+      const color = passColor(order);
+      return `${color} ${start}% ${end}%`;
+    });
+    return `linear-gradient(to top, ${segments.join(", ")})`;
+  }
+  function createDensityBar(dayStat, isToday, maxTotal) {
     const bar = document.createElement("div");
     bar.className = "block-board-density-bar";
     if (isToday) bar.classList.add("today");
-    bar.style.setProperty("--density-value", String(dayCount));
+    const total = Number(dayStat?.total ?? 0);
+    bar.style.setProperty("--density-value", String(total));
     const fill = document.createElement("div");
     fill.className = "block-board-density-fill";
-    fill.style.height = `${Math.min(100, dayCount * 12)}%`;
+    const height = maxTotal > 0 ? Math.min(100, Math.round(total / maxTotal * 100)) : 0;
+    fill.style.height = `${height}%`;
+    const gradient = buildDensityGradient(dayStat?.byOrder || /* @__PURE__ */ new Map(), total);
+    fill.style.background = gradient;
     bar.appendChild(fill);
     return bar;
   }
-  function createDensityLegend(day, count, isToday) {
+  function createDensityLegend(dayStat, isToday, maxTotal) {
     const slot = document.createElement("div");
     slot.className = "block-board-density-slot";
     if (isToday) slot.classList.add("today");
-    const bar = createDensityBar(count, isToday);
+    const bar = createDensityBar(dayStat, isToday, maxTotal);
+    if (Number.isFinite(dayStat?.day)) {
+      const displayDate = new Date(dayStat.day);
+      slot.title = displayDate.toLocaleDateString();
+    }
     slot.appendChild(bar);
     const label = document.createElement("div");
     label.className = "block-board-density-label";
-    label.textContent = new Date(day).getDate();
+    label.textContent = new Date(dayStat.day).getDate();
     slot.appendChild(label);
     return slot;
   }
@@ -8880,8 +9236,23 @@ var Sevenn = (() => {
     card.dataset.lectureId = entry?.lecture?.id ?? "";
     card.dataset.passOrder = entry?.pass?.order ?? "";
     card.dataset.passDue = Number.isFinite(entry?.pass?.due) ? String(entry.pass.due) : "";
-    const action = entry?.pass?.action ? ` \u2022 ${entry.pass.action}` : "";
-    card.innerHTML = `<div class="card-title">${entry?.lecture?.name || "Lecture"}</div><div class="card-meta">${entry?.pass?.label || ""}${action}</div>`;
+    const title = document.createElement("div");
+    title.className = "card-title";
+    title.textContent = entry?.lecture?.name || "Lecture";
+    card.appendChild(title);
+    const meta = document.createElement("div");
+    meta.className = "card-meta";
+    const metaParts = [];
+    if (entry?.pass?.label) metaParts.push(entry.pass.label);
+    else if (entry?.pass?.order != null) metaParts.push(`Pass ${entry.pass.order}`);
+    if (entry?.pass?.action) metaParts.push(entry.pass.action);
+    meta.textContent = metaParts.length ? metaParts.join(" \u2022 ") : "Pass";
+    card.appendChild(meta);
+    const due = document.createElement("div");
+    due.className = "card-due";
+    const dueText = Number.isFinite(entry?.pass?.due) ? formatPassDueLabel(entry.pass.due) : "Unscheduled";
+    due.textContent = dueText;
+    card.appendChild(due);
     card.addEventListener("dragstart", (event) => {
       if (!event.dataTransfer) return;
       const payload = {
@@ -8925,41 +9296,51 @@ var Sevenn = (() => {
   }
   function renderUrgentQueues(root, queues, handlers) {
     const wrapper = document.createElement("section");
-    wrapper.className = "block-board-urgent";
+    wrapper.className = "block-board-summary";
     const config = [
-      { key: "overdue", label: "Overdue" },
-      { key: "today", label: "Today" },
-      { key: "tomorrow", label: "Tomorrow" }
+      { key: "today", label: "Today's To-Do", empty: "Nothing due today.", accent: "var(--blue)" },
+      { key: "tomorrow", label: "Due Tomorrow", empty: "Nothing due tomorrow.", accent: "var(--yellow)" },
+      { key: "overdue", label: "Overdue", empty: "No overdue passes. \u{1F389}", accent: "var(--rose)" }
     ];
-    config.forEach(({ key, label }) => {
-      const group = document.createElement("div");
-      group.className = "block-board-urgent-group";
+    config.forEach(({ key, label, empty, accent }) => {
+      const card = document.createElement("article");
+      card.className = "block-board-summary-card";
+      if (accent) card.style.setProperty("--summary-accent", accent);
       const header = document.createElement("div");
-      header.className = "block-board-urgent-header";
-      header.textContent = label;
-      const pushAll = document.createElement("button");
-      pushAll.type = "button";
-      pushAll.className = "btn tertiary";
-      pushAll.textContent = "Push all +1 day";
-      pushAll.addEventListener("click", () => handlers.onPushAll(key));
-      header.appendChild(pushAll);
-      group.appendChild(header);
-      const list = document.createElement("div");
-      list.className = "block-board-urgent-list";
+      header.className = "block-board-summary-header";
+      const title = document.createElement("h3");
+      title.className = "block-board-summary-title";
+      title.textContent = label;
+      header.appendChild(title);
       const entries = queues[key] || [];
+      const count = document.createElement("span");
+      count.className = "block-board-summary-count";
+      count.textContent = String(entries.length);
+      header.appendChild(count);
+      if (entries.length) {
+        const pushAll = document.createElement("button");
+        pushAll.type = "button";
+        pushAll.className = "btn tertiary block-board-summary-action";
+        pushAll.textContent = "Push to tomorrow";
+        pushAll.addEventListener("click", () => handlers.onPushAll(key));
+        header.appendChild(pushAll);
+      }
+      card.appendChild(header);
+      const list = document.createElement("div");
+      list.className = "block-board-summary-list";
       if (!entries.length) {
-        const empty = document.createElement("div");
-        empty.className = "block-board-empty";
-        empty.textContent = "Nothing queued.";
-        list.appendChild(empty);
+        const emptyState = document.createElement("div");
+        emptyState.className = "block-board-summary-empty";
+        emptyState.textContent = empty || "Nothing queued.";
+        list.appendChild(emptyState);
       } else {
         entries.forEach((entry) => {
           const chip = buildPassElement(entry, handlers.onComplete, handlers.onDelay);
           list.appendChild(chip);
         });
       }
-      group.appendChild(list);
-      wrapper.appendChild(group);
+      card.appendChild(list);
+      wrapper.appendChild(card);
     });
     root.appendChild(wrapper);
   }
@@ -8998,7 +9379,7 @@ var Sevenn = (() => {
       if (!lecture) return;
       const dayValue = column.dataset.day;
       const targetDay = dayValue ? Number(dayValue) : null;
-      const newDue = targetDay != null ? targetDay + (payload?.due != null ? payload.due % DAY_MS : 9 * 60 * 60 * 1e3) : null;
+      const newDue = targetDay != null ? targetDay + (payload?.due != null ? payload.due % DAY_MS2 : 9 * 60 * 60 * 1e3) : null;
       await updateLectureSchedule(lecture, (lec) => applyPassDueUpdate(lec, passOrder, newDue));
       await refresh();
     });
@@ -9008,18 +9389,46 @@ var Sevenn = (() => {
     const wrapper = document.createElement("section");
     wrapper.className = "block-board-block";
     wrapper.dataset.blockId = String(block?.blockId ?? "");
+    if (block?.color) {
+      wrapper.style.setProperty("--block-accent", block.color);
+      wrapper.classList.add("has-accent");
+    }
     const header = document.createElement("div");
     header.className = "block-board-block-header";
+    const heading = document.createElement("div");
+    heading.className = "block-board-block-heading";
     const title = document.createElement("h2");
+    title.className = "block-board-block-title";
     title.textContent = block?.title || block?.name || `Block ${block?.blockId}`;
-    header.appendChild(title);
+    if (block?.color) {
+      title.style.setProperty("--block-accent", block.color);
+      title.classList.add("has-accent");
+    }
+    heading.appendChild(title);
+    const metaParts = [];
+    const rangeText = blockRangeLabel(block);
+    if (rangeText) metaParts.push(rangeText);
+    const weekValue = Number(block?.weeks);
+    if (Number.isFinite(weekValue) && weekValue > 0) {
+      const weeks = Math.round(weekValue);
+      metaParts.push(`${weeks} week${weeks === 1 ? "" : "s"}`);
+    }
+    const span = blockSpanDays(block);
+    if (span) metaParts.push(`${span} day${span === 1 ? "" : "s"}`);
+    if (metaParts.length) {
+      const meta = document.createElement("div");
+      meta.className = "block-board-block-meta";
+      meta.textContent = metaParts.join(" \u2022 ");
+      heading.appendChild(meta);
+    }
+    header.appendChild(heading);
     const controls = document.createElement("div");
     controls.className = "block-board-block-controls";
     const collapseBtn = document.createElement("button");
     collapseBtn.type = "button";
     collapseBtn.className = "btn secondary";
     const isCollapsed = boardState.collapsedBlocks.includes(String(block?.blockId));
-    collapseBtn.textContent = isCollapsed ? "Expand" : "Collapse";
+    collapseBtn.textContent = isCollapsed ? "Expand" : "Minimize";
     collapseBtn.addEventListener("click", () => {
       const current = ensureBoardState();
       const nextCollapsed = new Set(current.collapsedBlocks.map(String));
@@ -9035,7 +9444,7 @@ var Sevenn = (() => {
     const densityBtn = document.createElement("button");
     densityBtn.type = "button";
     densityBtn.className = "btn secondary";
-    densityBtn.textContent = boardState.showDensity ? "Hide density" : "Show density";
+    densityBtn.textContent = boardState.showDensity ? "Hide timeline" : "Show timeline";
     densityBtn.addEventListener("click", () => {
       setBlockBoardState({ showDensity: !ensureBoardState().showDensity });
       refresh();
@@ -9043,35 +9452,46 @@ var Sevenn = (() => {
     controls.appendChild(densityBtn);
     header.appendChild(controls);
     wrapper.appendChild(header);
+    const assignments = buildDayAssignments(blockLectures, days);
     if (boardState.showDensity) {
+      const dayStats = days.map((day) => {
+        const entries = assignments.get(day) || [];
+        const breakdown = /* @__PURE__ */ new Map();
+        entries.forEach((entry) => {
+          const order = Number(entry?.pass?.order);
+          if (!Number.isFinite(order)) return;
+          breakdown.set(order, (breakdown.get(order) || 0) + 1);
+        });
+        return { day, total: entries.length, byOrder: breakdown };
+      });
+      const maxTotal = dayStats.reduce((max, stat) => Math.max(max, stat.total), 0);
+      const timeline = document.createElement("div");
+      timeline.className = "block-board-timeline";
+      const timelineHeader = document.createElement("div");
+      timelineHeader.className = "block-board-timeline-header";
+      const timelineTitle = document.createElement("h3");
+      timelineTitle.className = "block-board-timeline-title";
+      timelineTitle.textContent = `Block Timeline \u2014 ${block?.title || block?.name || "Block"}`;
+      timelineHeader.appendChild(timelineTitle);
+      const spanCount = blockSpanDays(block) || days.length;
+      const spanLabel = document.createElement("span");
+      spanLabel.className = "block-board-timeline-span";
+      spanLabel.textContent = `${spanCount} day${spanCount === 1 ? "" : "s"}`;
+      timelineHeader.appendChild(spanLabel);
+      timeline.appendChild(timelineHeader);
       const density = document.createElement("div");
       density.className = "block-board-density";
-      const counts = days.map((day) => {
-        const start = day;
-        const end = day + DAY_MS;
-        let total = 0;
-        blockLectures.forEach((lecture) => {
-          const passes = Array.isArray(lecture?.passes) ? lecture.passes : [];
-          passes.forEach((pass) => {
-            if (Number.isFinite(pass?.completedAt)) return;
-            if (!Number.isFinite(pass?.due)) return;
-            if (pass.due >= start && pass.due < end) total += 1;
-          });
-        });
-        return total;
-      });
-      counts.forEach((count, idx) => {
-        const day = days[idx];
-        const slot = createDensityLegend(day, count, startOfDay2(Date.now()) === day);
+      dayStats.forEach((stat) => {
+        const slot = createDensityLegend(stat, startOfDay2(Date.now()) === stat.day, Math.max(1, maxTotal));
         density.appendChild(slot);
       });
-      wrapper.appendChild(density);
+      timeline.appendChild(density);
+      wrapper.appendChild(timeline);
     }
     if (isCollapsed) {
       container.appendChild(wrapper);
       return;
     }
-    const assignments = buildDayAssignments(blockLectures, days);
     const board = document.createElement("div");
     board.className = "block-board-grid";
     const unscheduled = document.createElement("div");

--- a/js/storage/storage.js
+++ b/js/storage/storage.js
@@ -333,6 +333,27 @@ async function generateBlockId(storeRef, title) {
   }
 }
 
+function normalizeDateInput(value) {
+  if (value == null) return null;
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) return null;
+    return value.toISOString().slice(0, 10);
+  }
+  if (typeof value === 'number') {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return null;
+    return date.toISOString().slice(0, 10);
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const date = new Date(trimmed);
+    if (Number.isNaN(date.getTime())) return null;
+    return date.toISOString().slice(0, 10);
+  }
+  return null;
+}
+
 export async function upsertBlock(def) {
   const title = typeof def?.title === 'string' ? def.title : '';
   let blockId = typeof def?.blockId === 'string' && def.blockId.trim() ? def.blockId.trim() : '';
@@ -398,7 +419,19 @@ export async function upsertBlock(def) {
     order: def.order || existing?.order || now,
     createdAt: existing?.createdAt || now,
     updatedAt: now,
-    weeks: typeof def.weeks === 'number' ? def.weeks : existing?.weeks
+    weeks: typeof def.weeks === 'number' ? def.weeks : existing?.weeks,
+    startDate:
+      def.startDate !== undefined
+        ? normalizeDateInput(def.startDate)
+        : existing?.startDate
+          ? normalizeDateInput(existing.startDate)
+          : null,
+    endDate:
+      def.endDate !== undefined
+        ? normalizeDateInput(def.endDate)
+        : existing?.endDate
+          ? normalizeDateInput(existing.endDate)
+          : null
   };
   delete next.lectures;
   const writeStore = await store('blocks', 'readwrite');

--- a/js/ui/components/block-board.js
+++ b/js/ui/components/block-board.js
@@ -26,9 +26,29 @@ const PASS_COLORS = [
   'var(--green)',
   'var(--orange)',
   'var(--purple)',
-  'var(--teal)'
+  'var(--teal)',
+  'var(--yellow)',
+  'var(--rose)',
+  'var(--indigo)',
+  'var(--cyan)'
 ];
 const BOARD_DAYS = 14;
+
+const BLOCK_RANGE_FORMAT = new Intl.DateTimeFormat(undefined, {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric'
+});
+
+const PASS_DUE_FORMAT = new Intl.DateTimeFormat(undefined, {
+  month: 'short',
+  day: 'numeric'
+});
+
+const PASS_TIME_FORMAT = new Intl.DateTimeFormat(undefined, {
+  hour: 'numeric',
+  minute: '2-digit'
+});
 
 function ensureBoardState() {
   if (!state.blockBoard) {
@@ -55,10 +75,49 @@ function formatDay(timestamp) {
   return formatter.format(date);
 }
 
+function parseBlockDate(value) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date;
+}
+
+function formatBlockDate(value) {
+  const date = parseBlockDate(value);
+  if (!date) return null;
+  return BLOCK_RANGE_FORMAT.format(date);
+}
+
+function blockRangeLabel(block) {
+  const start = formatBlockDate(block?.startDate);
+  const end = formatBlockDate(block?.endDate);
+  if (start && end) return `${start} → ${end}`;
+  if (start) return `Starts ${start}`;
+  if (end) return `Ends ${end}`;
+  return null;
+}
+
+function blockSpanDays(block) {
+  const start = parseBlockDate(block?.startDate);
+  const end = parseBlockDate(block?.endDate);
+  if (!start || !end) return null;
+  const diff = end.getTime() - start.getTime();
+  if (diff < 0) return null;
+  return Math.round(diff / DAY_MS) + 1;
+}
+
 function formatDueTime(due) {
   if (!Number.isFinite(due)) return 'Unscheduled';
   const formatter = new Intl.DateTimeFormat(undefined, { hour: 'numeric', minute: '2-digit' });
   return formatter.format(new Date(due));
+}
+
+function formatPassDueLabel(due) {
+  if (!Number.isFinite(due)) return '';
+  const date = new Date(due);
+  const datePart = PASS_DUE_FORMAT.format(date);
+  const timePart = PASS_TIME_FORMAT.format(date);
+  return `${datePart} • ${timePart}`;
 }
 
 function collectBoardDays(now = Date.now()) {
@@ -71,6 +130,7 @@ function buildPassElement(entry, onComplete, onDelay) {
   const chip = document.createElement('div');
   chip.className = 'block-board-pass-chip';
   chip.style.setProperty('--chip-accent', passColor(entry?.pass?.order));
+  chip.dataset.passOrder = String(entry?.pass?.order ?? '');
   const title = document.createElement('div');
   title.className = 'block-board-pass-title';
   title.textContent = entry?.lecture?.name || `Lecture ${entry?.lecture?.id}`;
@@ -79,9 +139,14 @@ function buildPassElement(entry, onComplete, onDelay) {
   const meta = document.createElement('div');
   meta.className = 'block-board-pass-meta';
   const label = entry?.pass?.label || `Pass ${entry?.pass?.order ?? ''}`;
-  const action = entry?.pass?.action ? ` • ${entry.pass.action}` : '';
-  const dueLabel = formatDueTime(entry?.pass?.due);
-  meta.textContent = `${label}${action ? action : ''} • ${dueLabel}`;
+  const action = entry?.pass?.action ? entry.pass.action : '';
+  const dueLabel = Number.isFinite(entry?.pass?.due)
+    ? formatPassDueLabel(entry.pass.due)
+    : 'Unscheduled';
+  const parts = [label];
+  if (action) parts.push(action);
+  if (dueLabel) parts.push(dueLabel);
+  meta.textContent = parts.join(' • ');
   chip.appendChild(meta);
 
   const actions = document.createElement('div');
@@ -124,27 +189,54 @@ function applyPassDueUpdate(lecture, passOrder, newDue) {
   return { ...lecture, passes, status, nextDueAt };
 }
 
-function createDensityBar(dayCount, isToday) {
+function buildDensityGradient(byOrder, total) {
+  if (!total) return 'linear-gradient(to top, var(--accent) 0% 100%)';
+  const entries = Array.from(byOrder.entries())
+    .filter(([, count]) => Number.isFinite(count) && count > 0)
+    .sort(([a], [b]) => Number(a) - Number(b));
+  if (!entries.length) {
+    return 'linear-gradient(to top, var(--accent) 0% 100%)';
+  }
+  let traversed = 0;
+  const segments = entries.map(([order, count]) => {
+    const start = (traversed / total) * 100;
+    traversed += count;
+    const end = (traversed / total) * 100;
+    const color = passColor(order);
+    return `${color} ${start}% ${end}%`;
+  });
+  return `linear-gradient(to top, ${segments.join(', ')})`;
+}
+
+function createDensityBar(dayStat, isToday, maxTotal) {
   const bar = document.createElement('div');
   bar.className = 'block-board-density-bar';
   if (isToday) bar.classList.add('today');
-  bar.style.setProperty('--density-value', String(dayCount));
+  const total = Number(dayStat?.total ?? 0);
+  bar.style.setProperty('--density-value', String(total));
   const fill = document.createElement('div');
   fill.className = 'block-board-density-fill';
-  fill.style.height = `${Math.min(100, dayCount * 12)}%`;
+  const height = maxTotal > 0 ? Math.min(100, Math.round((total / maxTotal) * 100)) : 0;
+  fill.style.height = `${height}%`;
+  const gradient = buildDensityGradient(dayStat?.byOrder || new Map(), total);
+  fill.style.background = gradient;
   bar.appendChild(fill);
   return bar;
 }
 
-function createDensityLegend(day, count, isToday) {
+function createDensityLegend(dayStat, isToday, maxTotal) {
   const slot = document.createElement('div');
   slot.className = 'block-board-density-slot';
   if (isToday) slot.classList.add('today');
-  const bar = createDensityBar(count, isToday);
+  const bar = createDensityBar(dayStat, isToday, maxTotal);
+  if (Number.isFinite(dayStat?.day)) {
+    const displayDate = new Date(dayStat.day);
+    slot.title = displayDate.toLocaleDateString();
+  }
   slot.appendChild(bar);
   const label = document.createElement('div');
   label.className = 'block-board-density-label';
-  label.textContent = new Date(day).getDate();
+  label.textContent = new Date(dayStat.day).getDate();
   slot.appendChild(label);
   return slot;
 }
@@ -158,9 +250,28 @@ function createPassCard(entry, onDrag) {
   card.dataset.lectureId = entry?.lecture?.id ?? '';
   card.dataset.passOrder = entry?.pass?.order ?? '';
   card.dataset.passDue = Number.isFinite(entry?.pass?.due) ? String(entry.pass.due) : '';
-  const action = entry?.pass?.action ? ` • ${entry.pass.action}` : '';
-  card.innerHTML = `<div class="card-title">${entry?.lecture?.name || 'Lecture'}</div>`
-    + `<div class="card-meta">${(entry?.pass?.label || '')}${action}</div>`;
+  const title = document.createElement('div');
+  title.className = 'card-title';
+  title.textContent = entry?.lecture?.name || 'Lecture';
+  card.appendChild(title);
+
+  const meta = document.createElement('div');
+  meta.className = 'card-meta';
+  const metaParts = [];
+  if (entry?.pass?.label) metaParts.push(entry.pass.label);
+  else if (entry?.pass?.order != null) metaParts.push(`Pass ${entry.pass.order}`);
+  if (entry?.pass?.action) metaParts.push(entry.pass.action);
+  meta.textContent = metaParts.length ? metaParts.join(' • ') : 'Pass';
+  card.appendChild(meta);
+
+  const due = document.createElement('div');
+  due.className = 'card-due';
+  const dueText = Number.isFinite(entry?.pass?.due)
+    ? formatPassDueLabel(entry.pass.due)
+    : 'Unscheduled';
+  due.textContent = dueText;
+  card.appendChild(due);
+
   card.addEventListener('dragstart', (event) => {
     if (!event.dataTransfer) return;
     const payload = {
@@ -207,42 +318,57 @@ async function updateLectureSchedule(lecture, updateFn) {
 
 function renderUrgentQueues(root, queues, handlers) {
   const wrapper = document.createElement('section');
-  wrapper.className = 'block-board-urgent';
+  wrapper.className = 'block-board-summary';
   const config = [
-    { key: 'overdue', label: 'Overdue' },
-    { key: 'today', label: 'Today' },
-    { key: 'tomorrow', label: 'Tomorrow' }
+    { key: 'today', label: "Today's To-Do", empty: 'Nothing due today.', accent: 'var(--blue)' },
+    { key: 'tomorrow', label: 'Due Tomorrow', empty: 'Nothing due tomorrow.', accent: 'var(--yellow)' },
+    { key: 'overdue', label: 'Overdue', empty: 'No overdue passes. 🎉', accent: 'var(--rose)' }
   ];
-  config.forEach(({ key, label }) => {
-    const group = document.createElement('div');
-    group.className = 'block-board-urgent-group';
+  config.forEach(({ key, label, empty, accent }) => {
+    const card = document.createElement('article');
+    card.className = 'block-board-summary-card';
+    if (accent) card.style.setProperty('--summary-accent', accent);
+
     const header = document.createElement('div');
-    header.className = 'block-board-urgent-header';
-    header.textContent = label;
-    const pushAll = document.createElement('button');
-    pushAll.type = 'button';
-    pushAll.className = 'btn tertiary';
-    pushAll.textContent = 'Push all +1 day';
-    pushAll.addEventListener('click', () => handlers.onPushAll(key));
-    header.appendChild(pushAll);
-    group.appendChild(header);
+    header.className = 'block-board-summary-header';
+
+    const title = document.createElement('h3');
+    title.className = 'block-board-summary-title';
+    title.textContent = label;
+    header.appendChild(title);
+
+    const entries = queues[key] || [];
+    const count = document.createElement('span');
+    count.className = 'block-board-summary-count';
+    count.textContent = String(entries.length);
+    header.appendChild(count);
+
+    if (entries.length) {
+      const pushAll = document.createElement('button');
+      pushAll.type = 'button';
+      pushAll.className = 'btn tertiary block-board-summary-action';
+      pushAll.textContent = 'Push to tomorrow';
+      pushAll.addEventListener('click', () => handlers.onPushAll(key));
+      header.appendChild(pushAll);
+    }
+
+    card.appendChild(header);
 
     const list = document.createElement('div');
-    list.className = 'block-board-urgent-list';
-    const entries = queues[key] || [];
+    list.className = 'block-board-summary-list';
     if (!entries.length) {
-      const empty = document.createElement('div');
-      empty.className = 'block-board-empty';
-      empty.textContent = 'Nothing queued.';
-      list.appendChild(empty);
+      const emptyState = document.createElement('div');
+      emptyState.className = 'block-board-summary-empty';
+      emptyState.textContent = empty || 'Nothing queued.';
+      list.appendChild(emptyState);
     } else {
       entries.forEach(entry => {
         const chip = buildPassElement(entry, handlers.onComplete, handlers.onDelay);
         list.appendChild(chip);
       });
     }
-    group.appendChild(list);
-    wrapper.appendChild(group);
+    card.appendChild(list);
+    wrapper.appendChild(card);
   });
   root.appendChild(wrapper);
 }
@@ -294,19 +420,48 @@ function renderBlockBoardBlock(container, block, blockLectures, days, refresh) {
   const wrapper = document.createElement('section');
   wrapper.className = 'block-board-block';
   wrapper.dataset.blockId = String(block?.blockId ?? '');
+  if (block?.color) {
+    wrapper.style.setProperty('--block-accent', block.color);
+    wrapper.classList.add('has-accent');
+  }
 
   const header = document.createElement('div');
   header.className = 'block-board-block-header';
+  const heading = document.createElement('div');
+  heading.className = 'block-board-block-heading';
   const title = document.createElement('h2');
+  title.className = 'block-board-block-title';
   title.textContent = block?.title || block?.name || `Block ${block?.blockId}`;
-  header.appendChild(title);
+  if (block?.color) {
+    title.style.setProperty('--block-accent', block.color);
+    title.classList.add('has-accent');
+  }
+  heading.appendChild(title);
+
+  const metaParts = [];
+  const rangeText = blockRangeLabel(block);
+  if (rangeText) metaParts.push(rangeText);
+  const weekValue = Number(block?.weeks);
+  if (Number.isFinite(weekValue) && weekValue > 0) {
+    const weeks = Math.round(weekValue);
+    metaParts.push(`${weeks} week${weeks === 1 ? '' : 's'}`);
+  }
+  const span = blockSpanDays(block);
+  if (span) metaParts.push(`${span} day${span === 1 ? '' : 's'}`);
+  if (metaParts.length) {
+    const meta = document.createElement('div');
+    meta.className = 'block-board-block-meta';
+    meta.textContent = metaParts.join(' • ');
+    heading.appendChild(meta);
+  }
+  header.appendChild(heading);
   const controls = document.createElement('div');
   controls.className = 'block-board-block-controls';
   const collapseBtn = document.createElement('button');
   collapseBtn.type = 'button';
   collapseBtn.className = 'btn secondary';
   const isCollapsed = boardState.collapsedBlocks.includes(String(block?.blockId));
-  collapseBtn.textContent = isCollapsed ? 'Expand' : 'Collapse';
+  collapseBtn.textContent = isCollapsed ? 'Expand' : 'Minimize';
   collapseBtn.addEventListener('click', () => {
     const current = ensureBoardState();
     const nextCollapsed = new Set(current.collapsedBlocks.map(String));
@@ -322,7 +477,7 @@ function renderBlockBoardBlock(container, block, blockLectures, days, refresh) {
   const densityBtn = document.createElement('button');
   densityBtn.type = 'button';
   densityBtn.className = 'btn secondary';
-  densityBtn.textContent = boardState.showDensity ? 'Hide density' : 'Show density';
+  densityBtn.textContent = boardState.showDensity ? 'Hide timeline' : 'Show timeline';
   densityBtn.addEventListener('click', () => {
     setBlockBoardState({ showDensity: !ensureBoardState().showDensity });
     refresh();
@@ -331,29 +486,46 @@ function renderBlockBoardBlock(container, block, blockLectures, days, refresh) {
   header.appendChild(controls);
   wrapper.appendChild(header);
 
+  const assignments = buildDayAssignments(blockLectures, days);
+
   if (boardState.showDensity) {
+    const dayStats = days.map(day => {
+      const entries = assignments.get(day) || [];
+      const breakdown = new Map();
+      entries.forEach(entry => {
+        const order = Number(entry?.pass?.order);
+        if (!Number.isFinite(order)) return;
+        breakdown.set(order, (breakdown.get(order) || 0) + 1);
+      });
+      return { day, total: entries.length, byOrder: breakdown };
+    });
+    const maxTotal = dayStats.reduce((max, stat) => Math.max(max, stat.total), 0);
+    const timeline = document.createElement('div');
+    timeline.className = 'block-board-timeline';
+
+    const timelineHeader = document.createElement('div');
+    timelineHeader.className = 'block-board-timeline-header';
+    const timelineTitle = document.createElement('h3');
+    timelineTitle.className = 'block-board-timeline-title';
+    timelineTitle.textContent = `Block Timeline — ${block?.title || block?.name || 'Block'}`;
+    timelineHeader.appendChild(timelineTitle);
+
+    const spanCount = blockSpanDays(block) || days.length;
+    const spanLabel = document.createElement('span');
+    spanLabel.className = 'block-board-timeline-span';
+    spanLabel.textContent = `${spanCount} day${spanCount === 1 ? '' : 's'}`;
+    timelineHeader.appendChild(spanLabel);
+
+    timeline.appendChild(timelineHeader);
+
     const density = document.createElement('div');
     density.className = 'block-board-density';
-    const counts = days.map(day => {
-      const start = day;
-      const end = day + DAY_MS;
-      let total = 0;
-      blockLectures.forEach(lecture => {
-        const passes = Array.isArray(lecture?.passes) ? lecture.passes : [];
-        passes.forEach(pass => {
-          if (Number.isFinite(pass?.completedAt)) return;
-          if (!Number.isFinite(pass?.due)) return;
-          if (pass.due >= start && pass.due < end) total += 1;
-        });
-      });
-      return total;
-    });
-    counts.forEach((count, idx) => {
-      const day = days[idx];
-      const slot = createDensityLegend(day, count, startOfDay(Date.now()) === day);
+    dayStats.forEach(stat => {
+      const slot = createDensityLegend(stat, startOfDay(Date.now()) === stat.day, Math.max(1, maxTotal));
       density.appendChild(slot);
     });
-    wrapper.appendChild(density);
+    timeline.appendChild(density);
+    wrapper.appendChild(timeline);
   }
 
   if (isCollapsed) {
@@ -361,7 +533,6 @@ function renderBlockBoardBlock(container, block, blockLectures, days, refresh) {
     return;
   }
 
-  const assignments = buildDayAssignments(blockLectures, days);
   const board = document.createElement('div');
   board.className = 'block-board-grid';
 

--- a/style.css
+++ b/style.css
@@ -17,6 +17,14 @@
   --gray: #94a3b8;
   --accent: #38bdf8;
   --accent-soft: rgba(56, 189, 248, 0.15);
+  --orange: #fb923c;
+  --teal: #14b8a6;
+  --rose: #f472b6;
+  --indigo: #6366f1;
+  --cyan: #22d3ee;
+  --surface-1: rgba(12, 18, 32, 0.75);
+  --surface-2: rgba(14, 21, 35, 0.82);
+  --surface-3: rgba(148, 163, 184, 0.24);
   --radius: 14px;
   --radius-lg: 20px;
   --radius-sm: 8px;
@@ -5913,3 +5921,556 @@ body.map-toolbox-dragging {
 .block-board-pass-card { border-radius: 12px; border: 1px solid color-mix(in srgb, var(--card-accent) 45%, transparent); padding: 0.75rem; background: color-mix(in srgb, var(--card-accent) 12%, var(--surface-1)); display: flex; flex-direction: column; gap: 0.35rem; cursor: grab; }
 .block-board-pass-card .card-title { font-weight: 600; }
 .block-board-pass-card .card-meta { font-size: 0.8rem; opacity: 0.75; }
+
+/* --- Refined block board styling --- */
+.block-board-container { gap: 2.5rem; }
+
+.block-board-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+
+.block-board-summary-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.2rem 1.4rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.88), rgba(15, 23, 42, 0.72));
+  box-shadow: 0 22px 50px rgba(2, 6, 23, 0.45);
+}
+
+.block-board-summary-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid color-mix(in srgb, var(--summary-accent, var(--accent)) 35%, transparent);
+  pointer-events: none;
+}
+
+.block-board-summary-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.block-board-summary-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+  flex: 1;
+}
+
+.block-board-summary-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  background: color-mix(in srgb, var(--summary-accent, var(--accent)) 24%, rgba(255, 255, 255, 0.08));
+  color: var(--text);
+}
+
+.block-board-summary-action {
+  margin-left: auto;
+  font-size: 0.75rem;
+  padding: 0.35rem 0.7rem;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--summary-accent, var(--accent)) 18%, rgba(148, 163, 184, 0.12));
+  border-color: color-mix(in srgb, var(--summary-accent, var(--accent)) 32%, transparent);
+}
+
+.block-board-summary-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.block-board-summary-empty {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.block-board-pass-chip {
+  background: color-mix(in srgb, var(--chip-accent) 14%, rgba(12, 18, 32, 0.85));
+  border: 1px solid color-mix(in srgb, var(--chip-accent) 45%, transparent);
+  border-radius: 16px;
+  padding: 0.85rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  box-shadow: 0 18px 42px rgba(2, 6, 23, 0.38);
+}
+
+.block-board-pass-title {
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.block-board-pass-meta {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.block-board-pass-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.block-board-pass-actions .btn {
+  font-size: 0.75rem;
+  padding: 0.35rem 0.65rem;
+}
+
+.block-board-block {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  background: linear-gradient(170deg, rgba(11, 16, 28, 0.92), rgba(15, 22, 37, 0.78));
+  box-shadow: 0 28px 60px rgba(2, 6, 23, 0.5);
+}
+
+.block-board-block.has-accent {
+  border-color: color-mix(in srgb, var(--block-accent) 32%, var(--border));
+  box-shadow: 0 34px 70px color-mix(in srgb, var(--block-accent) 18%, transparent);
+}
+
+.block-board-block-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 1.5rem;
+  justify-content: space-between;
+}
+
+.block-board-block-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.block-board-block-title {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.block-board-block-title.has-accent {
+  color: var(--block-accent);
+}
+
+.block-board-block-meta {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.block-board-block-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.block-board-block-controls .btn {
+  font-size: 0.8rem;
+  padding: 0.45rem 0.85rem;
+}
+
+.block-board-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.1rem 1.3rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  background: linear-gradient(160deg, rgba(10, 15, 28, 0.9), rgba(12, 20, 36, 0.72));
+}
+
+.block-board-timeline-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.block-board-timeline-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.block-board-timeline-span {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.block-board-density {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(26px, 1fr));
+  gap: 0.55rem;
+  align-items: end;
+}
+
+.block-board-density-slot {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.block-board-density-slot.today {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.block-board-density-bar {
+  width: 100%;
+  height: 120px;
+  border-radius: 12px;
+  background: var(--surface-1);
+  overflow: hidden;
+  display: flex;
+  align-items: flex-end;
+}
+
+.block-board-density-fill {
+  width: 100%;
+  border-radius: 12px;
+  background: var(--accent);
+  transition: height 0.2s ease;
+}
+
+.block-board-density-label {
+  font-size: 0.75rem;
+}
+
+.block-board-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.block-board-grid {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(240px, 1fr);
+  gap: 1.25rem;
+  overflow-x: auto;
+  padding-bottom: 0.75rem;
+}
+
+.block-board-day-column,
+.block-board-unscheduled {
+  display: flex;
+  flex-direction: column;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  min-height: 280px;
+  backdrop-filter: blur(12px);
+}
+
+.block-board-day-column.today {
+  border-color: color-mix(in srgb, var(--accent) 48%, var(--border));
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+.block-board-day-header {
+  padding: 1rem;
+  border-bottom: 1px solid var(--surface-3);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.block-board-day-list {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  overflow-y: auto;
+}
+
+.block-board-pass-card {
+  border-radius: var(--radius);
+  border: 1px solid color-mix(in srgb, var(--card-accent) 40%, transparent);
+  background: color-mix(in srgb, var(--card-accent) 12%, rgba(10, 16, 28, 0.88));
+  padding: 0.85rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  box-shadow: 0 24px 44px rgba(2, 6, 23, 0.45);
+}
+
+.block-board-pass-card .card-title {
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.block-board-pass-card .card-meta,
+.block-board-pass-card .card-due {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.block-board-pass-card:active {
+  cursor: grabbing;
+}
+
+.block-board-day-column.dropping {
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.block-board-pass-card + .block-board-pass-card {
+  margin-top: 0.25rem;
+}
+
+/* --- Settings block details --- */
+.settings-block-row {
+  background: linear-gradient(170deg, rgba(14, 22, 36, 0.92), rgba(11, 17, 30, 0.82));
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  box-shadow: 0 26px 60px rgba(2, 6, 23, 0.45);
+  gap: 1.25rem;
+}
+
+.settings-block-row.has-accent {
+  border-color: color-mix(in srgb, var(--block-accent) 32%, var(--border));
+  box-shadow: 0 32px 70px color-mix(in srgb, var(--block-accent) 22%, transparent);
+}
+
+.settings-block-header {
+  align-items: center;
+}
+
+.settings-block-title {
+  font-size: 1.2rem;
+}
+
+.settings-block-controls {
+  margin-left: auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.settings-block-controls .btn {
+  font-size: 0.8rem;
+  padding: 0.45rem 0.85rem;
+}
+
+.settings-block-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.75rem;
+}
+
+.settings-block-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: var(--radius);
+  background: rgba(148, 163, 184, 0.12);
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.settings-block-detail strong {
+  color: var(--text);
+  font-size: 0.95rem;
+}
+
+.settings-block-edit,
+.settings-block-add {
+  gap: 0.75rem;
+}
+
+.settings-block-edit .input,
+.settings-block-add .input {
+  flex: 1 1 180px;
+}
+
+/* --- Lecture table refresh --- */
+.lectures-table th {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.lecture-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.lecture-cell-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.lecture-block {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: color-mix(in srgb, var(--block-accent, var(--accent)) 16%, rgba(148, 163, 184, 0.12));
+  color: var(--text);
+}
+
+.lecture-block.has-accent {
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--block-accent) 40%, transparent);
+}
+
+.lecture-name {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.lecture-position {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.lecture-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.lecture-tag {
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.12);
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.lecture-schedule {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  color: var(--text-muted);
+}
+
+.lecture-week {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.lecture-status-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.lecture-status-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.14);
+  font-size: 0.75rem;
+  text-transform: capitalize;
+}
+
+.lecture-status-pill[data-status='completed'] {
+  background: color-mix(in srgb, var(--green) 25%, transparent);
+}
+
+.lecture-status-pill[data-status='overdue'] {
+  background: color-mix(in srgb, var(--rose) 30%, transparent);
+}
+
+.lecture-next-due {
+  font-size: 0.8rem;
+}
+
+.lecture-passes {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.lecture-pass-summary {
+  font-weight: 500;
+}
+
+.lecture-pass-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.lecture-pass-plan {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.lecture-pass-chip {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  min-width: 160px;
+  padding: 0.8rem 0.9rem;
+  border-radius: 14px;
+  border: 1px solid color-mix(in srgb, var(--chip-accent) 45%, transparent);
+  background: color-mix(in srgb, var(--chip-accent) 12%, rgba(12, 18, 32, 0.82));
+  box-shadow: 0 18px 40px rgba(2, 6, 23, 0.35);
+}
+
+.lecture-pass-chip-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.lecture-pass-chip-order {
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--chip-accent) 28%, rgba(148, 163, 184, 0.12));
+  font-size: 0.75rem;
+}
+
+.lecture-pass-chip-label {
+  font-size: 0.9rem;
+}
+
+.lecture-pass-chip-meta {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.lecture-pass-chip.is-complete {
+  opacity: 0.72;
+}
+
+.lecture-pass-chip.is-overdue {
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--chip-accent) 45%, transparent);
+}
+
+.lecture-pass-empty {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  font-style: italic;
+}

--- a/test/ui.block-board.test.js
+++ b/test/ui.block-board.test.js
@@ -59,7 +59,7 @@ describe('block board rendering', () => {
     const data = sampleData();
     const { saveLectureMock } = setupBoardDeps(data);
     await renderBlockBoard(container, () => {});
-    const urgentHeaders = container.querySelectorAll('.block-board-urgent-header');
+    const urgentHeaders = container.querySelectorAll('.block-board-summary-header');
     assert.equal(urgentHeaders.length, 3);
     const markBtn = Array.from(container.querySelectorAll('.block-board-pass-actions button')).find(btn => btn.textContent?.includes('Mark done'));
     assert(markBtn);
@@ -73,7 +73,7 @@ describe('block board rendering', () => {
     await renderBlockBoard(container, () => {});
     assert.equal(saveLectureMock.mock.callCount(), 2);
 
-    const pushAllBtn = Array.from(container.querySelectorAll('.block-board-urgent-header .btn.tertiary')).find(btn => btn.textContent?.includes('Push all'));
+    const pushAllBtn = Array.from(container.querySelectorAll('.block-board-summary-header .btn.tertiary')).find(btn => btn.textContent?.toLowerCase().includes('push'));
     assert(pushAllBtn);
     pushAllBtn.click();
     await renderBlockBoard(container, () => {});
@@ -84,13 +84,13 @@ describe('block board rendering', () => {
     const data = sampleData();
     setupBoardDeps(data);
     await renderBlockBoard(container, () => {});
-    const densityBtn = Array.from(container.querySelectorAll('.block-board-block-controls .btn.secondary')).find(btn => btn.textContent?.toLowerCase().includes('density'));
+    const densityBtn = Array.from(container.querySelectorAll('.block-board-block-controls .btn.secondary')).find(btn => btn.textContent?.toLowerCase().includes('timeline'));
     assert(densityBtn);
     densityBtn.click();
     await renderBlockBoard(container, () => {});
     assert.equal(state.blockBoard.showDensity, false);
 
-    const collapseBtn = Array.from(container.querySelectorAll('.block-board-block-controls .btn.secondary')).find(btn => btn.textContent?.toLowerCase().includes('collapse'));
+    const collapseBtn = Array.from(container.querySelectorAll('.block-board-block-controls .btn.secondary')).find(btn => btn.textContent?.toLowerCase().includes('minimize'));
     assert(collapseBtn);
     collapseBtn.click();
     await renderBlockBoard(container, () => {});


### PR DESCRIPTION
## Summary
- add block start and end date persistence and expose them in refreshed settings forms
- redesign the block board with summary cards, timeline visualization, and color-coded pass cards
- restyle the lecture list with per-pass chips and updated schedule details plus supporting CSS updates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf9caa4c488322929b3c832589377a