### PR TITLE
Adjust block board marquee and weekly scroll

### DIFF
--- a/style.css
+++ b/style.css
@@ -6491,6 +6491,7 @@ body.map-toolbox-dragging {
   min-width: 0;
   flex: 1;
   --marquee-distance: 0px;
+  --marquee-duration: 9s;
 }
 
 .block-board-pass-title-inner {
@@ -6501,7 +6502,7 @@ body.map-toolbox-dragging {
 }
 
 .block-board-pass-title.is-animated .block-board-pass-title-inner {
-  animation: block-board-pass-marquee 9s ease-in-out infinite alternate;
+  animation: block-board-pass-marquee var(--marquee-duration, 9s) linear infinite;
 }
 
 .block-board-pass-title.is-animated:hover .block-board-pass-title-inner {


### PR DESCRIPTION
## Summary
- prevent block board pass titles from animating when text fits and run the marquee in a single looping direction with distance-based timing
- auto-scroll weekly block board grids to the current day on initial load and persist horizontal scroll position per block
- rebuild the compiled bundle and update styles to support the new marquee behavior

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d1a437af9483229b08e82966eb323a