### PR TITLE
Enhance lecture scheduling UI and block board layout

### DIFF
--- a/js/state.js
+++ b/js/state.js
@@ -14,7 +14,7 @@ export const state = {
   filters: { types:["disease","drug","concept"], block:"", week:"", onlyFav:false, sort:"updated" },
   lectures: { query: '', blockId: '', week: '', status: '', tag: '' },
   entryLayout: { mode: 'list', columns: 3, scale: 1, controlsVisible: false },
-  blockBoard: { collapsedBlocks: [], showDensity: true },
+  blockBoard: { collapsedBlocks: [], hiddenTimelines: [] },
   builder: {
     blocks:[],
     weeks:[],
@@ -52,15 +52,27 @@ export function setBuilder(patch){ Object.assign(state.builder, patch); }
 export function setBlockBoardState(patch) {
   if (!patch) return;
   if (!state.blockBoard) {
-    state.blockBoard = { collapsedBlocks: [], showDensity: true };
+    state.blockBoard = { collapsedBlocks: [], hiddenTimelines: [] };
   }
   const current = state.blockBoard;
+  if (!Array.isArray(current.hiddenTimelines)) {
+    current.hiddenTimelines = [];
+  }
   if (Array.isArray(patch.collapsedBlocks)) {
     const unique = Array.from(new Set(patch.collapsedBlocks.map(id => String(id))));
     current.collapsedBlocks = unique;
   }
+  if (Array.isArray(patch.hiddenTimelines)) {
+    const uniqueHidden = Array.from(new Set(patch.hiddenTimelines.map(id => String(id))));
+    current.hiddenTimelines = uniqueHidden;
+  }
   if (Object.prototype.hasOwnProperty.call(patch, 'showDensity')) {
-    current.showDensity = Boolean(patch.showDensity);
+    const show = Boolean(patch.showDensity);
+    if (show) {
+      current.hiddenTimelines = current.hiddenTimelines.filter(id => id !== '__all__');
+    } else if (!current.hiddenTimelines.includes('__all__')) {
+      current.hiddenTimelines = [...current.hiddenTimelines, '__all__'];
+    }
   }
 }
 export function setLecturesState(patch) {

--- a/js/storage/lecture-schema.js
+++ b/js/storage/lecture-schema.js
@@ -45,6 +45,20 @@ export function normalizeLectureRecord(blockId, lecture, now = Date.now()) {
     const parsed = Number(weekRaw);
     if (!Number.isNaN(parsed)) week = parsed;
   }
+  const startRaw = lecture.startAt;
+  let startAt = null;
+  if (Number.isFinite(startRaw)) {
+    startAt = startRaw;
+  } else if (typeof startRaw === 'string' && startRaw.trim()) {
+    const parsedStart = Number(startRaw);
+    if (!Number.isNaN(parsedStart)) {
+      startAt = parsedStart;
+    }
+  }
+  if (!Number.isFinite(startAt)) {
+    startAt = Number.isFinite(lecture.createdAt) ? lecture.createdAt : now;
+  }
+
   const tags = Array.isArray(lecture.tags)
     ? lecture.tags.filter(tag => typeof tag === 'string' && tag.trim()).map(tag => tag.trim())
     : [];
@@ -57,6 +71,7 @@ export function normalizeLectureRecord(blockId, lecture, now = Date.now()) {
     plan: passPlan,
     passes: lecture.passes,
     plannerDefaults,
+    startAt,
     now
   });
 
@@ -80,6 +95,7 @@ export function normalizeLectureRecord(blockId, lecture, now = Date.now()) {
     plannerDefaults,
     status,
     nextDueAt,
+    startAt,
     createdAt,
     updatedAt
   };

--- a/style.css
+++ b/style.css
@@ -5912,11 +5912,6 @@ body.map-toolbox-dragging {
 .block-board-block { display: flex; flex-direction: column; gap: 1.1rem; }
 .block-board-block-header { display: flex; justify-content: space-between; align-items: center; gap: 1rem; }
 .block-board-block-controls { display: flex; gap: 0.5rem; }
-.block-board-density { display: grid; grid-template-columns: repeat(auto-fit, minmax(22px, 1fr)); gap: 0.4rem; align-items: end; }
-.block-board-density-slot { display: flex; flex-direction: column; align-items: center; gap: 0.35rem; font-size: 0.7rem; opacity: 0.8; }
-.block-board-density-slot.today { font-weight: 600; opacity: 1; }
-.block-board-density-bar { width: 100%; background: var(--surface-1); border-radius: 10px; height: 82px; display: flex; align-items: flex-end; justify-content: center; overflow: hidden; }
-.block-board-density-fill { width: 100%; background: color-mix(in srgb, var(--accent) 55%, transparent); border-radius: 10px; transition: height 0.2s ease; }
 .block-board-grid { display: grid; grid-auto-flow: column; grid-auto-columns: minmax(210px, 1fr); gap: 0.85rem; overflow-x: auto; padding-bottom: 0.5rem; }
 .block-board-day-column { background: color-mix(in srgb, var(--surface-2) 90%, rgba(15, 23, 42, 0.55)); border-radius: 12px; display: flex; flex-direction: column; }
 .block-board-day-header { font-weight: 600; padding: 0.75rem 0.9rem; border-bottom: 1px solid var(--surface-3); }
@@ -6095,11 +6090,11 @@ body.map-toolbox-dragging {
 .block-board-timeline {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  padding: 0.9rem 1rem;
+  gap: 0.65rem;
+  padding: 0.85rem 0.95rem;
   border-radius: var(--radius-lg);
-  border: 1px solid var(--border);
-  background: linear-gradient(160deg, rgba(10, 15, 28, 0.85), rgba(12, 20, 36, 0.65));
+  border: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
+  background: linear-gradient(155deg, rgba(10, 15, 28, 0.82), rgba(12, 20, 36, 0.62));
 }
 
 .block-board-timeline-header {
@@ -6122,18 +6117,30 @@ body.map-toolbox-dragging {
 
 .block-board-density {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(22px, 1fr));
-  gap: 0.4rem;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(56px, 1fr);
+  gap: 0.55rem;
   align-items: end;
+  overflow-x: auto;
+  padding-bottom: 0.2rem;
+}
+
+.block-board-density::-webkit-scrollbar {
+  height: 6px;
+}
+
+.block-board-density::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.22);
+  border-radius: 999px;
 }
 
 .block-board-density-slot {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.3rem;
   align-items: center;
-  font-size: 0.7rem;
-  color: var(--text-muted);
+  font-size: 0.68rem;
+  color: color-mix(in srgb, var(--text-muted) 85%, white 8%);
 }
 
 .block-board-density-slot.today {
@@ -6143,23 +6150,24 @@ body.map-toolbox-dragging {
 
 .block-board-density-bar {
   width: 100%;
-  height: 82px;
+  height: 70px;
   border-radius: 10px;
-  background: var(--surface-1);
+  background: rgba(9, 14, 24, 0.8);
   overflow: hidden;
   display: flex;
   align-items: flex-end;
+  border: 1px solid rgba(148, 163, 184, 0.12);
 }
 
 .block-board-density-fill {
   width: 100%;
   border-radius: 10px;
-  background: var(--accent);
+  background: color-mix(in srgb, var(--accent) 65%, transparent);
   transition: height 0.2s ease;
 }
 
 .block-board-density-label {
-  font-size: 0.7rem;
+  font-size: 0.68rem;
 }
 
 .block-board-list {
@@ -6234,19 +6242,29 @@ body.map-toolbox-dragging {
   padding: 0.75rem 0.9rem 0.9rem;
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: 0.55rem;
   overflow-y: auto;
+  max-height: 320px;
+}
+
+.block-board-day-list::-webkit-scrollbar {
+  width: 6px;
+}
+
+.block-board-day-list::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.25);
+  border-radius: 999px;
 }
 
 .block-board-pass-card {
   border-radius: var(--radius);
   border: 1px solid color-mix(in srgb, var(--card-accent) 40%, transparent);
-  background: color-mix(in srgb, var(--card-accent) 10%, rgba(10, 16, 28, 0.85));
-  padding: 0.75rem 0.85rem;
+  background: color-mix(in srgb, var(--card-accent) 12%, rgba(10, 16, 28, 0.82));
+  padding: 0.65rem 0.8rem;
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
-  box-shadow: 0 16px 30px rgba(2, 6, 23, 0.35);
+  gap: 0.35rem;
+  box-shadow: 0 14px 26px rgba(2, 6, 23, 0.3);
 }
 
 .block-board-pass-card .card-title {
@@ -6275,16 +6293,16 @@ body.map-toolbox-dragging {
 .add-lecture-btn {
   display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem 1.2rem;
-  border-radius: var(--radius-lg);
+  gap: 0.6rem;
+  padding: 0.65rem 1.05rem;
+  border-radius: 999px;
   font-weight: 600;
   letter-spacing: 0.02em;
-  color: #031327;
-  background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 88%, rgba(255, 255, 255, 0.85)), color-mix(in srgb, var(--accent) 64%, rgba(192, 132, 252, 0.82)));
-  border: 1px solid color-mix(in srgb, var(--accent) 70%, transparent);
-  box-shadow: 0 22px 38px color-mix(in srgb, var(--accent) 28%, transparent);
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  color: #041320;
+  background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 85%, rgba(255, 255, 255, 0.82)), color-mix(in srgb, var(--accent) 52%, rgba(192, 132, 252, 0.78)));
+  border: 1px solid color-mix(in srgb, var(--accent) 68%, transparent);
+  box-shadow: 0 18px 36px color-mix(in srgb, var(--accent) 24%, transparent);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, border-color 0.2s ease;
 }
 
 .add-lecture-btn:disabled {
@@ -6294,21 +6312,27 @@ body.map-toolbox-dragging {
   color: var(--text-muted);
 }
 
+.add-lecture-btn:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 22px 40px color-mix(in srgb, var(--accent) 32%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 78%, transparent);
+}
+
 .add-lecture-btn-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2rem;
-  height: 2rem;
+  width: 1.8rem;
+  height: 1.8rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.7);
-  color: #031327;
-  font-size: 1.15rem;
+  background: rgba(255, 255, 255, 0.72);
+  color: #041320;
+  font-size: 1.05rem;
   font-weight: 700;
 }
 
 .add-lecture-btn-label {
-  font-size: 1rem;
+  font-size: 0.95rem;
   letter-spacing: 0.01em;
 }
 
