### PR TITLE
Refine block board styling and controls

### DIFF
--- a/js/ui/components/block-board.js
+++ b/js/ui/components/block-board.js
@@ -4,7 +4,6 @@ import { listAllLectures, saveLecture } from '../../storage/storage.js';
 import {
   groupLectureQueues,
   markPassCompleted,
-  shiftLecturePasses,
   deriveLectureStatus,
   calculateNextDue
 } from '../../lectures/scheduler.js';
@@ -34,6 +33,15 @@ const PASS_COLORS = [
   'var(--cyan)'
 ];
 const DEFAULT_BOARD_DAYS = 14;
+const SHIFT_OFFSET_UNITS = [
+  { id: 'minutes', label: 'minutes', minutes: 1 },
+  { id: 'hours', label: 'hours', minutes: 60 },
+  { id: 'days', label: 'days', minutes: 60 * 24 },
+  { id: 'weeks', label: 'weeks', minutes: 60 * 24 * 7 }
+];
+const TIMELINE_BASE_UNIT_HEIGHT = 8;
+const TIMELINE_MAX_BAR_HEIGHT = 200;
+const TIMELINE_MIN_SEGMENT_HEIGHT = 3;
 
 const BLOCK_RANGE_FORMAT = new Intl.DateTimeFormat(undefined, {
   month: 'short',
@@ -114,6 +122,223 @@ function blockSpanDays(block) {
   const diff = end.getTime() - start.getTime();
   if (diff < 0) return null;
   return Math.round(diff / DAY_MS) + 1;
+}
+
+function normalizeShiftUnit(id) {
+  if (typeof id !== 'string') return 'days';
+  const normalized = SHIFT_OFFSET_UNITS.find(option => option.id === id);
+  return normalized ? normalized.id : 'days';
+}
+
+function combineShiftValueUnit(value, unitId) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return 0;
+  }
+  const unit = SHIFT_OFFSET_UNITS.find(option => option.id === normalizeShiftUnit(unitId)) || SHIFT_OFFSET_UNITS[2];
+  return Math.max(0, Math.round(numeric * unit.minutes));
+}
+
+function buildScopeOptions(mode) {
+  if (mode === 'pull') {
+    return [
+      { id: 'single', label: 'Only this pass' },
+      { id: 'chain-before', label: 'This & preceding passes' }
+    ];
+  }
+  return [
+    { id: 'single', label: 'Only this pass' },
+    { id: 'chain-after', label: 'This & following passes' }
+  ];
+}
+
+function openShiftDialog(mode, { title, description, defaultValue = 1, defaultUnit = 'days' } = {}) {
+  return new Promise(resolve => {
+    const overlay = document.createElement('div');
+    overlay.className = 'modal block-board-shift-modal';
+
+    const card = document.createElement('div');
+    card.className = 'card block-board-shift-card';
+
+    const heading = document.createElement('h3');
+    heading.textContent = title || (mode === 'push' ? 'Push later' : 'Pull earlier');
+    card.appendChild(heading);
+
+    if (description) {
+      const desc = document.createElement('p');
+      desc.className = 'block-board-shift-description';
+      desc.textContent = description;
+      card.appendChild(desc);
+    }
+
+    const fields = document.createElement('div');
+    fields.className = 'block-board-shift-fields';
+
+    const amountField = document.createElement('label');
+    amountField.className = 'block-board-shift-field';
+    amountField.textContent = 'Amount';
+    const amountInput = document.createElement('input');
+    amountInput.type = 'number';
+    amountInput.className = 'input block-board-shift-input';
+    amountInput.min = '0';
+    amountInput.step = '1';
+    amountInput.value = String(defaultValue);
+    amountField.appendChild(amountInput);
+    fields.appendChild(amountField);
+
+    const unitField = document.createElement('label');
+    unitField.className = 'block-board-shift-field';
+    unitField.textContent = 'Unit';
+    const unitSelect = document.createElement('select');
+    unitSelect.className = 'input block-board-shift-unit';
+    SHIFT_OFFSET_UNITS.forEach(option => {
+      const opt = document.createElement('option');
+      opt.value = option.id;
+      opt.textContent = option.label;
+      unitSelect.appendChild(opt);
+    });
+    unitSelect.value = normalizeShiftUnit(defaultUnit);
+    unitField.appendChild(unitSelect);
+    fields.appendChild(unitField);
+
+    card.appendChild(fields);
+
+    const scopeGroup = document.createElement('fieldset');
+    scopeGroup.className = 'block-board-shift-scope';
+    const legend = document.createElement('legend');
+    legend.textContent = 'Scope';
+    scopeGroup.appendChild(legend);
+    const scopeInputs = [];
+    buildScopeOptions(mode).forEach((option, index) => {
+      const wrapper = document.createElement('label');
+      wrapper.className = 'block-board-shift-scope-option';
+      const input = document.createElement('input');
+      input.type = 'radio';
+      input.name = 'block-board-shift-scope';
+      input.value = option.id;
+      if (index === 0) input.checked = true;
+      const span = document.createElement('span');
+      span.textContent = option.label;
+      wrapper.appendChild(input);
+      wrapper.appendChild(span);
+      scopeGroup.appendChild(wrapper);
+      scopeInputs.push(input);
+    });
+    card.appendChild(scopeGroup);
+
+    const feedback = document.createElement('div');
+    feedback.className = 'block-board-shift-error';
+    card.appendChild(feedback);
+
+    const actions = document.createElement('div');
+    actions.className = 'block-board-shift-actions';
+    const confirm = document.createElement('button');
+    confirm.type = 'button';
+    confirm.className = 'btn';
+    confirm.textContent = mode === 'push' ? 'Push later' : 'Pull earlier';
+    const cancel = document.createElement('button');
+    cancel.type = 'button';
+    cancel.className = 'btn secondary';
+    cancel.textContent = 'Cancel';
+    actions.appendChild(confirm);
+    actions.appendChild(cancel);
+    card.appendChild(actions);
+
+    function cleanup(result) {
+      if (document.body.contains(overlay)) {
+        document.body.removeChild(overlay);
+      }
+      resolve(result);
+    }
+
+    confirm.addEventListener('click', () => {
+      const minutes = combineShiftValueUnit(amountInput.value, unitSelect.value);
+      if (!Number.isFinite(minutes) || minutes <= 0) {
+        feedback.textContent = 'Enter a value greater than zero.';
+        feedback.classList.add('is-visible');
+        amountInput.focus();
+        return;
+      }
+      const selectedScope = scopeInputs.find(input => input.checked)?.value || 'single';
+      cleanup({ minutes, scope: selectedScope });
+    });
+
+    cancel.addEventListener('click', () => cleanup(null));
+    overlay.addEventListener('click', event => {
+      if (event.target === overlay) {
+        cleanup(null);
+      }
+    });
+
+    overlay.appendChild(card);
+    document.body.appendChild(overlay);
+    amountInput.focus({ preventScroll: true });
+  });
+}
+
+function shiftPassesForScope(lecture, passOrder, deltaMinutes, scope) {
+  if (!lecture || typeof lecture !== 'object') return lecture;
+  const targetOrder = Number(passOrder);
+  if (!Number.isFinite(targetOrder)) return lecture;
+  const delta = Number(deltaMinutes);
+  if (!Number.isFinite(delta) || delta === 0) return lecture;
+  const passes = Array.isArray(lecture.passes) ? lecture.passes.map(pass => ({ ...pass })) : [];
+  if (!passes.length) return lecture;
+  const shiftMs = Math.round(delta * 60 * 1000);
+  const normalizedScope = scope === 'chain-after' || scope === 'chain-before' ? scope : 'single';
+  passes.forEach(pass => {
+    const order = Number(pass?.order);
+    if (!Number.isFinite(order)) return;
+    const inScope = normalizedScope === 'chain-after'
+      ? order >= targetOrder
+      : normalizedScope === 'chain-before'
+        ? order <= targetOrder
+        : order === targetOrder;
+    if (!inScope) return;
+    if (!Number.isFinite(pass?.due)) return;
+    if (Number.isFinite(pass?.completedAt)) return;
+    const nextDue = Math.max(0, Math.round(pass.due + shiftMs));
+    pass.due = nextDue;
+  });
+  const status = deriveLectureStatus(passes, lecture.status);
+  const nextDueAt = calculateNextDue(passes);
+  return {
+    ...lecture,
+    passes,
+    status,
+    nextDueAt
+  };
+}
+
+function collectTimelineSegments(blockLectures, days) {
+  const dayMap = new Map(days.map(day => [day, []]));
+  blockLectures.forEach(lecture => {
+    const passes = Array.isArray(lecture?.passes) ? lecture.passes : [];
+    passes.forEach(pass => {
+      if (!pass) return;
+      const due = Number(pass?.due);
+      if (!Number.isFinite(due)) return;
+      const dayKey = startOfDay(due);
+      if (!dayMap.has(dayKey)) return;
+      dayMap.get(dayKey).push({
+        lecture,
+        pass,
+        order: Number(pass?.order),
+        completed: Number.isFinite(pass?.completedAt)
+      });
+    });
+  });
+  return days.map(day => {
+    const entries = (dayMap.get(day) || []).slice().sort((a, b) => {
+      const orderA = Number.isFinite(a.order) ? a.order : Number.POSITIVE_INFINITY;
+      const orderB = Number.isFinite(b.order) ? b.order : Number.POSITIVE_INFINITY;
+      if (orderA !== orderB) return orderA - orderB;
+      const nameA = a.lecture?.name || '';
+      const nameB = b.lecture?.name || '';
+      return nameA.localeCompare(nameB);
+    });
+    return { day, entries };
+  });
 }
 
 function formatDueTime(due) {
@@ -216,7 +441,7 @@ function collectDaysForBlock(block, lectures = [], now = Date.now()) {
   return [];
 }
 
-function buildPassElement(entry, onComplete, onDelay) {
+function buildPassElement(entry, onComplete, onShift) {
   const chip = document.createElement('div');
   chip.className = 'block-board-pass-chip';
   chip.style.setProperty('--chip-accent', passColor(entry?.pass?.order));
@@ -248,12 +473,21 @@ function buildPassElement(entry, onComplete, onDelay) {
   done.addEventListener('click', () => onComplete(entry));
   actions.appendChild(done);
 
-  const delay = document.createElement('button');
-  delay.type = 'button';
-  delay.className = 'btn tertiary';
-  delay.textContent = '+1 day';
-  delay.addEventListener('click', () => onDelay(entry));
-  actions.appendChild(delay);
+  if (typeof onShift === 'function') {
+    const push = document.createElement('button');
+    push.type = 'button';
+    push.className = 'btn tertiary';
+    push.textContent = 'Push';
+    push.addEventListener('click', () => onShift(entry, 'push'));
+    actions.appendChild(push);
+
+    const pull = document.createElement('button');
+    pull.type = 'button';
+    pull.className = 'btn tertiary';
+    pull.textContent = 'Pull';
+    pull.addEventListener('click', () => onShift(entry, 'pull'));
+    actions.appendChild(pull);
+  }
 
   chip.appendChild(actions);
   return chip;
@@ -277,58 +511,6 @@ function applyPassDueUpdate(lecture, passOrder, newDue) {
   const status = deriveLectureStatus(passes, lecture?.status);
   const nextDueAt = calculateNextDue(passes);
   return { ...lecture, passes, status, nextDueAt };
-}
-
-function buildDensityGradient(byOrder, total) {
-  if (!total) return 'linear-gradient(to top, var(--accent) 0% 100%)';
-  const entries = Array.from(byOrder.entries())
-    .filter(([, count]) => Number.isFinite(count) && count > 0)
-    .sort(([a], [b]) => Number(a) - Number(b));
-  if (!entries.length) {
-    return 'linear-gradient(to top, var(--accent) 0% 100%)';
-  }
-  let traversed = 0;
-  const segments = entries.map(([order, count]) => {
-    const start = (traversed / total) * 100;
-    traversed += count;
-    const end = (traversed / total) * 100;
-    const color = passColor(order);
-    return `${color} ${start}% ${end}%`;
-  });
-  return `linear-gradient(to top, ${segments.join(', ')})`;
-}
-
-function createDensityBar(dayStat, isToday, maxTotal) {
-  const bar = document.createElement('div');
-  bar.className = 'block-board-density-bar';
-  if (isToday) bar.classList.add('today');
-  const total = Number(dayStat?.total ?? 0);
-  bar.style.setProperty('--density-value', String(total));
-  const fill = document.createElement('div');
-  fill.className = 'block-board-density-fill';
-  const height = maxTotal > 0 ? Math.min(100, Math.round((total / maxTotal) * 100)) : 0;
-  fill.style.height = `${height}%`;
-  const gradient = buildDensityGradient(dayStat?.byOrder || new Map(), total);
-  fill.style.background = gradient;
-  bar.appendChild(fill);
-  return bar;
-}
-
-function createDensityLegend(dayStat, isToday, maxTotal) {
-  const slot = document.createElement('div');
-  slot.className = 'block-board-density-slot';
-  if (isToday) slot.classList.add('today');
-  const bar = createDensityBar(dayStat, isToday, maxTotal);
-  if (Number.isFinite(dayStat?.day)) {
-    const displayDate = new Date(dayStat.day);
-    slot.title = displayDate.toLocaleDateString();
-  }
-  slot.appendChild(bar);
-  const label = document.createElement('div');
-  label.className = 'block-board-density-label';
-  label.textContent = new Date(dayStat.day).getDate();
-  slot.appendChild(label);
-  return slot;
 }
 
 function createPassCard(entry, onDrag) {
@@ -433,15 +615,6 @@ function renderUrgentQueues(root, queues, handlers) {
     count.textContent = String(entries.length);
     header.appendChild(count);
 
-    if (entries.length) {
-      const pushAll = document.createElement('button');
-      pushAll.type = 'button';
-      pushAll.className = 'btn tertiary block-board-summary-action';
-      pushAll.textContent = 'Push to tomorrow';
-      pushAll.addEventListener('click', () => handlers.onPushAll(key));
-      header.appendChild(pushAll);
-    }
-
     card.appendChild(header);
 
     const list = document.createElement('div');
@@ -453,7 +626,7 @@ function renderUrgentQueues(root, queues, handlers) {
       list.appendChild(emptyState);
     } else {
       entries.forEach(entry => {
-        const chip = buildPassElement(entry, handlers.onComplete, handlers.onDelay);
+        const chip = buildPassElement(entry, handlers.onComplete, handlers.onShift);
         list.appendChild(chip);
       });
     }
@@ -601,17 +774,7 @@ function renderBlockBoardBlock(container, block, blockLectures, days, refresh) {
   unscheduledEntries.forEach(entry => blockEntries.push(entry));
 
   if (!timelineHidden) {
-    const dayStats = days.map(day => {
-      const entries = assignments.get(day) || [];
-      const breakdown = new Map();
-      entries.forEach(entry => {
-        const order = Number(entry?.pass?.order);
-        if (!Number.isFinite(order)) return;
-        breakdown.set(order, (breakdown.get(order) || 0) + 1);
-      });
-      return { day, total: entries.length, byOrder: breakdown };
-    });
-    const maxTotal = dayStats.reduce((max, stat) => Math.max(max, stat.total), 0);
+    const timelineData = collectTimelineSegments(blockLectures, days);
     const timeline = document.createElement('div');
     timeline.className = 'block-board-timeline';
 
@@ -630,13 +793,63 @@ function renderBlockBoardBlock(container, block, blockLectures, days, refresh) {
 
     timeline.appendChild(timelineHeader);
 
-    const density = document.createElement('div');
-    density.className = 'block-board-density';
-    dayStats.forEach(stat => {
-      const slot = createDensityLegend(stat, startOfDay(Date.now()) === stat.day, Math.max(1, maxTotal));
-      density.appendChild(slot);
+    const track = document.createElement('div');
+    track.className = 'block-board-timeline-track';
+    const todayKey = startOfDay(Date.now());
+    timelineData.forEach(({ day, entries }) => {
+      const column = document.createElement('div');
+      column.className = 'block-board-timeline-column';
+      if (day === todayKey) {
+        column.classList.add('is-today');
+      }
+      const date = new Date(day);
+      const isoDate = Number.isFinite(day) ? date.toISOString().slice(0, 10) : '';
+      const tooltip = isoDate ? `${isoDate} • ${entries.length} due` : `${date.toLocaleDateString()} • ${entries.length} due`;
+      column.setAttribute('data-count', String(entries.length));
+
+      const bar = document.createElement('div');
+      bar.className = 'block-board-timeline-bar';
+      bar.title = tooltip;
+      const count = entries.length;
+      if (count > 0) {
+        const gap = 2;
+        let segmentHeight = TIMELINE_BASE_UNIT_HEIGHT;
+        const gapTotal = gap * Math.max(0, count - 1);
+        let totalHeight = segmentHeight * count + gapTotal;
+        if (totalHeight > TIMELINE_MAX_BAR_HEIGHT) {
+          const available = Math.max(TIMELINE_MAX_BAR_HEIGHT - gapTotal, TIMELINE_MIN_SEGMENT_HEIGHT * count);
+          segmentHeight = Math.max(TIMELINE_MIN_SEGMENT_HEIGHT, available / count);
+          totalHeight = segmentHeight * count + gapTotal;
+        }
+        bar.style.height = `${Math.max(totalHeight, TIMELINE_MIN_SEGMENT_HEIGHT)}px`;
+        entries.forEach(entry => {
+          const segment = document.createElement('div');
+          segment.className = 'block-board-timeline-segment';
+          segment.style.background = passColor(entry.order);
+          segment.style.height = `${segmentHeight}px`;
+          if (!entry.completed) {
+            segment.classList.add('is-pending');
+          }
+          bar.appendChild(segment);
+        });
+      } else {
+        bar.classList.add('is-empty');
+      }
+      column.appendChild(bar);
+
+      const label = document.createElement('div');
+      label.className = 'block-board-timeline-day';
+      label.textContent = date.getDate();
+      label.setAttribute('aria-hidden', 'true');
+      column.appendChild(label);
+
+      if (tooltip) {
+        column.setAttribute('aria-label', tooltip);
+      }
+
+      track.appendChild(column);
     });
-    timeline.appendChild(density);
+    timeline.appendChild(track);
     wrapper.appendChild(timeline);
   }
 
@@ -720,23 +933,26 @@ export async function renderBlockBoard(container, refresh) {
       await updateLectureSchedule(lecture, lec => markPassCompleted(lec, passIndex));
       await renderBlockBoard(container, refresh);
     },
-    onDelay: async (entry) => {
-      const lecture = entry?.lecture;
-      if (!lecture) return;
-      await updateLectureSchedule(lecture, lec => shiftLecturePasses(lec, 24 * 60));
-      await renderBlockBoard(container, refresh);
-    },
-    onPushAll: async (bucket) => {
-      const entries = queues[bucket] || [];
-      const affected = new Set();
-      for (const entry of entries) {
-        if (!entry?.lecture) continue;
-        const key = `${entry.lecture.blockId}-${entry.lecture.id}`;
-        if (affected.has(key)) continue;
-        affected.add(key);
-        await updateLectureSchedule(entry.lecture, lec => shiftLecturePasses(lec, 24 * 60));
+    onShift: async (entry, mode) => {
+      if (!entry?.lecture) return;
+      const lecture = entry.lecture;
+      const passOrder = Number(entry?.pass?.order);
+      if (!Number.isFinite(passOrder)) return;
+      const lectureLabel = lecture?.name || `Lecture ${lecture?.id ?? ''}`;
+      const passLabel = entry?.pass?.label || (Number.isFinite(passOrder) ? `Pass ${passOrder}` : 'Pass');
+      const result = await openShiftDialog(mode, {
+        description: `${lectureLabel} • ${passLabel}`,
+        defaultUnit: 'days',
+        defaultValue: 1
+      });
+      if (!result || !Number.isFinite(result.minutes) || result.minutes <= 0) return;
+      const delta = mode === 'push' ? result.minutes : -result.minutes;
+      try {
+        await updateLectureSchedule(lecture, lec => shiftPassesForScope(lec, passOrder, delta, result.scope));
+        await renderBlockBoard(container, refresh);
+      } catch (err) {
+        console.error('Failed to shift pass timing', err);
       }
-      await renderBlockBoard(container, refresh);
     }
   });
   container.appendChild(urgentHost);

--- a/style.css
+++ b/style.css
@@ -38,6 +38,30 @@
   box-sizing: border-box;
 }
 
+* {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(148, 163, 184, 0.32) transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: rgba(148, 163, 184, 0.35);
+  border-radius: 999px;
+  border: 2px solid rgba(5, 8, 16, 0.65);
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(148, 163, 184, 0.5);
+}
+
 .sr-only {
   position: absolute;
   width: 1px;
@@ -6005,10 +6029,11 @@ body.map-toolbox-dragging {
 .block-board-urgent-group { background: var(--surface-2); border-radius: 12px; padding: 1rem; display: flex; flex-direction: column; gap: 0.75rem; }
 .block-board-urgent-header { font-weight: 600; display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; }
 .block-board-urgent-list { display: flex; flex-direction: column; gap: 0.5rem; }
-.block-board-pass-chip { background: color-mix(in srgb, var(--chip-accent) 16%, var(--surface-1)); border: 1px solid color-mix(in srgb, var(--chip-accent) 40%, transparent); border-radius: 10px; padding: 0.75rem; display: flex; flex-direction: column; gap: 0.5rem; }
-.block-board-pass-title { font-weight: 600; }
-.block-board-pass-meta { font-size: 0.85rem; opacity: 0.8; }
-.block-board-pass-actions { display: flex; gap: 0.5rem; }
+.block-board-pass-chip { background: color-mix(in srgb, var(--chip-accent) 22%, rgba(8, 13, 24, 0.82)); border: 1px solid color-mix(in srgb, var(--chip-accent) 45%, transparent); border-radius: 10px; padding: 0.42rem 0.65rem; display: flex; flex-direction: column; gap: 0.25rem; box-shadow: 0 10px 22px rgba(8, 11, 22, 0.38); }
+.block-board-pass-title { font-weight: 600; font-size: 0.82rem; line-height: 1.2; }
+.block-board-pass-meta { font-size: 0.7rem; opacity: 0.78; letter-spacing: 0.02em; text-transform: uppercase; }
+.block-board-pass-actions { display: flex; flex-wrap: wrap; gap: 0.25rem; align-items: center; }
+.block-board-pass-actions .btn { padding: 0.28rem 0.5rem; font-size: 0.68rem; letter-spacing: 0.04em; }
 .block-board-empty { font-size: 0.85rem; opacity: 0.7; }
 .block-board-list { display: flex; flex-direction: column; gap: 1.5rem; }
 .block-board-block { display: flex; flex-direction: column; gap: 1.1rem; }
@@ -6017,12 +6042,12 @@ body.map-toolbox-dragging {
 .block-board-grid { display: grid; grid-auto-flow: column; grid-auto-columns: minmax(210px, 1fr); gap: 0.85rem; overflow-x: auto; padding-bottom: 0.5rem; }
 .block-board-day-column { background: color-mix(in srgb, var(--surface-2) 90%, rgba(15, 23, 42, 0.55)); border-radius: 12px; display: flex; flex-direction: column; }
 .block-board-day-header { font-weight: 600; padding: 0.75rem 0.9rem; border-bottom: 1px solid var(--surface-3); }
-.block-board-day-list { display: flex; flex-direction: column; gap: 0.45rem; padding: 0.65rem 0.85rem 0.8rem; }
+.block-board-day-list { display: flex; flex-direction: column; gap: 0.3rem; padding: 0.6rem 0.8rem 0.75rem; }
 .block-board-day-column.today .block-board-day-header { color: var(--accent); }
 .block-board-day-column.dropping { outline: 2px dashed var(--accent); }
-.block-board-pass-card { border-radius: 10px; border: 1px solid color-mix(in srgb, var(--card-accent) 55%, rgba(148, 163, 184, 0.18)); padding: 0.5rem 0.65rem; background: linear-gradient(150deg, color-mix(in srgb, var(--card-accent) 26%, rgba(10, 16, 28, 0.82)), rgba(6, 10, 18, 0.88)); display: flex; flex-direction: column; gap: 0.25rem; cursor: grab; box-shadow: 0 14px 28px rgba(2, 6, 23, 0.28); }
+.block-board-pass-card { border-radius: 9px; border: 1px solid color-mix(in srgb, var(--card-accent) 55%, rgba(148, 163, 184, 0.18)); padding: 0.4rem 0.55rem; background: linear-gradient(150deg, color-mix(in srgb, var(--card-accent) 24%, rgba(10, 16, 28, 0.8)), rgba(6, 10, 18, 0.86)); display: flex; flex-direction: column; gap: 0.2rem; cursor: grab; box-shadow: 0 12px 24px rgba(2, 6, 23, 0.24); }
 .block-board-pass-card .card-title { font-weight: 600; }
-.block-board-pass-card .card-meta { font-size: 0.78rem; opacity: 0.78; }
+.block-board-pass-card .card-meta { font-size: 0.76rem; opacity: 0.8; }
 
 /* --- Refined block board styling --- */
 .block-board-container { gap: 1.8rem; }
@@ -6102,35 +6127,43 @@ body.map-toolbox-dragging {
 }
 
 .block-board-pass-chip {
-  background: color-mix(in srgb, var(--chip-accent) 14%, rgba(12, 18, 32, 0.85));
-  border: 1px solid color-mix(in srgb, var(--chip-accent) 45%, transparent);
-  border-radius: 16px;
-  padding: 0.85rem 1rem;
+  background: color-mix(in srgb, var(--chip-accent) 18%, rgba(10, 15, 28, 0.78));
+  border: 1px solid color-mix(in srgb, var(--chip-accent) 42%, transparent);
+  border-radius: 12px;
+  padding: 0.6rem 0.75rem;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  box-shadow: 0 18px 42px rgba(2, 6, 23, 0.38);
+  gap: 0.35rem;
+  box-shadow: 0 14px 30px rgba(2, 6, 23, 0.28);
 }
 
 .block-board-pass-title {
   font-weight: 600;
   letter-spacing: 0.01em;
+  font-size: 0.92rem;
 }
 
 .block-board-pass-meta {
-  font-size: 0.8rem;
-  color: var(--text-muted);
+  font-size: 0.78rem;
+  color: color-mix(in srgb, var(--text-muted) 92%, white 6%);
 }
 
 .block-board-pass-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.35rem;
+  align-items: center;
 }
 
 .block-board-pass-actions .btn {
-  font-size: 0.75rem;
-  padding: 0.35rem 0.65rem;
+  font-size: 0.72rem;
+  padding: 0.28rem 0.55rem;
+  border-radius: 999px;
+}
+
+.block-board-pass-actions .btn.tertiary {
+  background: color-mix(in srgb, var(--chip-accent) 24%, rgba(148, 163, 184, 0.12));
+  border-color: color-mix(in srgb, var(--chip-accent) 32%, transparent);
 }
 
 .block-board-block {
@@ -6192,11 +6225,12 @@ body.map-toolbox-dragging {
 .block-board-timeline {
   display: flex;
   flex-direction: column;
-  gap: 0.65rem;
-  padding: 0.85rem 0.95rem;
+  gap: 1rem;
+  padding: 1rem 1.1rem;
   border-radius: var(--radius-lg);
-  border: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
-  background: linear-gradient(155deg, rgba(10, 15, 28, 0.82), rgba(12, 20, 36, 0.62));
+  border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+  background: radial-gradient(circle at top left, rgba(24, 34, 55, 0.85), rgba(9, 14, 28, 0.82));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
 .block-board-timeline-header {
@@ -6217,59 +6251,94 @@ body.map-toolbox-dragging {
   color: var(--text-muted);
 }
 
-.block-board-density {
-  display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: minmax(56px, 1fr);
-  gap: 0.55rem;
-  align-items: end;
+.block-board-timeline-track {
+  position: relative;
+  display: flex;
+  align-items: flex-end;
+  gap: 0.4rem;
+  min-height: 210px;
+  padding: 0.25rem 0.15rem 0.5rem;
   overflow-x: auto;
-  padding-bottom: 0.2rem;
 }
 
-.block-board-density::-webkit-scrollbar {
-  height: 6px;
+.block-board-timeline-track::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 2.1rem;
+  border-top: 1px dashed rgba(148, 163, 184, 0.2);
+  pointer-events: none;
+  z-index: 0;
 }
 
-.block-board-density::-webkit-scrollbar-thumb {
-  background: rgba(148, 163, 184, 0.22);
+.block-board-timeline-column {
+  flex: 0 0 22px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  position: relative;
+  z-index: 1;
+}
+
+.block-board-timeline-bar {
+  width: 100%;
+  min-width: 12px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: stretch;
+  gap: 2px;
+  padding: 0.25rem;
+  border-radius: 10px;
+  background: linear-gradient(180deg, rgba(11, 18, 32, 0.9), rgba(5, 10, 18, 0.7));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  min-height: 14px;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.block-board-timeline-bar.is-empty {
+  padding: 0;
+  background: rgba(12, 20, 36, 0.45);
+  height: 16px;
   border-radius: 999px;
 }
 
-.block-board-density-slot {
-  display: flex;
-  flex-direction: column;
-  gap: 0.3rem;
-  align-items: center;
-  font-size: 0.68rem;
-  color: color-mix(in srgb, var(--text-muted) 85%, white 8%);
+.block-board-timeline-column.is-today .block-board-timeline-bar {
+  box-shadow: 0 0 0 2px rgba(250, 204, 21, 0.45);
 }
 
-.block-board-density-slot.today {
-  color: var(--text);
+.block-board-timeline-column:hover .block-board-timeline-bar:not(.is-empty) {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 25px rgba(15, 23, 42, 0.35);
+}
+
+.block-board-timeline-segment {
+  width: 100%;
+  border-radius: 6px;
+  position: relative;
+  min-height: 3px;
+  box-shadow: 0 6px 12px rgba(2, 6, 23, 0.28);
+}
+
+.block-board-timeline-segment.is-pending::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: rgba(15, 23, 42, 0.4);
+}
+
+.block-board-timeline-day {
+  font-size: 0.7rem;
+  color: color-mix(in srgb, var(--text-muted) 82%, white 8%);
+  letter-spacing: 0.02em;
+}
+
+.block-board-timeline-column.is-today .block-board-timeline-day {
+  color: var(--yellow);
   font-weight: 600;
-}
-
-.block-board-density-bar {
-  width: 100%;
-  height: 70px;
-  border-radius: 10px;
-  background: rgba(9, 14, 24, 0.8);
-  overflow: hidden;
-  display: flex;
-  align-items: flex-end;
-  border: 1px solid rgba(148, 163, 184, 0.12);
-}
-
-.block-board-density-fill {
-  width: 100%;
-  border-radius: 10px;
-  background: color-mix(in srgb, var(--accent) 65%, transparent);
-  transition: height 0.2s ease;
-}
-
-.block-board-density-label {
-  font-size: 0.68rem;
 }
 
 .block-board-list {
@@ -6359,24 +6428,25 @@ body.map-toolbox-dragging {
 }
 
 .block-board-pass-card {
-  border-radius: 10px;
+  border-radius: 9px;
   border: 1px solid color-mix(in srgb, var(--card-accent) 55%, rgba(148, 163, 184, 0.18));
-  background: linear-gradient(150deg, color-mix(in srgb, var(--card-accent) 26%, rgba(10, 16, 28, 0.82)), rgba(6, 10, 18, 0.88));
-  padding: 0.5rem 0.65rem;
+  background: linear-gradient(150deg, color-mix(in srgb, var(--card-accent) 24%, rgba(10, 16, 28, 0.8)), rgba(6, 10, 18, 0.86));
+  padding: 0.4rem 0.55rem;
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-  box-shadow: 0 14px 28px rgba(2, 6, 23, 0.28);
+  gap: 0.2rem;
+  box-shadow: 0 12px 24px rgba(2, 6, 23, 0.24);
 }
 
 .block-board-pass-card .card-title {
   font-weight: 600;
   letter-spacing: 0.01em;
+  font-size: 0.92rem;
 }
 
 .block-board-pass-card .card-meta,
 .block-board-pass-card .card-due {
-  font-size: 0.78rem;
+  font-size: 0.76rem;
   color: color-mix(in srgb, var(--text-muted) 90%, white 6%);
 }
 
@@ -6390,6 +6460,87 @@ body.map-toolbox-dragging {
 
 .block-board-pass-card + .block-board-pass-card {
   margin-top: 0.2rem;
+}
+
+.modal.block-board-shift-modal {
+  z-index: 40;
+}
+
+.block-board-shift-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  padding: 1.3rem;
+  min-width: min(360px, 85vw);
+}
+
+.block-board-shift-description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.block-board-shift-fields {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.block-board-shift-field {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.78rem;
+  color: color-mix(in srgb, var(--text-muted) 90%, white 8%);
+}
+
+.block-board-shift-field .input {
+  width: 100%;
+}
+
+.block-board-shift-scope {
+  margin: 0;
+  padding: 0.75rem 0.85rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.block-board-shift-scope legend {
+  padding: 0 0.25rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.block-board-shift-scope-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.block-board-shift-scope-option input {
+  accent-color: var(--accent);
+}
+
+.block-board-shift-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.6rem;
+}
+
+.block-board-shift-error {
+  min-height: 1.1rem;
+  font-size: 0.78rem;
+  color: var(--rose);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.block-board-shift-error.is-visible {
+  opacity: 1;
 }
 
 .add-lecture-btn {

--- a/test/ui.block-board.test.js
+++ b/test/ui.block-board.test.js
@@ -67,17 +67,21 @@ describe('block board rendering', () => {
     await renderBlockBoard(container, () => {});
     assert.equal(saveLectureMock.mock.callCount(), 1);
 
-    const delayBtn = Array.from(container.querySelectorAll('.block-board-pass-actions button')).find(btn => btn.textContent?.includes('+1 day'));
-    assert(delayBtn);
-    delayBtn.click();
-    await renderBlockBoard(container, () => {});
+    const pushBtn = Array.from(container.querySelectorAll('.block-board-pass-actions button')).find(btn => btn.textContent?.includes('Push'));
+    assert(pushBtn);
+    pushBtn.click();
+    await Promise.resolve();
+    const modal = document.querySelector('.block-board-shift-card');
+    assert(modal);
+    const confirm = modal.querySelector('.block-board-shift-actions .btn:not(.secondary)');
+    assert(confirm);
+    confirm.click();
+    await Promise.resolve();
+    await Promise.resolve();
     assert.equal(saveLectureMock.mock.callCount(), 2);
 
-    const pushAllBtn = Array.from(container.querySelectorAll('.block-board-summary-header .btn.tertiary')).find(btn => btn.textContent?.toLowerCase().includes('push'));
-    assert(pushAllBtn);
-    pushAllBtn.click();
-    await renderBlockBoard(container, () => {});
-    assert.equal(saveLectureMock.mock.callCount(), 3);
+    const pushAllBtn = Array.from(container.querySelectorAll('.block-board-summary-header .btn')).find(btn => btn.textContent?.toLowerCase().includes('push to tomorrow'));
+    assert.equal(pushAllBtn, undefined);
   });
 
   it('persists density and collapse state', async () => {


### PR DESCRIPTION
## Summary
- restyle the block board to use slimmer pass chips, updated pass cards, and refreshed dark scrollbars across the app
- replace the +1 day shortcut with a configurable push/pull dialog and reuse it across urgent pass actions
- rebuild the block timeline with segmented daily columns that highlight today and distinguish pending versus completed passes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d16be0674c8322a341a0bde759641e