### PR TITLE
Enhance list and lecture UI accents

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -7336,15 +7336,17 @@ var Sevenn = (() => {
     if (!Number.isFinite(info?.completedAt) && Number.isFinite(info?.due) && info.due < now) {
       chip.classList.add("is-overdue");
     }
+    const passTitle = info?.action || info?.label || `Pass ${info?.order ?? ""}`;
     const check = document.createElement("label");
     check.className = "lecture-pass-chip-check";
     const checkbox = document.createElement("input");
     checkbox.type = "checkbox";
     checkbox.className = "lecture-pass-chip-checkbox";
     checkbox.checked = Number.isFinite(info?.completedAt);
+    checkbox.setAttribute("aria-label", `Toggle completion for ${passTitle}`);
     const faux = document.createElement("span");
     faux.className = "lecture-pass-chip-checkmark";
-    faux.textContent = "\u2713";
+    faux.setAttribute("aria-hidden", "true");
     check.append(checkbox, faux);
     chip.appendChild(check);
     const body = document.createElement("div");
@@ -7355,10 +7357,10 @@ var Sevenn = (() => {
     const badge = document.createElement("span");
     badge.className = "lecture-pass-chip-order";
     badge.textContent = `P${info?.order ?? ""}`;
-    const label = document.createElement("span");
-    label.className = "lecture-pass-chip-label";
-    label.textContent = info?.action || info?.label || `Pass ${info?.order ?? ""}`;
-    header.append(badge, label);
+    const labelEl = document.createElement("span");
+    labelEl.className = "lecture-pass-chip-label";
+    labelEl.textContent = passTitle;
+    header.append(badge, labelEl);
     body.appendChild(header);
     const functionLine = document.createElement("div");
     functionLine.className = "lecture-pass-chip-function";
@@ -8080,7 +8082,8 @@ var Sevenn = (() => {
     addBtn.dataset.action = "add-lecture";
     const addIcon = document.createElement("span");
     addIcon.className = "add-lecture-btn-icon";
-    addIcon.textContent = "+";
+    addIcon.setAttribute("aria-hidden", "true");
+    addIcon.innerHTML = '<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" focusable="false" aria-hidden="true"><path d="M8 3v10M3 8h10"/></svg>';
     const addLabel = document.createElement("span");
     addLabel.className = "add-lecture-btn-label";
     addLabel.textContent = "Add lecture";
@@ -15272,7 +15275,7 @@ var Sevenn = (() => {
         listTabConfig.forEach((cfg) => {
           const btn = document.createElement("button");
           btn.type = "button";
-          btn.className = "btn secondary list-subtab";
+          btn.className = "list-subtab";
           btn.textContent = cfg.label;
           btn.dataset.listKind = cfg.kind;
           btn.setAttribute("role", "tab");

--- a/js/app-shell.js
+++ b/js/app-shell.js
@@ -165,7 +165,7 @@ export function createAppShell({
       listTabConfig.forEach(cfg => {
         const btn = document.createElement('button');
         btn.type = 'button';
-        btn.className = 'btn secondary list-subtab';
+        btn.className = 'list-subtab';
         btn.textContent = cfg.label;
         btn.dataset.listKind = cfg.kind;
         btn.setAttribute('role', 'tab');

--- a/js/ui/components/lectures.js
+++ b/js/ui/components/lectures.js
@@ -295,15 +295,17 @@ function createPassChipDisplay(info, now = Date.now(), options = {}) {
     chip.classList.add('is-overdue');
   }
 
+  const passTitle = info?.action || info?.label || `Pass ${info?.order ?? ''}`;
   const check = document.createElement('label');
   check.className = 'lecture-pass-chip-check';
   const checkbox = document.createElement('input');
   checkbox.type = 'checkbox';
   checkbox.className = 'lecture-pass-chip-checkbox';
   checkbox.checked = Number.isFinite(info?.completedAt);
+  checkbox.setAttribute('aria-label', `Toggle completion for ${passTitle}`);
   const faux = document.createElement('span');
   faux.className = 'lecture-pass-chip-checkmark';
-  faux.textContent = '✓';
+  faux.setAttribute('aria-hidden', 'true');
   check.append(checkbox, faux);
   chip.appendChild(check);
 
@@ -316,10 +318,10 @@ function createPassChipDisplay(info, now = Date.now(), options = {}) {
   const badge = document.createElement('span');
   badge.className = 'lecture-pass-chip-order';
   badge.textContent = `P${info?.order ?? ''}`;
-  const label = document.createElement('span');
-  label.className = 'lecture-pass-chip-label';
-  label.textContent = info?.action || info?.label || `Pass ${info?.order ?? ''}`;
-  header.append(badge, label);
+  const labelEl = document.createElement('span');
+  labelEl.className = 'lecture-pass-chip-label';
+  labelEl.textContent = passTitle;
+  header.append(badge, labelEl);
   body.appendChild(header);
 
   const functionLine = document.createElement('div');
@@ -1211,7 +1213,8 @@ function buildToolbar(blocks, lectures, lectureLists, redraw, defaultPassPlan) {
   addBtn.dataset.action = 'add-lecture';
   const addIcon = document.createElement('span');
   addIcon.className = 'add-lecture-btn-icon';
-  addIcon.textContent = '+';
+  addIcon.setAttribute('aria-hidden', 'true');
+  addIcon.innerHTML = '<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" focusable="false" aria-hidden="true"><path d="M8 3v10M3 8h10"/></svg>';
   const addLabel = document.createElement('span');
   addLabel.className = 'add-lecture-btn-label';
   addLabel.textContent = 'Add lecture';

--- a/style.css
+++ b/style.css
@@ -468,35 +468,82 @@ button:not(.tab):not(.fab-btn):not(.builder-pill):not(.builder-mode-toggle):hove
 }
 
 .list-subtab {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
   border-radius: 999px;
-  padding: 6px 14px;
+  padding: 6px 18px;
   border: 1px solid rgba(148, 163, 184, 0.28);
   background: rgba(15, 23, 42, 0.6);
-  color: color-mix(in srgb, var(--text-muted) 90%, white 6%);
-  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  color: color-mix(in srgb, var(--text-muted) 80%, white 10%);
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.list-subtab:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 65%, transparent);
+  outline-offset: 2px;
+}
+
+.list-subtab[data-list-kind='disease'] {
+  background: rgba(249, 168, 212, 0.2);
+  border-color: rgba(249, 168, 212, 0.38);
+  color: color-mix(in srgb, var(--pink) 70%, white 12%);
+}
+
+.list-subtab[data-list-kind='disease']:is(:hover, :focus-visible):not(.active) {
+  background: rgba(249, 168, 212, 0.3);
+  border-color: rgba(249, 168, 212, 0.5);
+  color: color-mix(in srgb, var(--pink) 85%, white 6%);
+}
+
+.list-subtab[data-list-kind='drug'] {
+  background: rgba(96, 165, 250, 0.2);
+  border-color: rgba(96, 165, 250, 0.4);
+  color: color-mix(in srgb, var(--blue) 72%, white 10%);
+}
+
+.list-subtab[data-list-kind='drug']:is(:hover, :focus-visible):not(.active) {
+  background: rgba(96, 165, 250, 0.3);
+  border-color: rgba(96, 165, 250, 0.52);
+  color: color-mix(in srgb, var(--blue) 88%, white 8%);
+}
+
+.list-subtab[data-list-kind='concept'] {
+  background: rgba(134, 239, 172, 0.22);
+  border-color: rgba(134, 239, 172, 0.42);
+  color: color-mix(in srgb, var(--green) 68%, white 14%);
+}
+
+.list-subtab[data-list-kind='concept']:is(:hover, :focus-visible):not(.active) {
+  background: rgba(134, 239, 172, 0.32);
+  border-color: rgba(134, 239, 172, 0.52);
+  color: color-mix(in srgb, var(--green) 86%, white 8%);
 }
 
 .list-subtab.active {
-  color: #051626;
+  color: #041021;
   border-color: transparent;
+  box-shadow: 0 18px 34px rgba(2, 6, 23, 0.42);
+  transform: translateY(-1px);
 }
 
 .list-subtab[data-list-kind='disease'].active {
-  background: linear-gradient(135deg, color-mix(in srgb, var(--pink) 85%, white 18%), color-mix(in srgb, var(--pink) 62%, rgba(255, 255, 255, 0.12)));
-  box-shadow: 0 14px 28px color-mix(in srgb, var(--pink) 22%, transparent);
+  background: linear-gradient(135deg, rgba(249, 168, 212, 0.96), rgba(244, 114, 182, 0.94));
   color: #2b091b;
 }
 
 .list-subtab[data-list-kind='drug'].active {
-  background: linear-gradient(135deg, color-mix(in srgb, var(--blue) 82%, white 20%), color-mix(in srgb, var(--blue) 60%, rgba(255, 255, 255, 0.12)));
-  box-shadow: 0 14px 28px color-mix(in srgb, var(--blue) 24%, transparent);
-  color: #061a32;
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.96), rgba(34, 211, 238, 0.92));
+  color: #041021;
 }
 
 .list-subtab[data-list-kind='concept'].active {
-  background: linear-gradient(135deg, color-mix(in srgb, var(--green) 84%, white 18%), color-mix(in srgb, var(--green) 60%, rgba(255, 255, 255, 0.12)));
-  box-shadow: 0 14px 28px color-mix(in srgb, var(--green) 22%, transparent);
-  color: #092312;
+  background: linear-gradient(135deg, rgba(134, 239, 172, 0.96), rgba(16, 185, 129, 0.92));
+  color: #032514;
 }
 
 .list-host {
@@ -1329,21 +1376,28 @@ input[type="checkbox"]:checked::after {
 }
 
 .tag-chip-lecture {
-  background: rgba(191, 219, 254, 0.18);
-  border-color: rgba(191, 219, 254, 0.35);
+  background: color-mix(in srgb, var(--blue) 24%, rgba(15, 23, 42, 0.72));
+  border-color: color-mix(in srgb, var(--blue) 38%, transparent);
   font-size: 0.85rem;
+  color: color-mix(in srgb, var(--text) 82%, white 6%);
+}
+
+.tag-chip-lecture:is(:hover, :focus-visible) {
+  background: color-mix(in srgb, var(--blue) 36%, rgba(15, 23, 42, 0.68));
+  border-color: color-mix(in srgb, var(--blue) 54%, transparent);
+  color: color-mix(in srgb, var(--text) 92%, white 8%);
 }
 
 .tag-chip-lecture.active {
-  background: linear-gradient(135deg, rgba(191, 219, 254, 0.98), rgba(221, 214, 254, 0.96));
-  color: #0b162d;
-  font-weight: 700;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.96), rgba(99, 102, 241, 0.9));
+  color: #041021;
+  border-color: transparent;
+  box-shadow: 0 16px 32px rgba(56, 189, 248, 0.32);
 }
 
-.tag-chip-lecture.active:hover,
-.tag-chip-lecture.active:focus-visible {
-  background: linear-gradient(135deg, rgba(224, 231, 255, 0.98), rgba(199, 210, 254, 0.96));
-  color: #071023;
+.tag-chip-lecture.active:is(:hover, :focus-visible) {
+  background: linear-gradient(135deg, rgba(79, 209, 255, 0.98), rgba(129, 140, 248, 0.94));
+  color: #020a16;
 }
 
 .editor-extras {
@@ -6348,6 +6402,12 @@ body.map-toolbox-dragging {
   color: #041320;
   font-size: 1.05rem;
   font-weight: 700;
+  line-height: 1;
+}
+
+.add-lecture-btn-icon svg {
+  width: 1.05rem;
+  height: 1.05rem;
 }
 
 .add-lecture-btn-label {
@@ -7117,6 +7177,7 @@ body.map-toolbox-dragging {
 }
 
 .lecture-pass-chip-checkmark {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -7127,7 +7188,19 @@ body.map-toolbox-dragging {
   font-weight: 700;
   color: transparent;
   background: transparent;
-  transition: color 0.2s ease, background 0.2s ease;
+  overflow: hidden;
+  transition: background 0.25s ease, box-shadow 0.25s ease;
+}
+
+.lecture-pass-chip-checkmark::after {
+  content: '';
+  position: absolute;
+  inset: 4px;
+  border-radius: 50%;
+  background: transparent;
+  opacity: 0;
+  transform: scale(0.25);
+  transition: opacity 0.25s ease, transform 0.25s ease, background 0.25s ease;
 }
 
 .lecture-pass-chip-check:hover {
@@ -7140,8 +7213,14 @@ body.map-toolbox-dragging {
 }
 
 .lecture-pass-chip-checkbox:checked + .lecture-pass-chip-checkmark {
-  background: color-mix(in srgb, var(--chip-accent) 85%, white 28%);
-  color: #04101f;
+  background: rgba(34, 197, 94, 0.28);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.45);
+}
+
+.lecture-pass-chip-checkbox:checked + .lecture-pass-chip-checkmark::after {
+  background: linear-gradient(135deg, #4ade80, #22c55e);
+  opacity: 1;
+  transform: scale(1);
 }
 
 .lecture-pass-chip-header {
@@ -7207,14 +7286,19 @@ body.map-toolbox-dragging {
 }
 
 .lecture-pass-chip.is-complete .lecture-pass-chip-check {
-  background: color-mix(in srgb, var(--chip-accent) 16%, rgba(12, 19, 30, 0.9));
-  border-color: color-mix(in srgb, var(--chip-accent) 32%, rgba(148, 163, 184, 0.22));
+  background: color-mix(in srgb, #22c55e 24%, rgba(12, 19, 30, 0.88));
+  border-color: color-mix(in srgb, #22c55e 58%, rgba(148, 163, 184, 0.24));
 }
 
 .lecture-pass-chip.is-complete .lecture-pass-chip-checkmark {
-  background: color-mix(in srgb, var(--chip-accent) 32%, rgba(148, 163, 184, 0.28));
-  border-color: color-mix(in srgb, var(--chip-accent) 42%, rgba(148, 163, 184, 0.25));
-  color: #041523;
+  background: rgba(34, 197, 94, 0.28);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.45);
+}
+
+.lecture-pass-chip.is-complete .lecture-pass-chip-checkmark::after {
+  background: linear-gradient(135deg, #4ade80, #22c55e);
+  opacity: 1;
+  transform: scale(1);
 }
 
 .lecture-pass-chip.is-overdue {


### PR DESCRIPTION
## Summary
- add dedicated styling for list subtabs so disease, drug, and concept selectors carry their own accent colors
- refresh lecture selection UI by recoloring editor pills, swapping the add icon to an SVG, and giving pass toggles a filled confirmation state
- adjust list tab rendering to avoid the global button preset that washed out the new subtab palette

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a97e63e88322ad848482be2f428b