### PR TITLE
Adjust builder interactions and autosave UX

### DIFF
--- a/js/state.js
+++ b/js/state.js
@@ -24,7 +24,9 @@ export const state = {
     onlyFav:false,
     manualPicks:[],
     collapsedBlocks:[],
-    collapsedWeeks:[]
+    collapsedWeeks:[],
+    activeBlockId:'',
+    activeWeekKey:''
   },
   cards: {
     collapsedBlocks: [],

--- a/style.css
+++ b/style.css
@@ -1910,6 +1910,12 @@ input[type="checkbox"]:checked::after {
   opacity: 0.8;
 }
 
+.editor-status.editor-status-muted {
+  opacity: 0.5;
+  color: var(--muted-text, var(--gray));
+  transition: opacity 0.3s ease;
+}
+
 .editor-tag-block {
   padding: 8px;
   border-radius: var(--radius-sm);
@@ -2531,41 +2537,43 @@ button.builder-pill:hover {
 }
 
 
-button.builder-pill.active {
-
-  background: linear-gradient(135deg, rgba(125, 211, 252, 0.95), rgba(199, 210, 254, 0.92));
-  color: #0b162d;
+button.builder-pill.active,
+button.builder-pill[data-active="true"] {
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.95), rgba(99, 102, 241, 0.9));
+  color: #041225;
   border-color: transparent;
-  box-shadow: 0 14px 26px rgba(2, 6, 23, 0.32);
-
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.38);
+  font-weight: 600;
 }
 
 button.builder-pill.active:hover,
-button.builder-pill.active:focus-visible {
-  background: linear-gradient(135deg, rgba(148, 226, 255, 0.98), rgba(221, 214, 254, 0.96));
-  color: #061024;
+button.builder-pill.active:focus-visible,
+button.builder-pill[data-active="true"]:hover,
+button.builder-pill[data-active="true"]:focus-visible {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.98), rgba(129, 140, 248, 0.94));
+  color: #020a16;
 }
 
 button.builder-pill.builder-pill-lecture {
-
-  background: rgba(165, 180, 252, 0.16);
-  border-color: rgba(165, 180, 252, 0.32);
+  background: rgba(129, 140, 248, 0.18);
+  border-color: rgba(129, 140, 248, 0.38);
   font-size: 0.9rem;
 }
 
-button.builder-pill.builder-pill-lecture.active {
-
-  background: linear-gradient(135deg, rgba(191, 219, 254, 0.98), rgba(224, 231, 255, 0.96));
+button.builder-pill.builder-pill-lecture.active,
+button.builder-pill.builder-pill-lecture[data-active="true"] {
+  background: linear-gradient(135deg, rgba(129, 140, 248, 0.96), rgba(165, 180, 252, 0.92));
   border-color: transparent;
-  color: #0a1530;
-  box-shadow: 0 10px 22px rgba(15, 23, 42, 0.38);
-
+  color: #050d1f;
+  box-shadow: 0 14px 26px rgba(30, 41, 59, 0.4);
 }
 
 button.builder-pill.builder-pill-lecture.active:hover,
-button.builder-pill.builder-pill-lecture.active:focus-visible {
-  background: linear-gradient(135deg, rgba(221, 231, 255, 0.99), rgba(210, 221, 255, 0.97));
-  color: #050d1f;
+button.builder-pill.builder-pill-lecture.active:focus-visible,
+button.builder-pill.builder-pill-lecture[data-active="true"]:hover,
+button.builder-pill.builder-pill-lecture[data-active="true"]:focus-visible {
+  background: linear-gradient(135deg, rgba(165, 180, 252, 0.99), rgba(191, 219, 254, 0.97));
+  color: #040b1a;
 }
 
 button.builder-pill.builder-pill-small {


### PR DESCRIPTION
## Summary
- highlight builder lecture pills with a more distinct active gradient that also responds to toggle data attributes
- auto-collapse study builder blocks and weeks by tracking the active block/week, and render newer weeks first
- soften editor autosave updates by muting the status indicator and avoiding heavy refresh callbacks during silent saves

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1bf5b16408322841415e70611b458