### PR TITLE
Revamp lectures pass layout and interactions

### DIFF
--- a/js/ui/components/lectures.js
+++ b/js/ui/components/lectures.js
@@ -140,6 +140,21 @@ function formatPassDueTimestamp(due) {
   return `${PASS_DUE_FORMAT.format(date)} • ${PASS_TIME_FORMAT.format(date)}`;
 }
 
+function describePassCountdown(due, now = Date.now()) {
+  if (!Number.isFinite(due)) return 'Unscheduled';
+  const diffMs = due - now;
+  const dayMs = 24 * 60 * 60 * 1000;
+  if (Math.abs(diffMs) < dayMs) {
+    return diffMs >= 0 ? 'Due today' : 'Overdue today';
+  }
+  if (diffMs > 0) {
+    const days = Math.ceil(diffMs / dayMs);
+    return days === 1 ? 'In 1 day' : `In ${days} days`;
+  }
+  const overdueDays = Math.ceil(Math.abs(diffMs) / dayMs);
+  return overdueDays === 1 ? '1 day overdue' : `${overdueDays} days overdue`;
+}
+
 function buildPassDisplayList(lecture) {
   const scheduleList = Array.isArray(lecture?.passPlan?.schedule)
     ? lecture.passPlan.schedule
@@ -178,7 +193,9 @@ function buildPassDisplayList(lecture) {
         label: schedule.label || pass.label || `Pass ${order}`,
         action: schedule.action || pass.action || '',
         due: Number.isFinite(pass?.due) ? pass.due : null,
-        completedAt: Number.isFinite(pass?.completedAt) ? pass.completedAt : null
+        completedAt: Number.isFinite(pass?.completedAt) ? pass.completedAt : null,
+        offsetMinutes: Number.isFinite(schedule?.offsetMinutes) ? schedule.offsetMinutes : null,
+        anchor: schedule.anchor || pass.anchor || null
       };
     });
 }
