### PR TITLE
Refine block board styling and controls

### DIFF
--- a/style.css
+++ b/style.css
@@ -38,6 +38,30 @@
   box-sizing: border-box;
 }
 
+* {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(148, 163, 184, 0.32) transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: rgba(148, 163, 184, 0.35);
+  border-radius: 999px;
+  border: 2px solid rgba(5, 8, 16, 0.65);
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(148, 163, 184, 0.5);
+}
+
 .sr-only {
   position: absolute;
   width: 1px;
@@ -6005,10 +6029,10 @@ body.map-toolbox-dragging {
 .block-board-urgent-group { background: var(--surface-2); border-radius: 12px; padding: 1rem; display: flex; flex-direction: column; gap: 0.75rem; }
 .block-board-urgent-header { font-weight: 600; display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; }
 .block-board-urgent-list { display: flex; flex-direction: column; gap: 0.5rem; }
-.block-board-pass-chip { background: color-mix(in srgb, var(--chip-accent) 16%, var(--surface-1)); border: 1px solid color-mix(in srgb, var(--chip-accent) 40%, transparent); border-radius: 10px; padding: 0.75rem; display: flex; flex-direction: column; gap: 0.5rem; }
+.block-board-pass-chip { background: color-mix(in srgb, var(--chip-accent) 18%, rgba(10, 15, 28, 0.78)); border: 1px solid color-mix(in srgb, var(--chip-accent) 42%, transparent); border-radius: 12px; padding: 0.6rem 0.75rem; display: flex; flex-direction: column; gap: 0.35rem; }
 .block-board-pass-title { font-weight: 600; }
-.block-board-pass-meta { font-size: 0.85rem; opacity: 0.8; }
-.block-board-pass-actions { display: flex; gap: 0.5rem; }
+.block-board-pass-meta { font-size: 0.78rem; opacity: 0.78; letter-spacing: 0.01em; }
+.block-board-pass-actions { display: flex; flex-wrap: wrap; gap: 0.35rem; align-items: center; }
 .block-board-empty { font-size: 0.85rem; opacity: 0.7; }
 .block-board-list { display: flex; flex-direction: column; gap: 1.5rem; }
 .block-board-block { display: flex; flex-direction: column; gap: 1.1rem; }
@@ -6020,9 +6044,9 @@ body.map-toolbox-dragging {
 .block-board-day-list { display: flex; flex-direction: column; gap: 0.45rem; padding: 0.65rem 0.85rem 0.8rem; }
 .block-board-day-column.today .block-board-day-header { color: var(--accent); }
 .block-board-day-column.dropping { outline: 2px dashed var(--accent); }
-.block-board-pass-card { border-radius: 10px; border: 1px solid color-mix(in srgb, var(--card-accent) 55%, rgba(148, 163, 184, 0.18)); padding: 0.5rem 0.65rem; background: linear-gradient(150deg, color-mix(in srgb, var(--card-accent) 26%, rgba(10, 16, 28, 0.82)), rgba(6, 10, 18, 0.88)); display: flex; flex-direction: column; gap: 0.25rem; cursor: grab; box-shadow: 0 14px 28px rgba(2, 6, 23, 0.28); }
+.block-board-pass-card { border-radius: 9px; border: 1px solid color-mix(in srgb, var(--card-accent) 55%, rgba(148, 163, 184, 0.18)); padding: 0.4rem 0.55rem; background: linear-gradient(150deg, color-mix(in srgb, var(--card-accent) 24%, rgba(10, 16, 28, 0.8)), rgba(6, 10, 18, 0.86)); display: flex; flex-direction: column; gap: 0.2rem; cursor: grab; box-shadow: 0 12px 24px rgba(2, 6, 23, 0.24); }
 .block-board-pass-card .card-title { font-weight: 600; }
-.block-board-pass-card .card-meta { font-size: 0.78rem; opacity: 0.78; }
+.block-board-pass-card .card-meta { font-size: 0.76rem; opacity: 0.8; }
 
 /* --- Refined block board styling --- */
 .block-board-container { gap: 1.8rem; }
@@ -6102,35 +6126,43 @@ body.map-toolbox-dragging {
 }
 
 .block-board-pass-chip {
-  background: color-mix(in srgb, var(--chip-accent) 14%, rgba(12, 18, 32, 0.85));
-  border: 1px solid color-mix(in srgb, var(--chip-accent) 45%, transparent);
-  border-radius: 16px;
-  padding: 0.85rem 1rem;
+  background: color-mix(in srgb, var(--chip-accent) 18%, rgba(10, 15, 28, 0.78));
+  border: 1px solid color-mix(in srgb, var(--chip-accent) 42%, transparent);
+  border-radius: 12px;
+  padding: 0.6rem 0.75rem;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  box-shadow: 0 18px 42px rgba(2, 6, 23, 0.38);
+  gap: 0.35rem;
+  box-shadow: 0 14px 30px rgba(2, 6, 23, 0.28);
 }
 
 .block-board-pass-title {
   font-weight: 600;
   letter-spacing: 0.01em;
+  font-size: 0.92rem;
 }
 
 .block-board-pass-meta {
-  font-size: 0.8rem;
-  color: var(--text-muted);
+  font-size: 0.78rem;
+  color: color-mix(in srgb, var(--text-muted) 92%, white 6%);
 }
 
 .block-board-pass-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.35rem;
+  align-items: center;
 }
 
 .block-board-pass-actions .btn {
-  font-size: 0.75rem;
-  padding: 0.35rem 0.65rem;
+  font-size: 0.72rem;
+  padding: 0.28rem 0.55rem;
+  border-radius: 999px;
+}
+
+.block-board-pass-actions .btn.tertiary {
+  background: color-mix(in srgb, var(--chip-accent) 24%, rgba(148, 163, 184, 0.12));
+  border-color: color-mix(in srgb, var(--chip-accent) 32%, transparent);
 }
 
 .block-board-block {
@@ -6192,11 +6224,11 @@ body.map-toolbox-dragging {
 .block-board-timeline {
   display: flex;
   flex-direction: column;
-  gap: 0.65rem;
-  padding: 0.85rem 0.95rem;
+  gap: 0.75rem;
+  padding: 0.9rem 1.05rem;
   border-radius: var(--radius-lg);
   border: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
-  background: linear-gradient(155deg, rgba(10, 15, 28, 0.82), rgba(12, 20, 36, 0.62));
+  background: linear-gradient(155deg, rgba(10, 15, 28, 0.85), rgba(14, 22, 38, 0.6));
 }
 
 .block-board-timeline-header {
@@ -6217,59 +6249,67 @@ body.map-toolbox-dragging {
   color: var(--text-muted);
 }
 
-.block-board-density {
-  display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: minmax(56px, 1fr);
-  gap: 0.55rem;
-  align-items: end;
+.block-board-timeline-track {
+  display: flex;
+  gap: 0.45rem;
   overflow-x: auto;
-  padding-bottom: 0.2rem;
+  padding-bottom: 0.35rem;
 }
 
-.block-board-density::-webkit-scrollbar {
-  height: 6px;
-}
-
-.block-board-density::-webkit-scrollbar-thumb {
-  background: rgba(148, 163, 184, 0.22);
-  border-radius: 999px;
-}
-
-.block-board-density-slot {
+.block-board-timeline-column {
   display: flex;
   flex-direction: column;
-  gap: 0.3rem;
   align-items: center;
-  font-size: 0.68rem;
-  color: color-mix(in srgb, var(--text-muted) 85%, white 8%);
+  gap: 0.35rem;
+  min-width: 44px;
 }
 
-.block-board-density-slot.today {
-  color: var(--text);
-  font-weight: 600;
-}
-
-.block-board-density-bar {
+.block-board-timeline-bar {
   width: 100%;
-  height: 70px;
-  border-radius: 10px;
-  background: rgba(9, 14, 24, 0.8);
-  overflow: hidden;
+  min-width: 14px;
   display: flex;
-  align-items: flex-end;
-  border: 1px solid rgba(148, 163, 184, 0.12);
+  flex-direction: column-reverse;
+  justify-content: flex-start;
+  gap: 2px;
+  border-radius: 8px;
+  background: rgba(6, 10, 18, 0.82);
+  position: relative;
+  min-height: 12px;
 }
 
-.block-board-density-fill {
+.block-board-timeline-bar.is-empty {
+  height: 14px;
+  background: rgba(12, 20, 36, 0.45);
+}
+
+.block-board-timeline-column.is-today .block-board-timeline-bar {
+  box-shadow: 0 0 0 2px rgba(250, 204, 21, 0.45);
+}
+
+.block-board-timeline-segment {
   width: 100%;
-  border-radius: 10px;
-  background: color-mix(in srgb, var(--accent) 65%, transparent);
-  transition: height 0.2s ease;
+  border-radius: 4px;
+  position: relative;
+  min-height: 3px;
+  box-shadow: 0 6px 12px rgba(2, 6, 23, 0.28);
 }
 
-.block-board-density-label {
-  font-size: 0.68rem;
+.block-board-timeline-segment.is-pending::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: rgba(15, 23, 42, 0.35);
+}
+
+.block-board-timeline-day {
+  font-size: 0.75rem;
+  color: color-mix(in srgb, var(--text-muted) 88%, white 6%);
+}
+
+.block-board-timeline-column.is-today .block-board-timeline-day {
+  color: var(--yellow);
+  font-weight: 600;
 }
 
 .block-board-list {
@@ -6359,24 +6399,25 @@ body.map-toolbox-dragging {
 }
 
 .block-board-pass-card {
-  border-radius: 10px;
+  border-radius: 9px;
   border: 1px solid color-mix(in srgb, var(--card-accent) 55%, rgba(148, 163, 184, 0.18));
-  background: linear-gradient(150deg, color-mix(in srgb, var(--card-accent) 26%, rgba(10, 16, 28, 0.82)), rgba(6, 10, 18, 0.88));
-  padding: 0.5rem 0.65rem;
+  background: linear-gradient(150deg, color-mix(in srgb, var(--card-accent) 24%, rgba(10, 16, 28, 0.8)), rgba(6, 10, 18, 0.86));
+  padding: 0.4rem 0.55rem;
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-  box-shadow: 0 14px 28px rgba(2, 6, 23, 0.28);
+  gap: 0.2rem;
+  box-shadow: 0 12px 24px rgba(2, 6, 23, 0.24);
 }
 
 .block-board-pass-card .card-title {
   font-weight: 600;
   letter-spacing: 0.01em;
+  font-size: 0.92rem;
 }
 
 .block-board-pass-card .card-meta,
 .block-board-pass-card .card-due {
-  font-size: 0.78rem;
+  font-size: 0.76rem;
   color: color-mix(in srgb, var(--text-muted) 90%, white 6%);
 }
 
@@ -6390,6 +6431,87 @@ body.map-toolbox-dragging {
 
 .block-board-pass-card + .block-board-pass-card {
   margin-top: 0.2rem;
+}
+
+.modal.block-board-shift-modal {
+  z-index: 40;
+}
+
+.block-board-shift-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  padding: 1.3rem;
+  min-width: min(360px, 85vw);
+}
+
+.block-board-shift-description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.block-board-shift-fields {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.block-board-shift-field {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.78rem;
+  color: color-mix(in srgb, var(--text-muted) 90%, white 8%);
+}
+
+.block-board-shift-field .input {
+  width: 100%;
+}
+
+.block-board-shift-scope {
+  margin: 0;
+  padding: 0.75rem 0.85rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.block-board-shift-scope legend {
+  padding: 0 0.25rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.block-board-shift-scope-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.block-board-shift-scope-option input {
+  accent-color: var(--accent);
+}
+
+.block-board-shift-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.6rem;
+}
+
+.block-board-shift-error {
+  min-height: 1.1rem;
+  font-size: 0.78rem;
+  color: var(--rose);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.block-board-shift-error.is-visible {
+  opacity: 1;
 }
 
 .add-lecture-btn {

--- a/test/ui.block-board.test.js
+++ b/test/ui.block-board.test.js
@@ -67,17 +67,21 @@ describe('block board rendering', () => {
     await renderBlockBoard(container, () => {});
     assert.equal(saveLectureMock.mock.callCount(), 1);
 
-    const delayBtn = Array.from(container.querySelectorAll('.block-board-pass-actions button')).find(btn => btn.textContent?.includes('+1 day'));
-    assert(delayBtn);
-    delayBtn.click();
-    await renderBlockBoard(container, () => {});
+    const pushBtn = Array.from(container.querySelectorAll('.block-board-pass-actions button')).find(btn => btn.textContent?.includes('Push'));
+    assert(pushBtn);
+    pushBtn.click();
+    await Promise.resolve();
+    const modal = document.querySelector('.block-board-shift-card');
+    assert(modal);
+    const confirm = modal.querySelector('.block-board-shift-actions .btn:not(.secondary)');
+    assert(confirm);
+    confirm.click();
+    await Promise.resolve();
+    await Promise.resolve();
     assert.equal(saveLectureMock.mock.callCount(), 2);
 
-    const pushAllBtn = Array.from(container.querySelectorAll('.block-board-summary-header .btn.tertiary')).find(btn => btn.textContent?.toLowerCase().includes('push'));
-    assert(pushAllBtn);
-    pushAllBtn.click();
-    await renderBlockBoard(container, () => {});
-    assert.equal(saveLectureMock.mock.callCount(), 3);
+    const pushAllBtn = Array.from(container.querySelectorAll('.block-board-summary-header .btn')).find(btn => btn.textContent?.toLowerCase().includes('push to tomorrow'));
+    assert.equal(pushAllBtn, undefined);
   });
 
   it('persists density and collapse state', async () => {


### PR DESCRIPTION
## Summary
- restyle the block board to use slimmer pass chips, updated pass cards, and refreshed dark scrollbars across the app
- replace the +1 day shortcut with a configurable push/pull dialog and reuse it across urgent pass actions
- rebuild the block timeline with segmented daily columns that highlight today and distinguish pending versus completed passes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d16be0674c8322a341a0bde759641e