### PR TITLE
Add colored list subtabs, exclusive blocks, and sorting controls

### DIFF
--- a/js/state.js
+++ b/js/state.js
@@ -11,7 +11,7 @@ export const state = {
     Settings: ""
   },
   query: "",
-  filters: { types:["disease","drug","concept"], block:"", week:"", onlyFav:false, sort:"updated" },
+  filters: { types:["disease","drug","concept"], block:"", week:"", onlyFav:false, sort:"updated-desc" },
   lectures: { query: '', blockId: '', week: '', status: '', tag: '' },
   entryLayout: { mode: 'list', columns: 3, scale: 1, controlsVisible: false },
   blockBoard: { collapsedBlocks: [], hiddenTimelines: [] },

--- a/style.css
+++ b/style.css
@@ -120,7 +120,7 @@ button:focus-visible {
   outline-offset: 3px;
 }
 
-button:not(.tab):not(.fab-btn):not(.builder-pill):not(.builder-mode-toggle) {
+button:not(.tab):not(.fab-btn):not(.builder-pill):not(.builder-mode-toggle):not(.list-subtab) {
   background: rgba(148, 163, 184, 0.14);
   color: var(--text);
   border: 1px solid var(--border);
@@ -129,7 +129,7 @@ button:not(.tab):not(.fab-btn):not(.builder-pill):not(.builder-mode-toggle) {
   box-shadow: none;
 }
 
-button:not(.tab):not(.fab-btn):not(.builder-pill):not(.builder-mode-toggle):hover {
+button:not(.tab):not(.fab-btn):not(.builder-pill):not(.builder-mode-toggle):not(.list-subtab):hover {
   background: rgba(148, 163, 184, 0.22);
 }
 
@@ -498,9 +498,9 @@ button:not(.tab):not(.fab-btn):not(.builder-pill):not(.builder-mode-toggle):hove
   gap: 0.35rem;
   border-radius: 999px;
   padding: 6px 18px;
-  border: 1px solid rgba(148, 163, 184, 0.28);
-  background: rgba(15, 23, 42, 0.6);
-  color: color-mix(in srgb, var(--text-muted) 80%, white 10%);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.55);
+  color: var(--text-muted);
   font-size: 0.9rem;
   font-weight: 600;
   letter-spacing: 0.01em;
@@ -513,61 +513,60 @@ button:not(.tab):not(.fab-btn):not(.builder-pill):not(.builder-mode-toggle):hove
 }
 
 .list-subtab[data-list-kind='disease'] {
-  background: rgba(249, 168, 212, 0.2);
-  border-color: rgba(249, 168, 212, 0.38);
-  color: color-mix(in srgb, var(--pink) 70%, white 12%);
+  background: color-mix(in srgb, var(--purple) 18%, transparent);
+  border-color: color-mix(in srgb, var(--purple) 42%, transparent);
+  color: color-mix(in srgb, var(--purple) 72%, white 18%);
 }
 
 .list-subtab[data-list-kind='disease']:is(:hover, :focus-visible):not(.active) {
-  background: rgba(249, 168, 212, 0.3);
-  border-color: rgba(249, 168, 212, 0.5);
-  color: color-mix(in srgb, var(--pink) 85%, white 6%);
+  background: color-mix(in srgb, var(--purple) 28%, transparent);
+  border-color: color-mix(in srgb, var(--purple) 58%, transparent);
+  color: color-mix(in srgb, var(--purple) 86%, white 10%);
 }
 
 .list-subtab[data-list-kind='drug'] {
-  background: rgba(96, 165, 250, 0.2);
-  border-color: rgba(96, 165, 250, 0.4);
-  color: color-mix(in srgb, var(--blue) 72%, white 10%);
+  background: color-mix(in srgb, var(--green) 20%, transparent);
+  border-color: color-mix(in srgb, var(--green) 46%, transparent);
+  color: color-mix(in srgb, var(--green) 70%, white 18%);
 }
 
 .list-subtab[data-list-kind='drug']:is(:hover, :focus-visible):not(.active) {
-  background: rgba(96, 165, 250, 0.3);
-  border-color: rgba(96, 165, 250, 0.52);
-  color: color-mix(in srgb, var(--blue) 88%, white 8%);
+  background: color-mix(in srgb, var(--green) 30%, transparent);
+  border-color: color-mix(in srgb, var(--green) 60%, transparent);
+  color: color-mix(in srgb, var(--green) 88%, white 8%);
 }
 
 .list-subtab[data-list-kind='concept'] {
-  background: rgba(134, 239, 172, 0.22);
-  border-color: rgba(134, 239, 172, 0.42);
-  color: color-mix(in srgb, var(--green) 68%, white 14%);
+  background: color-mix(in srgb, var(--blue) 20%, transparent);
+  border-color: color-mix(in srgb, var(--blue) 44%, transparent);
+  color: color-mix(in srgb, var(--blue) 74%, white 16%);
 }
 
 .list-subtab[data-list-kind='concept']:is(:hover, :focus-visible):not(.active) {
-  background: rgba(134, 239, 172, 0.32);
-  border-color: rgba(134, 239, 172, 0.52);
-  color: color-mix(in srgb, var(--green) 86%, white 8%);
+  background: color-mix(in srgb, var(--blue) 30%, transparent);
+  border-color: color-mix(in srgb, var(--blue) 58%, transparent);
+  color: color-mix(in srgb, var(--blue) 90%, white 6%);
 }
 
 .list-subtab.active {
-  color: #041021;
   border-color: transparent;
   box-shadow: 0 18px 34px rgba(2, 6, 23, 0.42);
   transform: translateY(-1px);
 }
 
 .list-subtab[data-list-kind='disease'].active {
-  background: linear-gradient(135deg, rgba(249, 168, 212, 0.96), rgba(244, 114, 182, 0.94));
-  color: #2b091b;
+  background: linear-gradient(135deg, rgba(192, 132, 252, 0.96), rgba(124, 58, 237, 0.92));
+  color: #160b2c;
 }
 
 .list-subtab[data-list-kind='drug'].active {
-  background: linear-gradient(135deg, rgba(96, 165, 250, 0.96), rgba(34, 211, 238, 0.92));
-  color: #041021;
+  background: linear-gradient(135deg, rgba(74, 222, 128, 0.96), rgba(34, 197, 94, 0.92));
+  color: #05210f;
 }
 
 .list-subtab[data-list-kind='concept'].active {
-  background: linear-gradient(135deg, rgba(134, 239, 172, 0.96), rgba(16, 185, 129, 0.92));
-  color: #032514;
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.96), rgba(37, 99, 235, 0.92));
+  color: #021528;
 }
 
 .list-host {
@@ -2678,6 +2677,60 @@ button.builder-pill.builder-pill-outline {
   background: rgba(15, 23, 42, 0.35);
   border: 1px solid var(--border);
   border-radius: var(--radius);
+}
+
+.sort-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--pad-sm);
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 6px 12px;
+}
+
+.sort-select {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.sort-select select {
+  appearance: none;
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  padding: 4px 10px;
+  font-size: 0.9rem;
+}
+
+.sort-select select:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.sort-direction-btn {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  padding: 6px 12px;
+  font-size: 0.85rem;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.sort-direction-btn:hover,
+.sort-direction-btn:focus-visible {
+  color: var(--text);
+  border-color: var(--accent);
+  background: rgba(56, 189, 248, 0.18);
+}
+
+.sort-direction-btn[data-direction='asc'] {
+  box-shadow: inset 0 0 0 1px rgba(96, 165, 250, 0.35);
 }
 
 .layout-toggle {

--- a/test/storage.perf.test.js
+++ b/test/storage.perf.test.js
@@ -55,7 +55,7 @@ test('findItemsByFilter yields batched, filtered results efficiently', async () 
     await upsertItem(item);
   }
 
-  const blockQuery = findItemsByFilter({ types: ['disease'], block: blockId, week: 1, query: base, sort: 'updated' });
+  const blockQuery = findItemsByFilter({ types: ['disease'], block: blockId, week: 1, query: base, sort: 'updated-desc' });
   const batches = [];
   for await (const batch of blockQuery) {
     batches.push(batch);
@@ -70,16 +70,16 @@ test('findItemsByFilter yields batched, filtered results efficiently', async () 
   const repeated = await blockQuery.toArray();
   assert.deepEqual(repeated.map(it => it.id), flattened.map(it => it.id), 'cached materialization should match streamed batches');
 
-  const favoritesQuery = findItemsByFilter({ types: ['disease'], onlyFav: true, query: base, sort: 'updated' });
+  const favoritesQuery = findItemsByFilter({ types: ['disease'], onlyFav: true, query: base, sort: 'updated-desc' });
   const favorites = await favoritesQuery.toArray();
   assert.ok(favorites.length > 0, 'favorites filter should return matches');
   assert.ok(favorites.every(it => it.favorite), 'favorites query should only include favorite items');
 
-  const unlabeled = await findItemsByFilter({ types: ['disease'], block: '__unlabeled', query: base, sort: 'updated' }).toArray();
+  const unlabeled = await findItemsByFilter({ types: ['disease'], block: '__unlabeled', query: base, sort: 'updated-desc' }).toArray();
   assert.equal(unlabeled.length, expectedBlockMatches, 'unlabeled filter should return items without blocks');
   assert.ok(unlabeled.every(it => (it.blocks || []).length === 0), 'unlabeled results should have no block assignments');
 
-  const tagMatches = await findItemsByFilter({ types: ['disease'], query: markerTag, sort: 'name' }).toArray();
+  const tagMatches = await findItemsByFilter({ types: ['disease'], query: markerTag, sort: 'name-asc' }).toArray();
   const expectedTagCount = Math.ceil(TOTAL_ITEMS / 3);
   assert.equal(tagMatches.length, expectedTagCount, 'tag query should locate all tagged items');
   assert.ok(tagMatches.every(it => (it.tags || []).includes(markerTag)), 'query results should include the marker tag');


### PR DESCRIPTION
## Summary
- refresh list subtabs with a color-coded design and add sort controls with direction toggles
- enforce single-block expansion in the list view and align item accent colors
- extend storage sorting logic for new sort orders and cover them with updated tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1aea62a648322bc3a20f205abfe0c