@@ -188,6 +205,8 @@ function createPassChipDisplay(info, now = Date.now()) {
   chip.className = 'lecture-pass-chip';
   chip.style.setProperty('--chip-accent', passAccent(info?.order));
   chip.dataset.passOrder = String(info?.order ?? '');
+  chip.setAttribute('role', 'button');
+  chip.tabIndex = 0;
   if (Number.isFinite(info?.completedAt)) chip.classList.add('is-complete');
   if (!Number.isFinite(info?.completedAt) && Number.isFinite(info?.due) && info.due < now) {
     chip.classList.add('is-overdue');
@@ -205,18 +224,22 @@ function createPassChipDisplay(info, now = Date.now()) {
   header.appendChild(label);
   chip.appendChild(header);
 
-  const meta = document.createElement('div');
-  meta.className = 'lecture-pass-chip-meta';
-  let metaText = '';
-  if (Number.isFinite(info?.completedAt)) {
-    metaText = 'Completed';
-  } else if (Number.isFinite(info?.due)) {
-    metaText = formatPassDueTimestamp(info.due);
-  } else {
-    metaText = 'Unscheduled';
-  }
-  meta.textContent = metaText;
-  chip.appendChild(meta);
+  const functionLine = document.createElement('div');
+  functionLine.className = 'lecture-pass-chip-function';
+  functionLine.textContent = info?.action || info?.label || '';
+  chip.appendChild(functionLine);
+
+  const timing = document.createElement('div');
+  timing.className = 'lecture-pass-chip-due';
+  timing.textContent = Number.isFinite(info?.due)
+    ? formatPassDueTimestamp(info.due)
+    : 'No scheduled date';
+  chip.appendChild(timing);
+
+  const countdown = document.createElement('div');
+  countdown.className = 'lecture-pass-chip-countdown';
+  countdown.textContent = describePassCountdown(info?.due, now);
+  chip.appendChild(countdown);
   return chip;
 }
 
@@ -514,7 +537,7 @@ function getLectureState(lecture, stats) {
   return 'pending';
 }
 
-function renderLectureWeekRow(lecture, onEdit, onDelete, now = Date.now()) {
+function renderLectureWeekRow(lecture, onEdit, onDelete, onEditPass, now = Date.now()) {
   const row = document.createElement('tr');
   row.dataset.lectureRow = 'true';
   row.dataset.lectureId = String(lecture.id);
@@ -562,27 +585,48 @@ function renderLectureWeekRow(lecture, onEdit, onDelete, now = Date.now()) {
     overviewCell.appendChild(tagList);
   }
 
-  const summary = document.createElement('div');
-  summary.className = 'lecture-overview-summary';
-  summary.textContent = formatPassSummary(lecture);
-  overviewCell.appendChild(summary);
+  const metrics = document.createElement('div');
+  metrics.className = 'lecture-overview-metrics';
+
+  const completedMetric = document.createElement('span');
+  completedMetric.className = 'lecture-metric lecture-metric-complete';
+  completedMetric.textContent = `${stats.completed} complete`;
+  metrics.appendChild(completedMetric);
+
+  const remainingMetric = document.createElement('span');
+  remainingMetric.className = 'lecture-metric lecture-metric-remaining';
+  remainingMetric.textContent = `${stats.remaining} remaining`;
+  metrics.appendChild(remainingMetric);
+
+  overviewCell.appendChild(metrics);
 
   row.appendChild(overviewCell);
 
-  const plannedCell = document.createElement('td');
-  plannedCell.className = 'lecture-count-cell';
-  plannedCell.textContent = String(stats.planned);
-  row.appendChild(plannedCell);
-
-  const completedCell = document.createElement('td');
-  completedCell.className = 'lecture-count-cell';
-  completedCell.textContent = String(stats.completed);
-  row.appendChild(completedCell);
-
-  const remainingCell = document.createElement('td');
-  remainingCell.className = 'lecture-count-cell';
-  remainingCell.textContent = String(stats.remaining);
-  row.appendChild(remainingCell);
+  const passesCell = document.createElement('td');
+  passesCell.className = 'lecture-passes-cell';
+  const passScroller = document.createElement('div');
+  passScroller.className = 'lecture-pass-scroller';
+  const passList = buildPassDisplayList(lecture);
+  if (!passList.length) {
+    const empty = document.createElement('div');
+    empty.className = 'lecture-pass-empty';
+    empty.textContent = 'No passes planned';
+    passScroller.appendChild(empty);
+  } else {
+    passList.forEach(info => {
+      const chip = createPassChipDisplay(info, now);
+      chip.addEventListener('click', () => onEditPass(lecture, info));
+      chip.addEventListener('keydown', event => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onEditPass(lecture, info);
+        }
+      });
+      passScroller.appendChild(chip);
+    });
+  }
+  passesCell.appendChild(passScroller);
+  row.appendChild(passesCell);
 
   const nextDueCell = document.createElement('td');
   nextDueCell.className = 'lecture-next-cell';
@@ -613,7 +657,7 @@ function renderLectureWeekRow(lecture, onEdit, onDelete, now = Date.now()) {
   return row;
 }
 
-function renderLectureTable(blocks, lectures, filters, onEdit, onDelete) {
+function renderLectureTable(blocks, lectures, filters, onEdit, onDelete, onEditPass) {
   const card = document.createElement('section');
   card.className = 'card lectures-card';
 
@@ -752,9 +796,15 @@ function renderLectureTable(blocks, lectures, filters, onEdit, onDelete) {
 
       const thead = document.createElement('thead');
       const headerRow = document.createElement('tr');
-      ['Lecture', 'Planned passes', 'Completed', 'Remaining', 'Next due', 'Actions'].forEach(label => {
+      [
+        { label: 'Lecture', className: 'lectures-col-lecture' },
+        { label: 'Passes', className: 'lectures-col-passes' },
+        { label: 'Next due', className: 'lectures-col-next' },
+        { label: 'Actions', className: 'lectures-col-actions' }
+      ].forEach(column => {
         const th = document.createElement('th');
-        th.textContent = label;
+        th.textContent = column.label;
+        if (column.className) th.classList.add(column.className);
         headerRow.appendChild(th);
       });
       thead.appendChild(headerRow);
@@ -762,7 +812,7 @@ function renderLectureTable(blocks, lectures, filters, onEdit, onDelete) {
 
       const tbody = document.createElement('tbody');
       sortLecturesForDisplay(weekLectures).forEach(entry => {
-        const row = renderLectureWeekRow(entry, onEdit, onDelete, now);
+        const row = renderLectureWeekRow(entry, onEdit, onDelete, onEditPass, now);
         tbody.appendChild(row);
       });
       table.appendChild(tbody);
@@ -1360,6 +1410,434 @@ function handleDelete(lecture, redraw) {
   })();
 }
 
+function passScopeModal(mode) {
+  return new Promise(resolve => {
+    const overlay = document.createElement('div');
+    overlay.className = 'modal lecture-pass-scope-modal';
+
+    const card = document.createElement('div');
+    card.className = 'card lecture-pass-scope-card';
+
+    const title = document.createElement('h3');
+    title.textContent = mode === 'push'
+      ? 'Push pass timing'
+      : 'Pull pass timing';
+    card.appendChild(title);
+
+    const message = document.createElement('p');
+    message.textContent = mode === 'push'
+      ? 'Choose how far the push should ripple.'
+      : 'Choose how far the pull should ripple.';
+    card.appendChild(message);
+
+    const buttons = document.createElement('div');
+    buttons.className = 'row lecture-pass-scope-buttons';
+
+    const single = document.createElement('button');
+    single.className = 'btn secondary';
+    single.textContent = 'Only this pass';
+    single.addEventListener('click', () => {
+      cleanup('single');
+    });
+
+    const cascade = document.createElement('button');
+    cascade.className = 'btn';
+    cascade.textContent = mode === 'push' ? 'This & following' : 'This & preceding';
+    cascade.addEventListener('click', () => {
+      cleanup(mode === 'push' ? 'chain-after' : 'chain-before');
+    });
+
+    const cancel = document.createElement('button');
+    cancel.className = 'btn secondary';
+    cancel.textContent = 'Cancel';
+    cancel.addEventListener('click', () => {
+      cleanup(null);
+    });
+
+    buttons.appendChild(single);
+    buttons.appendChild(cascade);
+    buttons.appendChild(cancel);
+    card.appendChild(buttons);
+
+    overlay.appendChild(card);
+
+    function cleanup(result) {
+      if (document.body.contains(overlay)) {
+        document.body.removeChild(overlay);
+      }
+      resolve(result);
+    }
+
+    overlay.addEventListener('click', event => {
+      if (event.target === overlay) {
+        cleanup(null);
+      }
+    });
+
+    document.body.appendChild(overlay);
+    single.focus();
+  });
+}
+
+function clampOffsetMinutes(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return 0;
+  return Math.max(0, Math.round(numeric));
+}
+
+function cloneLecturePasses(lecture) {
+  return Array.isArray(lecture?.passes)
+    ? lecture.passes.map(pass => ({ ...pass }))
+    : [];
+}
+
+function normalizeSchedule(plan) {
+  return Array.isArray(plan?.schedule)
+    ? plan.schedule.map(step => ({ ...step }))
+    : [];
+}
+
+async function updatePassFunction(lecture, order, action, redraw) {
+  if (!lecture || lecture.blockId == null || lecture.id == null) return;
+  const plan = clonePassPlan(lecture.passPlan || {});
+  const schedule = normalizeSchedule(plan);
+  const step = schedule.find(entry => Number(entry?.order) === Number(order));
+  if (!step) return;
+  step.action = action;
+  const passes = cloneLecturePasses(lecture);
+  const pass = passes.find(entry => Number(entry?.order) === Number(order));
+  if (pass) {
+    pass.action = action;
+  }
+  plan.schedule = schedule;
+  await saveLecture({
+    blockId: lecture.blockId,
+    id: lecture.id,
+    passPlan: plan,
+    passes
+  });
+  await invalidateBlockCatalog();
+  await redraw();
+}
+
+async function shiftPassTiming(lecture, order, deltaMinutes, scope, redraw) {
+  if (!lecture || lecture.blockId == null || lecture.id == null) return;
+  if (!Number.isFinite(deltaMinutes) || deltaMinutes === 0) return;
+  const plan = clonePassPlan(lecture.passPlan || {});
+  const schedule = normalizeSchedule(plan);
+  if (!schedule.length) return;
+
+  const targetOrder = Number(order);
+  if (!Number.isFinite(targetOrder)) return;
+
+  const affectedOrders = new Set();
+  schedule.forEach(step => {
+    const currentOrder = Number(step?.order);
+    if (!Number.isFinite(currentOrder)) return;
+    if (scope === 'chain-after' && currentOrder >= targetOrder) {
+      affectedOrders.add(currentOrder);
+    } else if (scope === 'chain-before' && currentOrder <= targetOrder) {
+      affectedOrders.add(currentOrder);
+    } else if (!scope || scope === 'single') {
+      if (currentOrder === targetOrder) affectedOrders.add(currentOrder);
+    }
+  });
+  if (!affectedOrders.size) affectedOrders.add(targetOrder);
+
+  schedule.forEach(step => {
+    const currentOrder = Number(step?.order);
+    if (!Number.isFinite(currentOrder)) return;
+    const offset = clampOffsetMinutes(step.offsetMinutes);
+    if (affectedOrders.has(currentOrder)) {
+      step.offsetMinutes = Math.max(0, offset + deltaMinutes);
+    } else {
+      step.offsetMinutes = offset;
+    }
+  });
+
+  const minuteMs = 60 * 1000;
+  const passMap = new Map();
+  cloneLecturePasses(lecture).forEach(pass => {
+    const orderKey = Number(pass?.order);
+    if (Number.isFinite(orderKey) && !passMap.has(orderKey)) {
+      passMap.set(orderKey, { ...pass });
+    }
+  });
+
+  affectedOrders.forEach(orderKey => {
+    const pass = passMap.get(orderKey);
+    if (pass && Number.isFinite(pass.due)) {
+      const nextDue = Math.max(0, Math.round(pass.due + deltaMinutes * minuteMs));
+      pass.due = nextDue;
+      passMap.set(orderKey, pass);
+    }
+  });
+
+  const decorated = schedule.map((step, index) => ({
+    ...step,
+    originalOrder: Number(step?.order) || index + 1,
+    offsetMinutes: clampOffsetMinutes(step.offsetMinutes)
+  }));
+
+  decorated.sort((a, b) => {
+    if (a.offsetMinutes !== b.offsetMinutes) return a.offsetMinutes - b.offsetMinutes;
+    return a.originalOrder - b.originalOrder;
+  });
+
+  const newSchedule = [];
+  const reassignedPasses = [];
+  decorated.forEach((entry, index) => {
+    const newOrder = index + 1;
+    const base = { ...entry };
+    delete base.originalOrder;
+    base.order = newOrder;
+    newSchedule.push(base);
+    const pass = passMap.get(entry.originalOrder);
+    if (pass) {
+      pass.order = newOrder;
+      reassignedPasses.push(pass);
+      passMap.delete(entry.originalOrder);
+    }
+  });
+
+  passMap.forEach(pass => {
+    reassignedPasses.push(pass);
+  });
+
+  reassignedPasses.sort((a, b) => {
+    const ao = Number(a?.order) || 0;
+    const bo = Number(b?.order) || 0;
+    return ao - bo;
+  });
+
+  plan.schedule = newSchedule;
+
+  await saveLecture({
+    blockId: lecture.blockId,
+    id: lecture.id,
+    passPlan: plan,
+    passes: reassignedPasses
+  });
+  await invalidateBlockCatalog();
+  await redraw();
+}
+
+function openPassEditDialog({ lecture, passInfo, onUpdateAction, onShift }) {
+  const overlay = document.createElement('div');
+  overlay.className = 'modal lecture-pass-modal';
+
+  const card = document.createElement('div');
+  card.className = 'card lecture-pass-card';
+
+  const title = document.createElement('h2');
+  const passLabel = passInfo?.label || `Pass ${passInfo?.order ?? ''}`;
+  title.textContent = `Edit ${passLabel}`;
+  card.appendChild(title);
+
+  const meta = document.createElement('div');
+  meta.className = 'lecture-pass-meta';
+
+  const dateLine = document.createElement('div');
+  dateLine.className = 'lecture-pass-meta-line';
+  dateLine.textContent = Number.isFinite(passInfo?.due)
+    ? formatPassDueTimestamp(passInfo.due)
+    : 'No scheduled date';
+  meta.appendChild(dateLine);
+
+  const countdownLine = document.createElement('div');
+  countdownLine.className = 'lecture-pass-meta-line';
+  countdownLine.textContent = describePassCountdown(passInfo?.due);
+  meta.appendChild(countdownLine);
+
+  card.appendChild(meta);
+
+  const actionField = document.createElement('label');
+  actionField.className = 'lecture-pass-modal-field';
+  actionField.textContent = 'Pass function';
+  const actionInput = document.createElement('input');
+  actionInput.type = 'text';
+  actionInput.className = 'input';
+  actionInput.value = passInfo?.action || passInfo?.label || '';
+  const actionListId = `pass-action-${lecture.blockId}-${lecture.id}-${passInfo?.order}`
+    .replace(/[^a-zA-Z0-9_-]/g, '-');
+  const actionDatalist = document.createElement('datalist');
+  actionDatalist.id = actionListId;
+  LECTURE_PASS_ACTIONS.forEach(action => {
+    const option = document.createElement('option');
+    option.value = action;
+    actionDatalist.appendChild(option);
+  });
+  actionInput.setAttribute('list', actionListId);
+  actionField.appendChild(actionInput);
+  actionField.appendChild(actionDatalist);
+  card.appendChild(actionField);
+
+  const adjustSection = document.createElement('section');
+  adjustSection.className = 'lecture-pass-adjust';
+
+  const adjustTitle = document.createElement('h3');
+  adjustTitle.textContent = 'Adjust timing';
+  adjustSection.appendChild(adjustTitle);
+
+  const adjustControls = document.createElement('div');
+  adjustControls.className = 'lecture-pass-adjust-controls';
+
+  const amountInput = document.createElement('input');
+  amountInput.type = 'number';
+  amountInput.className = 'input lecture-pass-adjust-value';
+  amountInput.min = '0';
+  amountInput.step = '1';
+  amountInput.value = '1';
+
+  const unitSelect = document.createElement('select');
+  unitSelect.className = 'input lecture-pass-adjust-unit';
+  OFFSET_UNITS.forEach(option => {
+    const opt = document.createElement('option');
+    opt.value = option.id;
+    opt.textContent = option.label;
+    unitSelect.appendChild(opt);
+  });
+  unitSelect.value = 'days';
+
+  adjustControls.appendChild(amountInput);
+  adjustControls.appendChild(unitSelect);
+  adjustSection.appendChild(adjustControls);
+
+  const adjustButtons = document.createElement('div');
+  adjustButtons.className = 'lecture-pass-adjust-buttons';
+
+  const pushBtn = document.createElement('button');
+  pushBtn.type = 'button';
+  pushBtn.className = 'btn';
+  pushBtn.textContent = 'Push later';
+
+  const pullBtn = document.createElement('button');
+  pullBtn.type = 'button';
+  pullBtn.className = 'btn secondary';
+  pullBtn.textContent = 'Pull earlier';
+
+  adjustButtons.appendChild(pushBtn);
+  adjustButtons.appendChild(pullBtn);
+  adjustSection.appendChild(adjustButtons);
+
+  card.appendChild(adjustSection);
+
+  const feedback = document.createElement('div');
+  feedback.className = 'lecture-pass-feedback';
+  card.appendChild(feedback);
+
+  const actions = document.createElement('div');
+  actions.className = 'row lecture-pass-actions';
+
+  const saveBtn = document.createElement('button');
+  saveBtn.type = 'button';
+  saveBtn.className = 'btn';
+  saveBtn.textContent = 'Save function';
+
+  const closeBtn = document.createElement('button');
+  closeBtn.type = 'button';
+  closeBtn.className = 'btn secondary';
+  closeBtn.textContent = 'Close';
+
+  actions.appendChild(saveBtn);
+  actions.appendChild(closeBtn);
+  card.appendChild(actions);
+
+  overlay.appendChild(card);
+
+  function showMessage(message) {
+    feedback.textContent = message || '';
+    if (message) {
+      feedback.classList.add('is-visible');
+    } else {
+      feedback.classList.remove('is-visible');
+    }
+  }
+
+  let busy = false;
+
+  function setBusy(value) {
+    busy = Boolean(value);
+    saveBtn.disabled = busy;
+    pushBtn.disabled = busy;
+    pullBtn.disabled = busy;
+  }
+
+  function close() {
+    if (document.body.contains(overlay)) {
+      document.body.removeChild(overlay);
+    }
+  }
+
+  async function handleSave() {
+    if (busy) return;
+    const value = actionInput.value.trim();
+    if (!value) {
+      showMessage('Enter a function for this pass.');
+      return;
+    }
+    setBusy(true);
+    try {
+      await onUpdateAction(value);
+      close();
+    } catch (err) {
+      console.error(err);
+      showMessage('Failed to update pass. Please try again.');
+      setBusy(false);
+    }
+  }
+
+  async function handleShift(mode) {
+    if (busy) return;
+    const amount = Number(amountInput.value);
+    if (!Number.isFinite(amount) || amount <= 0) {
+      showMessage('Enter how much to adjust the pass by.');
+      return;
+    }
+    const minutes = combineOffsetValueUnit(amount, unitSelect.value);
+    if (!Number.isFinite(minutes) || minutes <= 0) {
+      showMessage('Pick a timing greater than zero.');
+      return;
+    }
+    const scope = await passScopeModal(mode);
+    if (!scope) return;
+    const delta = mode === 'push' ? minutes : -minutes;
+    setBusy(true);
+    try {
+      await onShift(delta, scope);
+      close();
+    } catch (err) {
+      console.error(err);
+      showMessage('Failed to adjust timing. Please try again.');
+      setBusy(false);
+    }
+  }
+
+  saveBtn.addEventListener('click', handleSave);
+  pushBtn.addEventListener('click', () => handleShift('push'));
+  pullBtn.addEventListener('click', () => handleShift('pull'));
+  closeBtn.addEventListener('click', close);
+
+  overlay.addEventListener('click', event => {
+    if (event.target === overlay) {
+      close();
+    }
+  });
+
+  document.body.appendChild(overlay);
+  actionInput.focus();
+}
+
+function handlePassEdit(lecture, passInfo, redraw) {
+  if (!lecture || !passInfo) return;
+  openPassEditDialog({
+    lecture,
+    passInfo,
+    onUpdateAction: action => updatePassFunction(lecture, passInfo.order, action, redraw),
+    onShift: (delta, scope) => shiftPassTiming(lecture, passInfo.order, delta, scope, redraw)
+  });
+}
+
 export async function renderLectures(root, redraw) {
   const [catalog, settings] = await Promise.all([
     loadBlockCatalog(),
@@ -1385,7 +1863,8 @@ export async function renderLectures(root, redraw) {
     filtered,
     filters,
     lecture => handleEdit(lecture, blocks, lectureLists, redraw),
-    lecture => handleDelete(lecture, redraw)
+    lecture => handleDelete(lecture, redraw),
+    (lecture, pass) => handlePassEdit(lecture, pass, redraw)
   );
   layout.appendChild(table);
 }

--- a/style.css
+++ b/style.css
@@ -1662,6 +1662,11 @@ input[type="checkbox"]:checked::after {
   z-index: 12000;
 }
 
+.modal.lecture-pass-scope-modal {
+  z-index: 13000;
+  background: rgba(15, 23, 42, 0.65);
+}
+
 .modal .card {
   width: 90%;
   max-width: 600px;
@@ -6603,6 +6608,14 @@ body.map-toolbox-dragging {
 }
 
 .lectures-week-table thead th {
+  border-bottom: 1px solid var(--surface-3);
+}
+
+.lectures-week-table tbody tr:last-child td {
+  border-bottom: 1px solid var(--surface-3);
+}
+
+.lectures-week-table thead th {
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
@@ -6618,6 +6631,34 @@ body.map-toolbox-dragging {
   flex-direction: column;
   gap: 0.45rem;
   min-width: 220px;
+}
+
+.lecture-overview-metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.lecture-metric {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--text-muted);
+}
+
+.lecture-metric-complete {
+  background: color-mix(in srgb, var(--green) 22%, rgba(148, 163, 184, 0.16));
+  color: color-mix(in srgb, var(--green) 75%, white 35%);
+}
+
+.lecture-metric-remaining {
+  background: color-mix(in srgb, var(--blue) 18%, rgba(148, 163, 184, 0.16));
+  color: color-mix(in srgb, var(--blue) 70%, white 35%);
 }
 
 .lecture-overview-header {
@@ -6675,17 +6716,44 @@ body.map-toolbox-dragging {
   background: color-mix(in srgb, var(--rose) 30%, transparent);
 }
 
-.lecture-count-cell {
-  width: 110px;
-  text-align: center;
-  font-variant-numeric: tabular-nums;
-  font-size: 0.95rem;
-}
-
 .lecture-next-cell {
   min-width: 200px;
   color: var(--text-muted);
   font-size: 0.85rem;
+}
+
+.lectures-col-passes {
+  width: 60%;
+}
+
+.lectures-col-next {
+  width: 18%;
+}
+
+.lectures-col-actions {
+  width: 10%;
+  text-align: right;
+}
+
+.lecture-passes-cell {
+  padding-right: 0;
+}
+
+.lecture-pass-scroller {
+  display: flex;
+  gap: 0.85rem;
+  overflow-x: auto;
+  padding-bottom: 0.25rem;
+  scroll-snap-type: x proximity;
+}
+
+.lecture-pass-scroller::-webkit-scrollbar {
+  height: 8px;
+}
+
+.lecture-pass-scroller::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.3);
+  border-radius: 999px;
 }
 
 .lecture-actions {
@@ -6719,13 +6787,17 @@ body.map-toolbox-dragging {
 .lecture-pass-chip {
   display: flex;
   flex-direction: column;
-  gap: 0.45rem;
-  min-width: 160px;
-  padding: 0.8rem 0.9rem;
-  border-radius: 14px;
-  border: 1px solid color-mix(in srgb, var(--chip-accent) 45%, transparent);
-  background: color-mix(in srgb, var(--chip-accent) 12%, rgba(12, 18, 32, 0.82));
-  box-shadow: 0 18px 40px rgba(2, 6, 23, 0.35);
+  gap: 0.35rem;
+  min-width: 200px;
+  padding: 0.9rem 1rem;
+  border-radius: 16px;
+  border: 1px solid color-mix(in srgb, var(--chip-accent) 35%, rgba(148, 163, 184, 0.1));
+  background: color-mix(in srgb, var(--chip-accent) 16%, rgba(15, 23, 42, 0.9));
+  box-shadow: 0 18px 42px rgba(2, 6, 23, 0.3);
+  color: #f8fafc;
+  scroll-snap-align: start;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .lecture-pass-chip-header {
@@ -6738,7 +6810,7 @@ body.map-toolbox-dragging {
 .lecture-pass-chip-order {
   padding: 0.2rem 0.65rem;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--chip-accent) 28%, rgba(148, 163, 184, 0.12));
+  background: color-mix(in srgb, var(--chip-accent) 35%, rgba(148, 163, 184, 0.16));
   font-size: 0.75rem;
 }
 
@@ -6746,15 +6818,142 @@ body.map-toolbox-dragging {
   font-size: 0.9rem;
 }
 
-.lecture-pass-chip-meta {
+.lecture-pass-chip-function {
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--chip-accent) 75%, white 25%);
+}
+
+.lecture-pass-chip-due {
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.lecture-pass-chip-countdown {
   font-size: 0.75rem;
-  color: var(--text-muted);
+  color: rgba(226, 232, 240, 0.75);
 }
 
 .lecture-pass-chip.is-complete {
-  opacity: 0.72;
+  opacity: 0.75;
 }
 
 .lecture-pass-chip.is-overdue {
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--chip-accent) 45%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--chip-accent) 55%, transparent);
+}
+
+.lecture-pass-chip:hover,
+.lecture-pass-chip:focus-visible {
+  transform: translateY(-4px);
+  box-shadow: 0 24px 48px rgba(2, 6, 23, 0.45);
+}
+
+.lecture-pass-chip:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--chip-accent) 55%, transparent);
+  outline-offset: 3px;
+}
+
+.lecture-pass-card {
+  max-width: 460px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.lecture-pass-card h2 {
+  margin-bottom: 0;
+}
+
+.lecture-pass-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.lecture-pass-meta-line {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.lecture-pass-modal-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.lecture-pass-modal-field .input {
+  font-weight: 500;
+}
+
+.lecture-pass-adjust {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.06);
+}
+
+.lecture-pass-adjust h3 {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.lecture-pass-adjust-controls {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.lecture-pass-adjust-controls .input {
+  max-width: 120px;
+}
+
+.lecture-pass-adjust-buttons {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.lecture-pass-feedback {
+  min-height: 1.2rem;
+  font-size: 0.8rem;
+  color: var(--rose);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.lecture-pass-feedback.is-visible {
+  opacity: 1;
+}
+
+.lecture-pass-actions {
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.lecture-pass-scope-card {
+  max-width: 360px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.lecture-pass-scope-card h3 {
+  margin: 0;
+}
+
+.lecture-pass-scope-buttons {
+  gap: 0.75rem;
+  justify-content: flex-end;
 }


### PR DESCRIPTION
## Summary
- restyle the lectures table to emphasize pass pills and inline pass metrics
- add a pass editor modal with push/pull scope options and function updates
- rebuild the bundle to include the refreshed UI logic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d075d00c8c83229564b22d96b010b8