### PR TITLE
Refine block board layout and behavior

### DIFF
--- a/js/state.js
+++ b/js/state.js
@@ -52,11 +52,17 @@ export function setBuilder(patch){ Object.assign(state.builder, patch); }
 export function setBlockBoardState(patch) {
   if (!patch) return;
   if (!state.blockBoard) {
-    state.blockBoard = { collapsedBlocks: [], hiddenTimelines: [] };
+    state.blockBoard = { collapsedBlocks: [], hiddenTimelines: [], autoCollapsed: [], autoHidden: [] };
   }
   const current = state.blockBoard;
   if (!Array.isArray(current.hiddenTimelines)) {
     current.hiddenTimelines = [];
+  }
+  if (!Array.isArray(current.autoCollapsed)) {
+    current.autoCollapsed = [];
+  }
+  if (!Array.isArray(current.autoHidden)) {
+    current.autoHidden = [];
   }
   if (Array.isArray(patch.collapsedBlocks)) {
     const unique = Array.from(new Set(patch.collapsedBlocks.map(id => String(id))));
@@ -65,6 +71,14 @@ export function setBlockBoardState(patch) {
   if (Array.isArray(patch.hiddenTimelines)) {
     const uniqueHidden = Array.from(new Set(patch.hiddenTimelines.map(id => String(id))));
     current.hiddenTimelines = uniqueHidden;
+  }
+  if (Array.isArray(patch.autoCollapsed)) {
+    const autoSet = Array.from(new Set(patch.autoCollapsed.map(id => String(id))));
+    current.autoCollapsed = autoSet;
+  }
+  if (Array.isArray(patch.autoHidden)) {
+    const autoHiddenSet = Array.from(new Set(patch.autoHidden.map(id => String(id))));
+    current.autoHidden = autoHiddenSet;
   }
   if (Object.prototype.hasOwnProperty.call(patch, 'showDensity')) {
     const show = Boolean(patch.showDensity);

--- a/style.css
+++ b/style.css
@@ -6057,9 +6057,9 @@ body.map-toolbox-dragging {
 .block-board-day-list {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-  padding: 0.6rem 0.85rem 0.75rem;
-  max-height: clamp(14rem, 32vh, 21rem);
+  gap: 0.4rem;
+  padding: 0.5rem 0.75rem 0.65rem;
+  max-height: clamp(16rem, 34vh, 22rem);
   overflow-y: auto;
 }
 .block-board-day-column.today .block-board-day-header { color: var(--accent); }
@@ -6446,143 +6446,58 @@ body.map-toolbox-dragging {
 }
 
 .block-board-pass-card {
-  border-radius: 9px;
-  border: 1px solid color-mix(in srgb, var(--card-accent) 55%, rgba(148, 163, 184, 0.18));
-  background: linear-gradient(150deg, color-mix(in srgb, var(--card-accent) 24%, rgba(10, 16, 28, 0.8)), rgba(6, 10, 18, 0.86));
-  padding: 0.4rem 0.55rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
-  box-shadow: 0 12px 24px rgba(2, 6, 23, 0.24);
-}
-
-.block-board-pass-card .card-title {
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  font-size: 0.92rem;
-}
-
-.block-board-pass-card .card-meta,
-.block-board-pass-card .card-due {
-  font-size: 0.76rem;
-  color: color-mix(in srgb, var(--text-muted) 90%, white 6%);
-}
-
-.block-board-pass-card:active {
-  cursor: grabbing;
-}
-
-.block-board-day-column.dropping {
-  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
-}
-
-.block-board-pass-card + .block-board-pass-card {
-  margin-top: 0.2rem;
-}
-
-/* --- Block board visual refresh overrides --- */
-.block-board-pass-card {
   position: relative;
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0.3rem;
-  padding: 0.4rem 0.7rem 0.55rem;
-  border-radius: 14px;
-  border: 1px solid color-mix(in srgb, var(--card-accent) 70%, rgba(148, 163, 184, 0.18));
-  background: linear-gradient(135deg, color-mix(in srgb, var(--card-accent) 76%, rgba(10, 16, 34, 0.78)), color-mix(in srgb, var(--card-accent) 50%, rgba(6, 10, 22, 0.92)));
-  box-shadow: 0 20px 38px color-mix(in srgb, var(--card-accent) 34%, rgba(3, 6, 24, 0.45));
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--card-accent) 62%, rgba(148, 163, 184, 0.24));
+  background: linear-gradient(135deg, color-mix(in srgb, var(--card-accent) 34%, rgba(15, 23, 42, 0.88)), rgba(12, 19, 33, 0.96));
+  box-shadow: 0 12px 28px rgba(5, 10, 25, 0.35);
   cursor: grab;
-  overflow: hidden;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+  min-height: 2.1rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease, opacity 0.2s ease;
 }
 
-.block-board-pass-card::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(120deg, rgba(255, 255, 255, 0.26), transparent 55%);
-  opacity: 0.35;
-  pointer-events: none;
+.block-board-pass-card:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(5, 10, 25, 0.4);
 }
 
 .block-board-pass-card:active {
   cursor: grabbing;
-}
-
-.block-board-pass-card.is-pending {
-  filter: saturate(1.05);
 }
 
 .block-board-pass-card.is-complete {
-  border-color: color-mix(in srgb, var(--card-accent) 26%, rgba(148, 163, 184, 0.26));
-  background: linear-gradient(135deg, color-mix(in srgb, var(--card-accent) 24%, rgba(10, 16, 28, 0.88)), rgba(6, 9, 18, 0.94));
-  box-shadow: 0 12px 20px rgba(3, 6, 20, 0.3);
-  filter: saturate(0.55);
+  opacity: 0.55;
+  filter: saturate(0.5);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--card-accent) 16%, rgba(15, 23, 42, 0.88)), rgba(10, 15, 28, 0.94));
+  box-shadow: 0 10px 20px rgba(4, 8, 20, 0.24);
+  border-color: color-mix(in srgb, var(--card-accent) 28%, rgba(148, 163, 184, 0.3));
 }
 
