### PR TITLE
Integrate lecture lists and polish scheduling UI

### DIFF
--- a/js/ui/components/block-board.js
+++ b/js/ui/components/block-board.js
@@ -8,6 +8,7 @@ import {
   deriveLectureStatus,
   calculateNextDue
 } from '../../lectures/scheduler.js';
+import { findActiveBlockId } from '../../utils.js';
 
 let loadCatalog = loadBlockCatalog;
 let fetchLectures = listAllLectures;
@@ -687,7 +688,20 @@ export async function renderBlockBoard(container, refresh) {
   container.innerHTML = '';
   container.classList.add('block-board-container');
 
+  const boardState = ensureBoardState();
   const { blocks } = await loadCatalog();
+  if ((!Array.isArray(boardState.collapsedBlocks) || boardState.collapsedBlocks.length === 0) && Array.isArray(blocks)) {
+    const activeBlockId = findActiveBlockId(blocks);
+    if (activeBlockId) {
+      const collapsedDefaults = blocks
+        .map(block => String(block?.blockId ?? ''))
+        .filter(id => id && id !== activeBlockId);
+      if (collapsedDefaults.length) {
+        setBlockBoardState({ collapsedBlocks: collapsedDefaults });
+        boardState.collapsedBlocks = collapsedDefaults;
+      }
+    }
+  }
   const lectures = await fetchLectures();
   const fallbackDays = collectDefaultBoardDays();
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -15,6 +15,82 @@ export function clamp(value, min, max) {
   return Math.min(max, Math.max(min, value));
 }
 
+function parseDateValue(value) {
+  if (!value) return Number.NaN;
+  if (value instanceof Date) {
+    const time = value.getTime();
+    return Number.isNaN(time) ? Number.NaN : time;
+  }
+  const date = new Date(value);
+  const time = date.getTime();
+  return Number.isNaN(time) ? Number.NaN : time;
+}
+
+export function findActiveBlockId(blocks, now = Date.now()) {
+  if (!Array.isArray(blocks) || blocks.length === 0) return '';
+  const nowTs = Number.isFinite(now) ? now : Date.now();
+  let current = null;
+  let upcoming = null;
+  let recent = null;
+
+  blocks.forEach(block => {
+    if (!block || block.blockId == null) return;
+    const id = String(block.blockId);
+    const start = parseDateValue(block.startDate);
+    const end = parseDateValue(block.endDate);
+
+    const hasStart = Number.isFinite(start);
+    const hasEnd = Number.isFinite(end);
+
+    if (hasStart && hasEnd) {
+      if (start <= nowTs && nowTs <= end) {
+        if (!current || start < current.start || (start === current.start && end < current.end)) {
+          current = { id, start, end };
+        }
+        return;
+      }
+      if (start > nowTs) {
+        if (!upcoming || start < upcoming.start) {
+          upcoming = { id, start };
+        }
+        return;
+      }
+      if (!recent || end > recent.end) {
+        recent = { id, end };
+      }
+      return;
+    }
+
+    if (hasStart) {
+      if (start <= nowTs) {
+        if (!recent || start > recent.end) {
+          recent = { id, end: start };
+        }
+      } else if (!upcoming || start < upcoming.start) {
+        upcoming = { id, start };
+      }
+      return;
+    }
+
+    if (hasEnd) {
+      if (nowTs <= end) {
+        if (!current || end < current.end) {
+          current = { id, start: end, end };
+        }
+      } else if (!recent || end > recent.end) {
+        recent = { id, end };
+      }
+    }
+  });
+
+  if (current) return current.id;
+  if (upcoming) return upcoming.id;
+  if (recent) return recent.id;
+
+  const first = blocks.find(block => block && block.blockId != null);
+  return first ? String(first.blockId) : '';
+}
+
 export function setToggleState(element, active, className = 'active') {
   if (!element) return;
   const isActive = Boolean(active);

--- a/style.css
+++ b/style.css
@@ -470,14 +470,33 @@ button:not(.tab):not(.fab-btn):not(.builder-pill):not(.builder-mode-toggle):hove
 .list-subtab {
   border-radius: 999px;
   padding: 6px 14px;
-  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.6);
+  color: color-mix(in srgb, var(--text-muted) 90%, white 6%);
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
 .list-subtab.active {
-  background: linear-gradient(135deg, rgba(191, 219, 254, 0.96), rgba(125, 211, 252, 0.9));
+  color: #051626;
   border-color: transparent;
-  color: #06283b;
-  box-shadow: 0 12px 26px rgba(14, 116, 144, 0.18);
+}
+
+.list-subtab[data-list-kind='disease'].active {
+  background: linear-gradient(135deg, color-mix(in srgb, var(--pink) 85%, white 18%), color-mix(in srgb, var(--pink) 62%, rgba(255, 255, 255, 0.12)));
+  box-shadow: 0 14px 28px color-mix(in srgb, var(--pink) 22%, transparent);
+  color: #2b091b;
+}
+
+.list-subtab[data-list-kind='drug'].active {
+  background: linear-gradient(135deg, color-mix(in srgb, var(--blue) 82%, white 20%), color-mix(in srgb, var(--blue) 60%, rgba(255, 255, 255, 0.12)));
+  box-shadow: 0 14px 28px color-mix(in srgb, var(--blue) 24%, transparent);
+  color: #061a32;
+}
+
+.list-subtab[data-list-kind='concept'].active {
+  background: linear-gradient(135deg, color-mix(in srgb, var(--green) 84%, white 18%), color-mix(in srgb, var(--green) 60%, rgba(255, 255, 255, 0.12)));
+  box-shadow: 0 14px 28px color-mix(in srgb, var(--green) 22%, transparent);
+  color: #092312;
 }
 
 .list-host {
@@ -5915,12 +5934,12 @@ body.map-toolbox-dragging {
 .block-board-grid { display: grid; grid-auto-flow: column; grid-auto-columns: minmax(210px, 1fr); gap: 0.85rem; overflow-x: auto; padding-bottom: 0.5rem; }
 .block-board-day-column { background: color-mix(in srgb, var(--surface-2) 90%, rgba(15, 23, 42, 0.55)); border-radius: 12px; display: flex; flex-direction: column; }
 .block-board-day-header { font-weight: 600; padding: 0.75rem 0.9rem; border-bottom: 1px solid var(--surface-3); }
-.block-board-day-list { display: flex; flex-direction: column; gap: 0.6rem; padding: 0.75rem 0.9rem 0.9rem; }
+.block-board-day-list { display: flex; flex-direction: column; gap: 0.45rem; padding: 0.65rem 0.85rem 0.8rem; }
 .block-board-day-column.today .block-board-day-header { color: var(--accent); }
 .block-board-day-column.dropping { outline: 2px dashed var(--accent); }
-.block-board-pass-card { border-radius: 12px; border: 1px solid color-mix(in srgb, var(--card-accent) 45%, transparent); padding: 0.75rem; background: color-mix(in srgb, var(--card-accent) 12%, var(--surface-1)); display: flex; flex-direction: column; gap: 0.35rem; cursor: grab; }
+.block-board-pass-card { border-radius: 10px; border: 1px solid color-mix(in srgb, var(--card-accent) 55%, rgba(148, 163, 184, 0.18)); padding: 0.5rem 0.65rem; background: linear-gradient(150deg, color-mix(in srgb, var(--card-accent) 26%, rgba(10, 16, 28, 0.82)), rgba(6, 10, 18, 0.88)); display: flex; flex-direction: column; gap: 0.25rem; cursor: grab; box-shadow: 0 14px 28px rgba(2, 6, 23, 0.28); }
 .block-board-pass-card .card-title { font-weight: 600; }
-.block-board-pass-card .card-meta { font-size: 0.8rem; opacity: 0.75; }
+.block-board-pass-card .card-meta { font-size: 0.78rem; opacity: 0.78; }
 
 /* --- Refined block board styling --- */
 .block-board-container { gap: 1.8rem; }
@@ -6239,10 +6258,10 @@ body.map-toolbox-dragging {
 }
 
 .block-board-day-list {
-  padding: 0.75rem 0.9rem 0.9rem;
+  padding: 0.65rem 0.85rem 0.8rem;
   display: flex;
   flex-direction: column;
-  gap: 0.55rem;
+  gap: 0.45rem;
   overflow-y: auto;
   max-height: 320px;
 }
@@ -6257,14 +6276,14 @@ body.map-toolbox-dragging {
 }
 
 .block-board-pass-card {
-  border-radius: var(--radius);
-  border: 1px solid color-mix(in srgb, var(--card-accent) 40%, transparent);
-  background: color-mix(in srgb, var(--card-accent) 12%, rgba(10, 16, 28, 0.82));
-  padding: 0.65rem 0.8rem;
+  border-radius: 10px;
+  border: 1px solid color-mix(in srgb, var(--card-accent) 55%, rgba(148, 163, 184, 0.18));
+  background: linear-gradient(150deg, color-mix(in srgb, var(--card-accent) 26%, rgba(10, 16, 28, 0.82)), rgba(6, 10, 18, 0.88));
+  padding: 0.5rem 0.65rem;
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-  box-shadow: 0 14px 26px rgba(2, 6, 23, 0.3);
+  gap: 0.25rem;
+  box-shadow: 0 14px 28px rgba(2, 6, 23, 0.28);
 }
 
 .block-board-pass-card .card-title {
@@ -6274,8 +6293,8 @@ body.map-toolbox-dragging {
 
 .block-board-pass-card .card-meta,
 .block-board-pass-card .card-due {
-  font-size: 0.8rem;
-  color: var(--text-muted);
+  font-size: 0.78rem;
+  color: color-mix(in srgb, var(--text-muted) 90%, white 6%);
 }
 
 .block-board-pass-card:active {
@@ -6287,7 +6306,7 @@ body.map-toolbox-dragging {
 }
 
 .block-board-pass-card + .block-board-pass-card {
-  margin-top: 0.25rem;
+  margin-top: 0.2rem;
 }
 
 .add-lecture-btn {
@@ -6773,16 +6792,16 @@ body.map-toolbox-dragging {
 }
 
 .lectures-block-group {
-  border: 1px solid var(--border);
+  border: 1px solid color-mix(in srgb, var(--border) 85%, transparent);
   border-radius: var(--radius-lg);
-  background: linear-gradient(170deg, rgba(15, 23, 42, 0.92), rgba(11, 18, 32, 0.82));
-  box-shadow: 0 26px 60px rgba(2, 6, 23, 0.45);
+  background: linear-gradient(170deg, rgba(13, 20, 32, 0.94), rgba(9, 14, 24, 0.82));
+  box-shadow: 0 20px 48px rgba(2, 6, 23, 0.38);
   overflow: hidden;
 }
 
 .lectures-block-group.has-accent {
   border-color: color-mix(in srgb, var(--block-accent) 32%, var(--border));
-  box-shadow: 0 30px 70px color-mix(in srgb, var(--block-accent) 24%, transparent);
+  box-shadow: 0 26px 56px color-mix(in srgb, var(--block-accent) 20%, transparent);
 }
 
 .lectures-block-summary {
@@ -6791,7 +6810,8 @@ body.map-toolbox-dragging {
   align-items: baseline;
   gap: 0.75rem;
   padding: 1rem 1.25rem;
-  background: rgba(148, 163, 184, 0.08);
+  background: rgba(148, 163, 184, 0.12);
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
   cursor: pointer;
 }
 
@@ -6813,14 +6833,15 @@ body.map-toolbox-dragging {
 .lectures-week-groups {
   display: flex;
   flex-direction: column;
-  gap: 0.9rem;
-  padding: 0 1.25rem 1.25rem;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem 1.3rem;
 }
 
 .lectures-week-group {
-  border: 1px solid var(--surface-3);
+  border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
   border-radius: var(--radius);
-  background: rgba(15, 23, 42, 0.65);
+  background: rgba(10, 16, 26, 0.82);
+  box-shadow: 0 14px 32px rgba(2, 6, 23, 0.28);
   overflow: hidden;
 }
 
@@ -6830,7 +6851,8 @@ body.map-toolbox-dragging {
   align-items: baseline;
   gap: 0.75rem;
   padding: 0.75rem 1rem;
-  background: rgba(148, 163, 184, 0.06);
+  background: rgba(148, 163, 184, 0.08);
+  border-bottom: 1px solid color-mix(in srgb, var(--surface-3) 85%, transparent);
   cursor: pointer;
 }
 
@@ -6861,21 +6883,22 @@ body.map-toolbox-dragging {
   border-radius: var(--radius-lg);
   overflow: hidden;
   background: rgba(8, 12, 22, 0.72);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.6);
 }
 
 .lectures-week-table th,
 .lectures-week-table td {
-  padding: 0.65rem 0.95rem;
-  border-top: 1px solid var(--surface-3);
+  padding: 0.6rem 0.9rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--surface-3) 85%, transparent);
   vertical-align: top;
 }
 
 .lectures-week-table thead th {
-  border-bottom: 1px solid var(--surface-3);
+  border-bottom: 1px solid color-mix(in srgb, var(--surface-3) 92%, transparent);
 }
 
 .lectures-week-table tbody tr:last-child td {
-  border-bottom: 1px solid var(--surface-3);
+  border-bottom: none;
 }
 
 .lectures-week-table thead th {
@@ -7003,9 +7026,9 @@ body.map-toolbox-dragging {
 
 .lecture-pass-scroller {
   display: flex;
-  gap: 0.65rem;
+  gap: 0.5rem;
   overflow-x: auto;
-  padding-bottom: 0.2rem;
+  padding-bottom: 0.25rem;
   padding-right: 0.2rem;
   scroll-snap-type: x proximity;
   max-width: 100%;
@@ -7052,13 +7075,13 @@ body.map-toolbox-dragging {
 .lecture-pass-chip {
   display: flex;
   align-items: stretch;
-  gap: 0.75rem;
-  min-width: 190px;
-  padding: 0.65rem 0.85rem;
-  border-radius: 16px;
-  border: 1px solid color-mix(in srgb, var(--chip-accent) 30%, rgba(148, 163, 184, 0.14));
-  background: linear-gradient(140deg, color-mix(in srgb, var(--chip-accent) 18%, rgba(12, 18, 32, 0.92)), rgba(8, 12, 22, 0.92));
-  box-shadow: 0 14px 32px rgba(2, 6, 23, 0.32);
+  gap: 0.55rem;
+  min-width: 160px;
+  padding: 0.55rem 0.75rem;
+  border-radius: 14px;
+  border: 1px solid color-mix(in srgb, var(--chip-accent) 45%, rgba(148, 163, 184, 0.18));
+  background: linear-gradient(140deg, color-mix(in srgb, var(--chip-accent) 32%, rgba(8, 12, 22, 0.9)), rgba(4, 8, 16, 0.92));
+  box-shadow: 0 16px 34px rgba(2, 6, 23, 0.34);
   color: #f8fafc;
   scroll-snap-align: start;
   cursor: pointer;
@@ -7068,7 +7091,7 @@ body.map-toolbox-dragging {
 .lecture-pass-chip-body {
   display: flex;
   flex-direction: column;
-  gap: 0.3rem;
+  gap: 0.28rem;
   min-width: 0;
 }
 
@@ -7077,14 +7100,13 @@ body.map-toolbox-dragging {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
-  height: 28px;
-  border-radius: 999px;
-  border: 1px solid color-mix(in srgb, var(--chip-accent) 45%, rgba(148, 163, 184, 0.3));
-  background: color-mix(in srgb, var(--chip-accent) 12%, rgba(10, 16, 26, 0.92));
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: 2px solid color-mix(in srgb, var(--chip-accent) 65%, rgba(255, 255, 255, 0.18));
+  background: color-mix(in srgb, var(--chip-accent) 24%, rgba(6, 12, 22, 0.9));
   cursor: pointer;
-  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+  transition: border-color 0.2s ease, background 0.2s ease;
 }
 
 .lecture-pass-chip-checkbox {
@@ -7098,18 +7120,18 @@ body.map-toolbox-dragging {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 16px;
-  height: 16px;
-  border-radius: 999px;
-  border: 2px solid color-mix(in srgb, var(--chip-accent) 70%, rgba(255, 255, 255, 0.12));
-  font-size: 0.7rem;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  font-size: 0.75rem;
   font-weight: 700;
   color: transparent;
-  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  background: transparent;
+  transition: color 0.2s ease, background 0.2s ease;
 }
 
 .lecture-pass-chip-check:hover {
-  background: color-mix(in srgb, var(--chip-accent) 18%, rgba(12, 19, 33, 0.88));
+  background: color-mix(in srgb, var(--chip-accent) 32%, rgba(6, 12, 22, 0.88));
 }
 
 .lecture-pass-chip-checkbox:focus-visible + .lecture-pass-chip-checkmark {
@@ -7118,9 +7140,8 @@ body.map-toolbox-dragging {
 }
 
 .lecture-pass-chip-checkbox:checked + .lecture-pass-chip-checkmark {
-  background: color-mix(in srgb, var(--chip-accent) 80%, white 25%);
-  border-color: color-mix(in srgb, var(--chip-accent) 90%, rgba(148, 163, 184, 0.25));
-  color: #031327;
+  background: color-mix(in srgb, var(--chip-accent) 85%, white 28%);
+  color: #04101f;
 }
 
 .lecture-pass-chip-header {


### PR DESCRIPTION
## Summary
- ensure the item editor reloads the latest block catalog, supports unscheduled lecture tags, and only records numeric week ids
- default the lectures view and block board to the active block using a shared helper for cleaner initial layouts
- refresh lecture tables, pass chips, block board cards, and list subtabs with refined spacing and color accents

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a348b6508322b33d38cfb286034c