### PR TITLE
Revamp curriculum tagging and media uploads

### DIFF
--- a/js/ui/components/media-upload.js
+++ b/js/ui/components/media-upload.js
@@ -1,0 +1,409 @@
+const DEFAULT_FRAME_WIDTH = 520;
+
+function clamp(value, min, max) {
+  if (Number.isNaN(value)) return min;
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}
+
+function sanitizeAspectRatio(ratio) {
+  if (!Number.isFinite(ratio) || ratio <= 0) return 1;
+  return clamp(ratio, 0.25, 4);
+}
+
+function toDataUrl(canvas, mimeType, quality) {
+  try {
+    return canvas.toDataURL(mimeType, quality);
+  } catch (err) {
+    console.error('Failed to export canvas', err);
+    return canvas.toDataURL();
+  }
+}
+
+export function cropImageFile(file) {
+  if (!(file instanceof File) || !file.type?.startsWith('image/')) {
+    return Promise.reject(new Error('File must be an image.'));
+  }
+
+  return new Promise((resolve, reject) => {
+    const objectUrl = URL.createObjectURL(file);
+    const image = new Image();
+    image.onload = () => {
+      URL.revokeObjectURL(objectUrl);
+      try {
+        openCropDialog({ image, file }).then(resolve).catch(reject);
+      } catch (err) {
+        reject(err);
+      }
+    };
+    image.onerror = () => {
+      URL.revokeObjectURL(objectUrl);
+      reject(new Error('Failed to load image file.'));
+    };
+    image.src = objectUrl;
+  });
+}
+
+function openCropDialog({ image, file }) {
+  return new Promise((resolve) => {
+    const overlay = document.createElement('div');
+    overlay.className = 'media-cropper-overlay';
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-modal', 'true');
+
+    const dialog = document.createElement('div');
+    dialog.className = 'media-cropper-dialog';
+    overlay.appendChild(dialog);
+
+    const header = document.createElement('header');
+    header.className = 'media-cropper-header';
+    const title = document.createElement('h3');
+    title.textContent = 'Upload image';
+    header.appendChild(title);
+    const closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.className = 'icon-btn ghost media-cropper-close';
+    closeBtn.title = 'Cancel';
+    closeBtn.textContent = '✕';
+    header.appendChild(closeBtn);
+    dialog.appendChild(header);
+
+    const body = document.createElement('div');
+    body.className = 'media-cropper-body';
+    dialog.appendChild(body);
+
+    const preview = document.createElement('div');
+    preview.className = 'media-cropper-preview';
+    const canvas = document.createElement('canvas');
+    canvas.width = DEFAULT_FRAME_WIDTH;
+    canvas.height = Math.round(DEFAULT_FRAME_WIDTH * 0.75);
+    preview.appendChild(canvas);
+    body.appendChild(preview);
+
+    const controls = document.createElement('div');
+    controls.className = 'media-cropper-controls';
+    body.appendChild(controls);
+
+    const ratioRow = document.createElement('div');
+    ratioRow.className = 'media-cropper-row';
+    const ratioLabel = document.createElement('label');
+    ratioLabel.textContent = 'Aspect ratio';
+    const ratioSelect = document.createElement('select');
+    ratioSelect.className = 'media-cropper-select';
+    const naturalRatio = sanitizeAspectRatio(image.naturalWidth / image.naturalHeight || 1);
+    const ratioOptions = [
+      { value: 'original', label: 'Original', ratio: naturalRatio },
+      { value: '1:1', label: 'Square', ratio: 1 },
+      { value: '4:3', label: '4 : 3', ratio: 4 / 3 },
+      { value: '3:4', label: '3 : 4', ratio: 3 / 4 },
+      { value: '16:9', label: '16 : 9', ratio: 16 / 9 }
+    ];
+    ratioOptions.forEach(opt => {
+      const option = document.createElement('option');
+      option.value = opt.value;
+      option.textContent = opt.label;
+      ratioSelect.appendChild(option);
+    });
+    ratioSelect.value = 'original';
+    ratioLabel.appendChild(ratioSelect);
+    ratioRow.appendChild(ratioLabel);
+    controls.appendChild(ratioRow);
+
+    const zoomRow = document.createElement('div');
+    zoomRow.className = 'media-cropper-row media-cropper-zoom';
+    const zoomLabel = document.createElement('span');
+    zoomLabel.textContent = 'Zoom';
+    zoomRow.appendChild(zoomLabel);
+    const zoomRange = document.createElement('input');
+    zoomRange.type = 'range';
+    zoomRange.min = '1';
+    zoomRange.max = '3';
+    zoomRange.step = '0.01';
+    zoomRange.value = '1';
+    zoomRange.className = 'media-cropper-zoom-range';
+    zoomRow.appendChild(zoomRange);
+    const zoomValue = document.createElement('span');
+    zoomValue.className = 'media-cropper-zoom-value';
+    zoomValue.textContent = '100%';
+    zoomRow.appendChild(zoomValue);
+    controls.appendChild(zoomRow);
+
+    const sizeRow = document.createElement('div');
+    sizeRow.className = 'media-cropper-row';
+    const widthLabel = document.createElement('label');
+    widthLabel.textContent = 'Output width';
+    const widthInput = document.createElement('input');
+    widthInput.type = 'number';
+    widthInput.min = '64';
+    widthInput.max = String(Math.max(64, Math.round(image.naturalWidth) || 1024));
+    widthInput.value = String(Math.min(960, Math.round(image.naturalWidth) || 960));
+    widthInput.className = 'media-cropper-size-input';
+    widthLabel.appendChild(widthInput);
+    sizeRow.appendChild(widthLabel);
+    const dimensions = document.createElement('span');
+    dimensions.className = 'media-cropper-dimensions';
+    dimensions.textContent = '×';
+    sizeRow.appendChild(dimensions);
+    controls.appendChild(sizeRow);
+
+    const altRow = document.createElement('div');
+    altRow.className = 'media-cropper-row';
+    const altLabel = document.createElement('label');
+    altLabel.textContent = 'Alt text';
+    const altInput = document.createElement('input');
+    altInput.type = 'text';
+    altInput.placeholder = 'Describe the image';
+    altInput.value = (file.name || '').replace(/\.[^.]+$/, '').replace(/[_-]+/g, ' ').trim();
+    altInput.className = 'media-cropper-alt-input';
+    altLabel.appendChild(altInput);
+    altRow.appendChild(altLabel);
+    controls.appendChild(altRow);
+
+    const actions = document.createElement('div');
+    actions.className = 'media-cropper-actions';
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.className = 'btn subtle';
+    cancelBtn.textContent = 'Cancel';
+    const confirmBtn = document.createElement('button');
+    confirmBtn.type = 'button';
+    confirmBtn.className = 'btn';
+    confirmBtn.textContent = 'Insert image';
+    actions.appendChild(cancelBtn);
+    actions.appendChild(confirmBtn);
+    dialog.appendChild(actions);
+
+    document.body.appendChild(overlay);
+
+    const ctx = canvas.getContext('2d');
+    ctx.imageSmoothingQuality = 'high';
+
+    let aspectRatio = naturalRatio;
+    let frameWidth = DEFAULT_FRAME_WIDTH;
+    let frameHeight = Math.max(120, Math.round(frameWidth / aspectRatio));
+    let minZoom = 1;
+    let zoom = 1;
+    let offsetX = 0;
+    let offsetY = 0;
+    let dragging = false;
+    let dragStartX = 0;
+    let dragStartY = 0;
+    let dragOffsetX = 0;
+    let dragOffsetY = 0;
+
+    function focusDefault() {
+      requestAnimationFrame(() => {
+        altInput.focus({ preventScroll: true });
+      });
+    }
+
+    function updateCanvasSize() {
+      frameHeight = Math.max(120, Math.round(frameWidth / aspectRatio));
+      canvas.width = frameWidth;
+      canvas.height = frameHeight;
+      updateZoomBounds();
+    }
+
+    function updateZoomBounds() {
+      const widthRatio = frameWidth / (image.naturalWidth || image.width || 1);
+      const heightRatio = frameHeight / (image.naturalHeight || image.height || 1);
+      const nextMin = sanitizeAspectRatio(Math.max(widthRatio, heightRatio));
+      minZoom = nextMin;
+      if (!Number.isFinite(zoom) || zoom < minZoom) {
+        zoom = minZoom;
+      }
+      zoomRange.min = String(Math.max(0.1, minZoom));
+      zoomRange.max = String(Math.max(minZoom * 4, minZoom + 0.5));
+      if (Number(zoomRange.value) < minZoom) {
+        zoomRange.value = String(minZoom);
+      }
+      render();
+    }
+
+    function clampOffsets() {
+      const scaledWidth = (image.naturalWidth || image.width || frameWidth) * zoom;
+      const scaledHeight = (image.naturalHeight || image.height || frameHeight) * zoom;
+      const maxOffsetX = Math.max(0, (scaledWidth - frameWidth) / 2);
+      const maxOffsetY = Math.max(0, (scaledHeight - frameHeight) / 2);
+      offsetX = clamp(offsetX, -maxOffsetX, maxOffsetX);
+      offsetY = clamp(offsetY, -maxOffsetY, maxOffsetY);
+    }
+
+    function getOutputWidth() {
+      const raw = Number(widthInput.value);
+      const maxWidth = Math.max(64, Math.round(image.naturalWidth) || 1024);
+      if (!Number.isFinite(raw)) return Math.min(maxWidth, 960);
+      return clamp(Math.round(raw), 64, maxWidth);
+    }
+
+    function updateMeta() {
+      const zoomPercent = Math.round((zoom / minZoom) * 100);
+      zoomValue.textContent = `${zoomPercent}%`;
+      const outWidth = getOutputWidth();
+      const outHeight = Math.max(1, Math.round(outWidth / aspectRatio));
+      dimensions.textContent = `${outWidth} × ${outHeight}`;
+    }
+
+    function render() {
+      clampOffsets();
+      ctx.fillStyle = 'rgba(15, 23, 42, 0.88)';
+      ctx.fillRect(0, 0, frameWidth, frameHeight);
+      const drawWidth = (image.naturalWidth || image.width || frameWidth) * zoom;
+      const drawHeight = (image.naturalHeight || image.height || frameHeight) * zoom;
+      const originX = (frameWidth - drawWidth) / 2 + offsetX;
+      const originY = (frameHeight - drawHeight) / 2 + offsetY;
+      ctx.save();
+      ctx.imageSmoothingEnabled = true;
+      ctx.imageSmoothingQuality = 'high';
+      ctx.drawImage(image, originX, originY, drawWidth, drawHeight);
+      ctx.restore();
+      ctx.strokeStyle = 'rgba(148, 163, 184, 0.65)';
+      ctx.lineWidth = 1;
+      ctx.strokeRect(0.5, 0.5, frameWidth - 1, frameHeight - 1);
+      updateMeta();
+    }
+
+    function closeDialog(result) {
+      window.removeEventListener('keydown', onKeyDown, true);
+      overlay.remove();
+      resolve(result || null);
+    }
+
+    function onKeyDown(event) {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closeDialog(null);
+      }
+    }
+
+    ratioSelect.addEventListener('change', () => {
+      const selected = ratioOptions.find(opt => opt.value === ratioSelect.value);
+      aspectRatio = sanitizeAspectRatio(selected ? selected.ratio : naturalRatio);
+      updateCanvasSize();
+      render();
+    });
+
+    zoomRange.addEventListener('input', () => {
+      const next = Number(zoomRange.value);
+      if (!Number.isFinite(next)) return;
+      const previous = zoom;
+      zoom = Math.max(minZoom, next);
+      if (previous > 0) {
+        const scale = zoom / previous;
+        offsetX *= scale;
+        offsetY *= scale;
+      }
+      render();
+    });
+
+    widthInput.addEventListener('input', () => updateMeta());
+
+    let activePointerId = null;
+    canvas.style.touchAction = 'none';
+
+    canvas.addEventListener('pointerdown', (event) => {
+      activePointerId = event.pointerId;
+      dragging = true;
+      dragStartX = event.clientX;
+      dragStartY = event.clientY;
+      dragOffsetX = offsetX;
+      dragOffsetY = offsetY;
+      canvas.classList.add('dragging');
+      try {
+        canvas.setPointerCapture(event.pointerId);
+      } catch (err) {
+        // Ignore failures on browsers that do not support pointer capture.
+      }
+    });
+
+    const handlePointerEnd = (event) => {
+      if (activePointerId !== null && event.pointerId !== activePointerId) return;
+      dragging = false;
+      canvas.classList.remove('dragging');
+      try {
+        canvas.releasePointerCapture(event.pointerId);
+      } catch (err) {
+        // Ignore
+      }
+      activePointerId = null;
+    };
+
+    canvas.addEventListener('pointerup', handlePointerEnd);
+    canvas.addEventListener('pointerleave', handlePointerEnd);
+
+    canvas.addEventListener('pointermove', (event) => {
+      if (!dragging) return;
+      const dx = event.clientX - dragStartX;
+      const dy = event.clientY - dragStartY;
+      offsetX = dragOffsetX + dx;
+      offsetY = dragOffsetY + dy;
+      render();
+    });
+
+    cancelBtn.addEventListener('click', () => closeDialog(null));
+    closeBtn.addEventListener('click', () => closeDialog(null));
+
+    confirmBtn.addEventListener('click', () => {
+      const exportCanvas = document.createElement('canvas');
+      const outWidth = getOutputWidth();
+      const outHeight = Math.max(1, Math.round(outWidth / aspectRatio));
+      exportCanvas.width = outWidth;
+      exportCanvas.height = outHeight;
+      const exportCtx = exportCanvas.getContext('2d');
+      exportCtx.imageSmoothingEnabled = true;
+      exportCtx.imageSmoothingQuality = 'high';
+
+      const drawWidth = (image.naturalWidth || image.width || outWidth) * zoom;
+      const drawHeight = (image.naturalHeight || image.height || outHeight) * zoom;
+      const originX = (frameWidth - drawWidth) / 2 + offsetX;
+      const originY = (frameHeight - drawHeight) / 2 + offsetY;
+      const cropX = clamp(-originX / zoom, 0, image.naturalWidth || image.width || outWidth);
+      const cropY = clamp(-originY / zoom, 0, image.naturalHeight || image.height || outHeight);
+      const cropWidth = Math.min((frameWidth) / zoom, (image.naturalWidth || image.width || outWidth));
+      const cropHeight = Math.min((frameHeight) / zoom, (image.naturalHeight || image.height || outHeight));
+
+      exportCtx.drawImage(
+        image,
+        cropX,
+        cropY,
+        cropWidth,
+        cropHeight,
+        0,
+        0,
+        exportCanvas.width,
+        exportCanvas.height
+      );
+
+      const mime = /^image\/jpe?g$/i.test(file.type) ? 'image/jpeg' : 'image/png';
+      const quality = mime === 'image/jpeg' ? 0.92 : undefined;
+      const dataUrl = toDataUrl(exportCanvas, mime, quality);
+      const altText = altInput.value.trim();
+      closeDialog({
+        dataUrl,
+        width: exportCanvas.width,
+        height: exportCanvas.height,
+        mimeType: mime,
+        altText
+      });
+    });
+
+    window.addEventListener('keydown', onKeyDown, true);
+    updateCanvasSize();
+    render();
+    focusDefault();
+  });
+}
+
+export function readFileAsDataUrl(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = () => reject(reader.error || new Error('Failed to read file.'));
+    try {
+      reader.readAsDataURL(file);
+    } catch (err) {
+      reject(err);
+    }
+  });
+}