-.block-board-pass-card.is-complete::before {
-  opacity: 0.12;
-}
-
-.block-board-pass-card + .block-board-pass-card {
-  margin-top: 0.2rem;
+.block-board-pass-card.is-complete:hover {
+  transform: none;
 }
 
 .block-board-pass-title {
   position: relative;
-  z-index: 1;
   overflow: hidden;
   white-space: nowrap;
   font-weight: 600;
   font-size: 0.78rem;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.015em;
+  min-width: 0;
+  flex: 1;
   --marquee-distance: 0px;
-}
-
-.block-board-pass-card .block-board-pass-title {
-  color: color-mix(in srgb, white 88%, var(--card-accent) 18%);
-}
-
-.block-board-pass-card.is-complete .block-board-pass-title {
-  color: color-mix(in srgb, white 62%, var(--card-accent) 12%);
-}
-
-.block-board-pass-chip .block-board-pass-title {
-  color: color-mix(in srgb, white 90%, var(--chip-accent) 22%);
-}
-
-.block-board-pass-chip.is-complete .block-board-pass-title {
-  color: color-mix(in srgb, white 64%, var(--chip-accent) 12%);
-}
-
-.block-board-pass-title::before,
-.block-board-pass-title::after {
-  content: '';
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  width: 1.1rem;
-  pointer-events: none;
-  z-index: 2;
-  opacity: 0.55;
-}
-
-.block-board-pass-title::before {
-  left: 0;
-  background: linear-gradient(90deg, rgba(6, 10, 18, 0.6), rgba(6, 10, 18, 0));
-}
-
-.block-board-pass-title::after {
-  right: 0;
-  background: linear-gradient(270deg, rgba(6, 10, 18, 0.6), rgba(6, 10, 18, 0));
 }
 
 .block-board-pass-title-inner {
   position: relative;
   display: inline-block;
   min-width: 100%;
-  padding-right: 1.5rem;
+  padding-right: 1rem;
 }
 
 .block-board-pass-title.is-animated .block-board-pass-title-inner {
@@ -6593,13 +6508,20 @@ body.map-toolbox-dragging {
   animation-play-state: paused;
 }
 
-.block-board-pass-details {
-  position: relative;
-  z-index: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0.12rem;
+.block-board-pass-card .block-board-pass-title {
+  color: color-mix(in srgb, white 88%, var(--card-accent) 18%);
+}
+
+.block-board-pass-card.is-complete .block-board-pass-title {
+  color: color-mix(in srgb, white 68%, var(--card-accent) 12%);
+}
+
+.block-board-pass-chip .block-board-pass-title {
+  color: color-mix(in srgb, white 90%, var(--chip-accent) 22%);
+}
+
+.block-board-pass-chip.is-complete .block-board-pass-title {
+  color: color-mix(in srgb, white 64%, var(--chip-accent) 12%);
 }
 
 .block-board-pass-order {
@@ -6607,22 +6529,34 @@ body.map-toolbox-dragging {
   letter-spacing: 0.18em;
   text-transform: uppercase;
   font-weight: 700;
-  color: color-mix(in srgb, white 72%, var(--card-accent) 22%);
+  color: color-mix(in srgb, white 74%, var(--chip-accent, var(--card-accent)) 24%);
 }
 
-.block-board-pass-order[data-action] {
-  cursor: help;
-}
-
-.block-board-pass-date {
-  font-size: 0.7rem;
-  letter-spacing: 0.04em;
-  color: color-mix(in srgb, white 78%, var(--card-accent) 26%);
-}
-
-.block-board-pass-card.is-complete .block-board-pass-order,
-.block-board-pass-card.is-complete .block-board-pass-date {
+.block-board-pass-chip.is-complete .block-board-pass-order {
   color: color-mix(in srgb, var(--text-muted) 84%, white 12%);
+}
+
+.block-board-pass-pill-order {
+  flex: none;
+  font-size: 0.62rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-weight: 700;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--card-accent) 68%, rgba(12, 18, 34, 0.82));
+  color: color-mix(in srgb, white 86%, var(--card-accent) 6%);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--card-accent) 82%, transparent 55%), 0 6px 14px rgba(4, 7, 18, 0.35);
+}
+
+.block-board-pass-card.is-complete .block-board-pass-pill-order {
+  background: color-mix(in srgb, var(--card-accent) 32%, rgba(12, 18, 32, 0.9));
+  color: color-mix(in srgb, var(--text-muted) 82%, white 14%);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--card-accent) 26%, transparent 55%), 0 4px 10px rgba(3, 6, 16, 0.28);
+}
+
+.block-board-day-column.dropping {
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
 }
 
 .block-board-pass-chip::before {


### PR DESCRIPTION
## Summary
- Restyle weekly pass entries into slim marquee-enabled pills with completion fades and scrolling day columns.
- Sort timeline segments and day/backlog passes so incomplete items stack on top while completed ones anchor the bottom.
- Auto-manage non-current block collapse/timeline visibility, preserve scroll positions on refresh, and rebuild the bundle with the updated state logic.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d19ec5e7308322bc29515dd7dfae16