@@ -6327,6 +6351,131 @@ body.map-toolbox-dragging {
 .lecture-pass-help {
   font-size: 0.8rem;
   color: var(--text-muted);
+}
+
+.lecture-dialog .card {
+  max-width: 640px;
+  padding: 1.6rem 1.8rem;
+  background: linear-gradient(160deg, rgba(12, 18, 30, 0.95), rgba(8, 12, 22, 0.92));
+  border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+  box-shadow: 0 26px 60px rgba(2, 6, 23, 0.5);
+  border-radius: var(--radius-lg);
+}
+
+.lecture-dialog .card h2 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+}
+
+.lecture-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.lecture-form-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  background: rgba(9, 14, 24, 0.65);
+  border-radius: var(--radius-lg);
+  padding: 1rem 1.15rem;
+  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.lecture-form-section-title {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--text-muted) 80%, white 5%);
+}
+
+.lecture-form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem 1rem;
+}
+
+.lecture-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-weight: 600;
+  color: color-mix(in srgb, var(--text-muted) 90%, white 10%);
+}
+
+.lecture-form-field[data-span="full"] {
+  grid-column: 1 / -1;
+}
+
+.lecture-form-field .input {
+  border-radius: var(--radius-sm);
+  border: 1px solid color-mix(in srgb, var(--border) 85%, transparent);
+  background: rgba(5, 10, 18, 0.85);
+  padding: 0.6rem 0.75rem;
+  font-size: 0.9rem;
+  color: var(--text);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.lecture-form-field .input:focus {
+  outline: none;
+  border-color: color-mix(in srgb, var(--accent) 65%, transparent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 28%, transparent);
+  background: rgba(8, 14, 24, 0.9);
+}
+
+.lecture-field-hint {
+  font-size: 0.75rem;
+  font-weight: 400;
+  color: color-mix(in srgb, var(--text-muted) 90%, white 5%);
+}
+
+.lecture-pass-count,
+.lecture-pass-summary-line,
+.lecture-pass-advanced {
+  background: rgba(9, 14, 24, 0.58);
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+  padding: 0.95rem 1.1rem;
+}
+
+.lecture-pass-summary-line {
+  font-size: 0.85rem;
+  color: color-mix(in srgb, var(--text-muted) 85%, white 10%);
+}
+
+.lecture-pass-advanced {
+  gap: 0.85rem;
+}
+
+.lecture-pass-advanced summary {
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--text-muted) 75%, white 10%);
+  cursor: pointer;
+}
+
+.lecture-pass-advanced summary::marker {
+  color: var(--text-muted);
+}
+
+.lecture-pass-advanced-hint {
+  font-size: 0.8rem;
+  color: color-mix(in srgb, var(--text-muted) 85%, white 5%);
+  margin: 0;
+}
+
+.lecture-dialog-actions {
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
+  margin-top: 0.25rem;
 }
 
 .lecture-pass-summary-line {
@@ -6547,19 +6696,21 @@ body.map-toolbox-dragging {
 .lectures-toolbar {
   display: flex;
   flex-wrap: wrap;
+  align-items: flex-end;
   justify-content: space-between;
-  gap: 1rem;
-  padding: 1rem 1.25rem;
+  gap: 0.85rem;
+  padding: 0.9rem 1.2rem;
   border-radius: var(--radius-lg);
-  border: 1px solid var(--border);
-  background: linear-gradient(160deg, rgba(12, 18, 32, 0.9), rgba(10, 16, 28, 0.74));
-  box-shadow: 0 24px 50px rgba(2, 6, 23, 0.35);
+  border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+  background: linear-gradient(150deg, rgba(11, 18, 30, 0.88), rgba(7, 12, 22, 0.7));
+  box-shadow: 0 18px 44px rgba(2, 6, 23, 0.32);
+  backdrop-filter: blur(18px);
 }
 
 .lectures-toolbar-filters {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 0.65rem;
   align-items: flex-end;
   flex: 1 1 60%;
   min-width: 260px;
@@ -6568,21 +6719,41 @@ body.map-toolbox-dragging {
 .lectures-toolbar-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 0.65rem;
   align-items: center;
   justify-content: flex-end;
   min-width: 220px;
 }
 
 .lectures-toolbar .input {
-  min-height: 42px;
+  min-height: 40px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--border) 85%, transparent);
+  background: rgba(9, 14, 24, 0.72);
+  padding: 0.4rem 1rem;
+  font-size: 0.85rem;
+  color: var(--text);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.lectures-toolbar .input:focus {
+  outline: none;
+  border-color: color-mix(in srgb, var(--accent) 65%, transparent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 25%, transparent);
+  background: rgba(13, 21, 34, 0.88);
 }
 
 .lectures-add-select {
-  min-width: 160px;
-  font-size: 0.9rem;
-  background: rgba(15, 23, 42, 0.85);
-  border-radius: var(--radius-sm);
+  min-width: 150px;
+  font-size: 0.85rem;
+  background: rgba(13, 20, 32, 0.78);
+  border-radius: 999px;
+}
+
+.lectures-tag-search {
+  flex: 1 1 220px;
+  min-width: 200px;
 }
 
 .lectures-card {
@@ -6684,12 +6855,17 @@ body.map-toolbox-dragging {
 
 .lectures-week-table {
   width: 100%;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 0.88rem;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  background: rgba(8, 12, 22, 0.72);
 }
 
 .lectures-week-table th,
 .lectures-week-table td {
-  padding: 0.75rem 1rem;
+  padding: 0.65rem 0.95rem;
   border-top: 1px solid var(--surface-3);
   vertical-align: top;
 }
@@ -6703,10 +6879,10 @@ body.map-toolbox-dragging {
 }
 
 .lectures-week-table thead th {
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--text-muted);
+  color: color-mix(in srgb, var(--text-muted) 85%, white 8%);
 }
 
 .lectures-week-table tbody tr:hover {
@@ -6716,8 +6892,8 @@ body.map-toolbox-dragging {
 .lecture-overview {
   display: flex;
   flex-direction: column;
-  gap: 0.45rem;
-  min-width: 220px;
+  gap: 0.35rem;
+  min-width: 210px;
 }
 
 .lecture-overview-metrics {
@@ -6752,7 +6928,7 @@ body.map-toolbox-dragging {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.65rem;
+  gap: 0.5rem;
 }
 
 .lecture-overview-position {
@@ -6766,7 +6942,7 @@ body.map-toolbox-dragging {
 }
 
 .lecture-name {
-  font-size: 1.05rem;
+  font-size: 1rem;
   font-weight: 600;
   margin: 0;
 }
@@ -6803,22 +6979,21 @@ body.map-toolbox-dragging {
   background: color-mix(in srgb, var(--rose) 30%, transparent);
 }
 
-.lecture-next-cell {
-  min-width: 200px;
-  color: var(--text-muted);
-  font-size: 0.85rem;
+
+.lecture-next-indicator {
+  margin-top: 0.35rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--text-muted) 82%, white 10%);
 }
 
 .lectures-col-passes {
-  width: 60%;
-}
-
-.lectures-col-next {
-  width: 18%;
+  width: 55%;
 }
 
 .lectures-col-actions {
-  width: 10%;
+  width: 12%;
   text-align: right;
 }
 
@@ -6828,10 +7003,10 @@ body.map-toolbox-dragging {
 
 .lecture-pass-scroller {
   display: flex;
-  gap: 0.85rem;
+  gap: 0.65rem;
   overflow-x: auto;
-  padding-bottom: 0.25rem;
-  padding-right: 0.25rem;
+  padding-bottom: 0.2rem;
+  padding-right: 0.2rem;
   scroll-snap-type: x proximity;
   max-width: 100%;
 }
@@ -6873,17 +7048,17 @@ body.map-toolbox-dragging {
   gap: 0.75rem;
 }
 
+
 .lecture-pass-chip {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 0.75rem;
+  display: flex;
   align-items: stretch;
-  min-width: 220px;
-  padding: 0.85rem 1rem;
-  border-radius: 18px;
-  border: 1px solid color-mix(in srgb, var(--chip-accent) 35%, rgba(148, 163, 184, 0.12));
-  background: color-mix(in srgb, var(--chip-accent) 18%, rgba(15, 23, 42, 0.88));
-  box-shadow: 0 18px 42px rgba(2, 6, 23, 0.3);
+  gap: 0.75rem;
+  min-width: 190px;
+  padding: 0.65rem 0.85rem;
+  border-radius: 16px;
+  border: 1px solid color-mix(in srgb, var(--chip-accent) 30%, rgba(148, 163, 184, 0.14));
+  background: linear-gradient(140deg, color-mix(in srgb, var(--chip-accent) 18%, rgba(12, 18, 32, 0.92)), rgba(8, 12, 22, 0.92));
+  box-shadow: 0 14px 32px rgba(2, 6, 23, 0.32);
   color: #f8fafc;
   scroll-snap-align: start;
   cursor: pointer;
@@ -6893,7 +7068,7 @@ body.map-toolbox-dragging {
 .lecture-pass-chip-body {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.3rem;
   min-width: 0;
 }
 
@@ -6902,12 +7077,12 @@ body.map-toolbox-dragging {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 34px;
-  height: 34px;
-  border-radius: 12px;
-  border: 1px solid color-mix(in srgb, var(--chip-accent) 45%, rgba(148, 163, 184, 0.2));
-  background: color-mix(in srgb, var(--chip-accent) 12%, rgba(12, 19, 33, 0.9));
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--chip-accent) 45%, rgba(148, 163, 184, 0.3));
+  background: color-mix(in srgb, var(--chip-accent) 12%, rgba(10, 16, 26, 0.92));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
   cursor: pointer;
   transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
 }
@@ -6923,11 +7098,11 @@ body.map-toolbox-dragging {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 18px;
-  height: 18px;
-  border-radius: 6px;
-  border: 2px solid color-mix(in srgb, var(--chip-accent) 70%, rgba(255, 255, 255, 0.08));
-  font-size: 0.75rem;
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  border: 2px solid color-mix(in srgb, var(--chip-accent) 70%, rgba(255, 255, 255, 0.12));
+  font-size: 0.7rem;
   font-weight: 700;
   color: transparent;
   transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
@@ -6951,21 +7126,21 @@ body.map-toolbox-dragging {
 .lecture-pass-chip-header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.45rem;
   font-weight: 600;
   min-width: 0;
 }
 
 .lecture-pass-chip-order {
-  padding: 0.2rem 0.65rem;
+  padding: 0.15rem 0.55rem;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--chip-accent) 30%, rgba(148, 163, 184, 0.18));
-  font-size: 0.75rem;
+  background: color-mix(in srgb, var(--chip-accent) 28%, rgba(148, 163, 184, 0.18));
+  font-size: 0.72rem;
   letter-spacing: 0.04em;
 }
 
 .lecture-pass-chip-label {
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   flex: 1;
   min-width: 0;
   overflow: hidden;
@@ -6974,27 +7149,27 @@ body.map-toolbox-dragging {
 }
 
 .lecture-pass-chip-function {
-  font-size: 0.75rem;
-  letter-spacing: 0.04em;
+  font-size: 0.72rem;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--chip-accent) 75%, white 25%);
+  color: color-mix(in srgb, var(--chip-accent) 70%, white 28%);
 }
 
 .lecture-pass-chip-due {
-  font-size: 0.85rem;
-  font-weight: 500;
+  font-size: 0.82rem;
+  font-weight: 600;
 }
 
 .lecture-pass-chip-countdown {
-  font-size: 0.75rem;
-  color: rgba(226, 232, 240, 0.75);
+  font-size: 0.72rem;
+  color: rgba(226, 232, 240, 0.7);
 }
 
 .lecture-pass-chip.is-complete {
-  background: color-mix(in srgb, var(--chip-accent) 10%, rgba(10, 16, 28, 0.92));
-  border-color: color-mix(in srgb, var(--chip-accent) 20%, rgba(148, 163, 184, 0.2));
-  color: color-mix(in srgb, #f8fafc 78%, rgba(148, 163, 184, 0.5));
-  filter: saturate(60%);
+  background: color-mix(in srgb, var(--chip-accent) 12%, rgba(10, 16, 26, 0.9));
+  border-color: color-mix(in srgb, var(--chip-accent) 22%, rgba(148, 163, 184, 0.26));
+  color: color-mix(in srgb, #f8fafc 76%, rgba(148, 163, 184, 0.55));
+  filter: saturate(65%);
 }
 
 .lecture-pass-chip.is-complete .lecture-pass-chip-function {
@@ -7011,13 +7186,13 @@ body.map-toolbox-dragging {
 }
 
 .lecture-pass-chip.is-complete .lecture-pass-chip-check {
-  background: color-mix(in srgb, var(--chip-accent) 14%, rgba(12, 19, 33, 0.88));
-  border-color: color-mix(in srgb, var(--chip-accent) 28%, rgba(148, 163, 184, 0.2));
+  background: color-mix(in srgb, var(--chip-accent) 16%, rgba(12, 19, 30, 0.9));
+  border-color: color-mix(in srgb, var(--chip-accent) 32%, rgba(148, 163, 184, 0.22));
 }
 
 .lecture-pass-chip.is-complete .lecture-pass-chip-checkmark {
-  background: color-mix(in srgb, var(--chip-accent) 35%, rgba(148, 163, 184, 0.25));
-  border-color: color-mix(in srgb, var(--chip-accent) 40%, rgba(148, 163, 184, 0.25));
+  background: color-mix(in srgb, var(--chip-accent) 32%, rgba(148, 163, 184, 0.28));
+  border-color: color-mix(in srgb, var(--chip-accent) 42%, rgba(148, 163, 184, 0.25));
   color: #041523;
 }
 
@@ -7032,8 +7207,8 @@ body.map-toolbox-dragging {
 
 .lecture-pass-chip:hover:not(.is-pending),
 .lecture-pass-chip:focus-visible {
-  transform: translateY(-4px);
-  box-shadow: 0 24px 48px rgba(2, 6, 23, 0.45);
+  transform: translateY(-2px);
+  box-shadow: 0 20px 38px rgba(2, 6, 23, 0.42);
 }
 
 .lecture-pass-chip:focus-visible {

--- a/test/ui.block-board.test.js
+++ b/test/ui.block-board.test.js
@@ -30,7 +30,7 @@ describe('block board rendering', () => {
     global.Node = dom.window.Node;
     container = document.createElement('div');
     document.body.appendChild(container);
-    state.blockBoard = { collapsedBlocks: [], showDensity: true };
+    state.blockBoard = { collapsedBlocks: [], hiddenTimelines: [] };
   });
 
   afterEach(() => {
@@ -88,7 +88,7 @@ describe('block board rendering', () => {
     assert(densityBtn);
     densityBtn.click();
     await renderBlockBoard(container, () => {});
-    assert.equal(state.blockBoard.showDensity, false);
+    assert(state.blockBoard.hiddenTimelines.includes('b1'));
 
     const collapseBtn = Array.from(container.querySelectorAll('.block-board-block-controls .btn.secondary')).find(btn => btn.textContent?.toLowerCase().includes('minimize'));
     assert(collapseBtn);


### PR DESCRIPTION
## Summary
- allow lectures to capture an explicit first-pass date, propagate it through scheduling, and surface the next due indicator inline with lecture details
- restyle the lecture toolbar, add-lecture dialog, and pass chips to match the refreshed aesthetic while simplifying the layout
- refine the block board with per-block timeline toggles, a single-row density view, constrained pass columns, and updated state handling
- regenerate the bundle so the packaged build reflects the new functionality and styles

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d08e678d288322b1a716e5ee83a3dd