--- a/style.css
+++ b/style.css
@@ -1255,10 +1255,14 @@ input[type="checkbox"]:checked::after {
   display: flex;
   flex-direction: column;
   gap: var(--pad);
-  min-height: 320px;
-  max-height: clamp(420px, 62vh, 680px);
-  overflow: hidden;
   flex: 1 1 auto;
+}
+
+.editor-tags-description {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  line-height: 1.4;
 }
 
 .editor-tags-title {
@@ -1273,13 +1277,66 @@ input[type="checkbox"]:checked::after {
   gap: 8px;
 }
 
+.editor-manual-weeks {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: var(--radius);
+  border: 1px dashed rgba(148, 163, 184, 0.32);
+  background: rgba(15, 23, 42, 0.4);
+}
+
+.editor-manual-weeks.empty {
+  border-style: solid;
+  border-color: rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.28);
+}
+
+.editor-manual-weeks-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.editor-manual-weeks-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.editor-manual-weeks-empty {
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.65);
+}
+
+.editor-manual-week-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(191, 219, 254, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  font-size: 0.82rem;
+  color: var(--text);
+}
+
+.editor-manual-week-chip .icon-btn {
+  font-size: 0.75rem;
+  width: 20px;
+  height: 20px;
+  line-height: 1;
+  color: rgba(226, 232, 240, 0.8);
+}
+
 .editor-block-panels {
   display: flex;
   flex-direction: column;
   gap: var(--pad-sm);
-  overflow-y: auto;
-  padding-right: 6px;
-  flex: 1;
 }
 
 .editor-block-panel {
@@ -1291,13 +1348,26 @@ input[type="checkbox"]:checked::after {
   border: 1px solid rgba(148, 163, 184, 0.22);
   background: rgba(8, 13, 23, 0.65);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.editor-block-panel.active {
+  border-color: rgba(96, 165, 250, 0.55);
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.72), rgba(56, 189, 248, 0.18));
+  box-shadow: 0 18px 28px rgba(15, 23, 42, 0.4);
 }
 
 .editor-block-panel-header {
   display: flex;
-  align-items: baseline;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 12px;
+}
+
+.editor-block-panel-title {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
 .editor-block-panel-header h4 {
@@ -1310,6 +1380,17 @@ input[type="checkbox"]:checked::after {
 .editor-block-meta {
   font-size: 0.8rem;
   color: var(--text-muted);
+}
+
+.editor-block-selected-count {
+  align-self: center;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: rgba(191, 219, 254, 0.9);
+  background: rgba(59, 130, 246, 0.22);
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(96, 165, 250, 0.32);
 }
 
 .editor-week-list {
@@ -1335,15 +1416,39 @@ input[type="checkbox"]:checked::after {
   background: linear-gradient(140deg, rgba(15, 23, 42, 0.75), rgba(56, 189, 248, 0.24));
 }
 
+.editor-week-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.editor-week-header span:first-child {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.editor-week-count {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.editor-week-manual {
+  margin-left: auto;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: rgba(96, 165, 250, 0.9);
+  background: rgba(56, 189, 248, 0.16);
+  padding: 3px 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(56, 189, 248, 0.32);
+}
+
 .editor-lecture-list {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
   padding-left: 4px;
-}
-
-.editor-lecture-list.collapsed {
-  display: none;
 }
 
 .editor-tags-empty {
@@ -1355,6 +1460,131 @@ input[type="checkbox"]:checked::after {
 .editor-tags-empty.subtle {
   color: rgba(248, 250, 252, 0.6);
   font-style: italic;
+}
+
+.media-cropper-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.78);
+  backdrop-filter: blur(6px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 1050;
+}
+
+.media-cropper-dialog {
+  width: min(640px, 100%);
+  background: rgba(8, 13, 23, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 24px 48px rgba(2, 6, 23, 0.55);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.media-cropper-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.media-cropper-header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--text);
+}
+
+.media-cropper-close {
+  font-size: 1.1rem;
+}
+
+.media-cropper-body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.media-cropper-preview {
+  border-radius: var(--radius);
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  background: rgba(15, 23, 42, 0.65);
+  padding: 12px;
+  display: flex;
+  justify-content: center;
+}
+
+.media-cropper-preview canvas {
+  max-width: 100%;
+  border-radius: var(--radius-sm);
+  cursor: grab;
+}
+
+.media-cropper-preview canvas.dragging {
+  cursor: grabbing;
+}
+
+.media-cropper-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.media-cropper-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.media-cropper-row label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--text);
+}
+
+.media-cropper-select,
+.media-cropper-size-input,
+.media-cropper-alt-input {
+  background: rgba(15, 23, 42, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  padding: 6px 10px;
+  min-width: 120px;
+}
+
+.media-cropper-zoom {
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+.media-cropper-zoom-range {
+  flex: 1;
+}
+
+.media-cropper-zoom-value {
+  min-width: 48px;
+  text-align: right;
+}
+
+.media-cropper-dimensions {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.media-cropper-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
 }
 
 .tag-chip {
@@ -1374,10 +1604,11 @@ input[type="checkbox"]:checked::after {
 }
 
 .tag-chip.active {
-  color: #041021;
-  border-color: transparent;
+  background: rgba(255, 255, 255, 0.96);
+  color: #020a16;
+  border-color: rgba(15, 23, 42, 0.18);
   font-weight: 600;
-  box-shadow: 0 14px 28px rgba(2, 6, 23, 0.38);
+  box-shadow: 0 14px 28px rgba(15, 23, 42, 0.36);
 }
 
 .tag-chip-block {
@@ -1386,7 +1617,9 @@ input[type="checkbox"]:checked::after {
 }
 
 .tag-chip-block.active {
-  background: linear-gradient(135deg, rgba(192, 132, 252, 0.96), rgba(59, 130, 246, 0.94));
+  background: rgba(255, 255, 255, 0.96);
+  color: #020a16;
+  border-color: rgba(15, 23, 42, 0.18);
 }
 
 .tag-chip-week {
@@ -1395,7 +1628,9 @@ input[type="checkbox"]:checked::after {
 }
 
 .tag-chip-week.active {
-  background: linear-gradient(135deg, rgba(56, 189, 248, 0.95), rgba(129, 140, 248, 0.9));
+  background: rgba(255, 255, 255, 0.96);
+  color: #020a16;
+  border-color: rgba(15, 23, 42, 0.18);
 }
 
 .tag-chip-lecture {
@@ -1412,14 +1647,14 @@ input[type="checkbox"]:checked::after {
 }
 
 .tag-chip-lecture.active {
-  background: linear-gradient(135deg, rgba(56, 189, 248, 0.96), rgba(99, 102, 241, 0.9));
+  background: rgba(255, 255, 255, 0.96);
   color: #041021;
-  border-color: transparent;
-  box-shadow: 0 16px 32px rgba(56, 189, 248, 0.32);
+  border-color: rgba(15, 23, 42, 0.18);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.32);
 }
 
 .tag-chip-lecture.active:is(:hover, :focus-visible) {
-  background: linear-gradient(135deg, rgba(79, 209, 255, 0.98), rgba(129, 140, 248, 0.94));
+  background: rgba(255, 255, 255, 0.98);
   color: #020a16;
 }
 


### PR DESCRIPTION
## Summary
- redesign the curriculum tagging section with inline block panels, manual week controls, and automatic block/week tracking
- add a media cropper overlay for image uploads and update styling, including white active tag chips
- let the rich text editor upload/crop images and upload audio/video files while preserving native Tab navigation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1b6f6111c8322ac7f069229079916