### PR TITLE
Revamp curriculum tagging and media workflows

### DIFF
--- a/style.css
+++ b/style.css
@@ -1285,6 +1285,7 @@ input[type="checkbox"]:checked::after {
   border-radius: var(--radius);
   border: 1px dashed rgba(148, 163, 184, 0.32);
   background: rgba(15, 23, 42, 0.4);
+  width: 100%;
 }
 
 .editor-manual-weeks.empty {
@@ -1333,87 +1334,213 @@ input[type="checkbox"]:checked::after {
   color: rgba(226, 232, 240, 0.8);
 }
 
-.editor-block-panels {
-  display: flex;
-  flex-direction: column;
-  gap: var(--pad-sm);
+.editor-curriculum-browser {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--pad);
+  margin-top: var(--pad);
 }
 
-.editor-block-panel {
+.editor-curriculum-column {
   display: flex;
   flex-direction: column;
   gap: var(--pad-sm);
-  padding: var(--pad-sm);
+  padding: var(--pad);
   border-radius: var(--radius);
-  border: 1px solid rgba(148, 163, 184, 0.22);
+  border: 1px solid rgba(148, 163, 184, 0.2);
   background: rgba(8, 13, 23, 0.65);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  min-height: 220px;
 }
 
-.editor-block-panel.active {
-  border-color: rgba(96, 165, 250, 0.55);
-  background: linear-gradient(145deg, rgba(15, 23, 42, 0.72), rgba(56, 189, 248, 0.18));
-  box-shadow: 0 18px 28px rgba(15, 23, 42, 0.4);
-}
-
-.editor-block-panel-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.editor-block-panel-title {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.editor-block-panel-header h4 {
+.editor-column-heading {
   margin: 0;
   font-size: 0.95rem;
   font-weight: 600;
+  letter-spacing: 0.01em;
   color: var(--text);
 }
 
-.editor-block-meta {
-  font-size: 0.8rem;
-  color: var(--text-muted);
-}
-
-.editor-block-selected-count {
-  align-self: center;
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: rgba(191, 219, 254, 0.9);
-  background: rgba(59, 130, 246, 0.22);
-  padding: 4px 10px;
-  border-radius: 999px;
-  border: 1px solid rgba(96, 165, 250, 0.32);
-}
-
-.editor-week-list {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.editor-week-section {
+.editor-block-list,
+.editor-week-browser {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 10px 12px;
-  border-radius: var(--radius);
-  border: 1px solid rgba(148, 163, 184, 0.22);
-  background: rgba(15, 23, 42, 0.45);
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.editor-week-section.active {
-  border-color: rgba(56, 189, 248, 0.6);
-  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.35);
-  background: linear-gradient(140deg, rgba(15, 23, 42, 0.75), rgba(56, 189, 248, 0.24));
+.editor-lecture-browser {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.editor-block-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.editor-block-button {
+  flex: 1;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(8, 13, 23, 0.5);
+  color: var(--text-muted);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.15s ease;
+}
+
+.editor-block-button:hover,
+.editor-block-button:focus-visible {
+  background: rgba(30, 64, 175, 0.35);
+  border-color: rgba(56, 189, 248, 0.45);
+  color: var(--text);
+  outline: none;
+}
+
+.editor-block-button.active {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.9), rgba(129, 140, 248, 0.85));
+  color: #020617;
+  border-color: transparent;
+  box-shadow: 0 18px 32px rgba(2, 6, 23, 0.42);
+}
+
+.editor-block-row.has-lectures .editor-block-button {
+  border-color: rgba(56, 189, 248, 0.45);
+  color: var(--text);
+}
+
+.editor-block-row.tagged .editor-block-button {
+  box-shadow: inset 0 0 0 1px rgba(192, 132, 252, 0.4);
+}
+
+.editor-block-label {
+  flex: 1;
+  text-align: left;
+}
+
+.editor-block-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: rgba(56, 189, 248, 0.25);
+  color: var(--text);
+}
+
+.editor-block-button.active .editor-block-count {
+  background: rgba(15, 23, 42, 0.18);
+  color: #020617;
+}
+
+.editor-block-tag-toggle {
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.editor-block-tag-toggle:hover,
+.editor-block-tag-toggle:focus-visible {
+  color: var(--text);
+  border-color: rgba(192, 132, 252, 0.55);
+  outline: none;
+}
+
+.editor-block-tag-toggle.active {
+  background: linear-gradient(135deg, rgba(192, 132, 252, 0.92), rgba(56, 189, 248, 0.9));
+  color: #020617;
+  border-color: transparent;
+  box-shadow: 0 12px 24px rgba(2, 6, 23, 0.35);
+}
+
+.editor-week-button {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(8, 13, 23, 0.5);
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.editor-week-button:hover,
+.editor-week-button:focus-visible {
+  background: rgba(30, 64, 175, 0.35);
+  border-color: rgba(56, 189, 248, 0.45);
+  color: var(--text);
+  outline: none;
+}
+
+.editor-week-button.active {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.8), rgba(129, 140, 248, 0.75));
+  color: #020617;
+  border-color: transparent;
+  box-shadow: 0 12px 24px rgba(2, 6, 23, 0.32);
+}
+
+.editor-week-button.has-selection {
+  border-color: rgba(56, 189, 248, 0.5);
+  color: var(--text);
+}
+
+.editor-week-button.manual {
+  box-shadow: inset 0 0 0 2px rgba(250, 204, 21, 0.45);
+}
+
+.editor-week-label {
+  font-weight: 600;
+}
+
+.editor-week-meta {
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.editor-lecture-button {
+  padding: 6px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(8, 13, 23, 0.5);
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.15s ease;
+}
+
+.editor-lecture-button:hover,
+.editor-lecture-button:focus-visible {
+  background: rgba(30, 64, 175, 0.35);
+  border-color: rgba(56, 189, 248, 0.45);
+  color: var(--text);
+  outline: none;
+}
+
+.editor-lecture-button.active {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.9), rgba(192, 132, 252, 0.88));
+  color: #020617;
+  border-color: transparent;
+  box-shadow: 0 10px 22px rgba(2, 6, 23, 0.32);
 }
 
 .editor-week-header {
@@ -1710,6 +1837,7 @@ input[type="checkbox"]:checked::after {
 }
 
 .rich-editor {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -1885,6 +2013,120 @@ input[type="checkbox"]:checked::after {
 .rich-editor-area:focus {
   outline: 2px solid var(--blue);
   outline-offset: 2px;
+}
+
+.rich-editor-image-active {
+  outline: 2px solid rgba(56, 189, 248, 0.55);
+  outline-offset: 2px;
+}
+
+.rich-editor-image-overlay {
+  position: absolute;
+  pointer-events: none;
+  border: 2px solid rgba(56, 189, 248, 0.75);
+  border-radius: var(--radius);
+  box-shadow: 0 0 0 1px rgba(14, 165, 233, 0.4), 0 12px 24px rgba(2, 6, 23, 0.4);
+  z-index: 25;
+}
+
+.rich-editor-image-overlay.is-resizing {
+  box-shadow: 0 0 0 2px rgba(14, 165, 233, 0.55), 0 16px 28px rgba(2, 6, 23, 0.45);
+}
+
+.rich-editor-image-overlay .rich-editor-image-handle,
+.rich-editor-image-overlay .rich-editor-image-tool {
+  pointer-events: auto;
+}
+
+.rich-editor-image-toolbar {
+  position: absolute;
+  top: -42px;
+  right: 8px;
+  display: inline-flex;
+  gap: 6px;
+  padding: 6px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.92);
+  box-shadow: 0 12px 24px rgba(2, 6, 23, 0.45);
+}
+
+.rich-editor-image-tool {
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: var(--radius-sm);
+  background: rgba(8, 13, 23, 0.85);
+  color: var(--text);
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 4px 10px;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.rich-editor-image-tool:hover,
+.rich-editor-image-tool:focus-visible {
+  border-color: rgba(56, 189, 248, 0.45);
+  color: var(--text);
+  background: rgba(15, 23, 42, 0.7);
+  outline: none;
+}
+
+.rich-editor-image-tool--primary {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.88), rgba(192, 132, 252, 0.82));
+  color: #020617;
+  border-color: transparent;
+  box-shadow: 0 12px 24px rgba(2, 6, 23, 0.45);
+}
+
+.rich-editor-image-tool--primary:hover,
+.rich-editor-image-tool--primary:focus-visible {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.95), rgba(192, 132, 252, 0.9));
+}
+
+.rich-editor-image-handle {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid rgba(15, 23, 42, 0.85);
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.92), rgba(129, 140, 248, 0.88));
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.4);
+  transition: transform 0.15s ease;
+}
+
+.rich-editor-image-handle--se {
+  right: -6px;
+  bottom: -6px;
+  cursor: nwse-resize;
+}
+
+.rich-editor-image-handle--e {
+  right: -6px;
+  top: 50%;
+  transform: translateY(-50%);
+  cursor: ew-resize;
+}
+
+.rich-editor-image-handle--s {
+  left: 50%;
+  bottom: -6px;
+  transform: translateX(-50%);
+  cursor: ns-resize;
+}
+
+.rich-editor-image-handle--e:hover,
+.rich-editor-image-handle--e:focus-visible {
+  transform: translateY(-50%) scale(1.1);
+}
+
+.rich-editor-image-handle--s:hover,
+.rich-editor-image-handle--s:focus-visible {
+  transform: translateX(-50%) scale(1.1);
+}
+
+.rich-editor-image-handle--se:hover,
+.rich-editor-image-handle--se:focus-visible {
+  transform: scale(1.1);
 }
 
 .editor-form textarea.input {
@@ -2920,6 +3162,43 @@ button.builder-pill.builder-pill-outline {
   background: rgba(15, 23, 42, 0.35);
   border: 1px solid var(--border);
   border-radius: var(--radius);
+}
+
+.entry-filter-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-end;
+  margin-right: auto;
+}
+
+.entry-filter-select {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.entry-filter-select select {
+  background: rgba(15, 23, 42, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  padding: 6px 10px;
+  min-width: 150px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.entry-filter-select select:focus-visible {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.55);
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.25);
+}
+
+.entry-filter-select select:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
 }
 
 .sort-controls {


### PR DESCRIPTION
## Summary
- redesign the curriculum tagging UI around a three-column browser for blocks, weeks, and lectures with updated state handling
- add block and week filters to the entries toolbar so lists can be narrowed before sorting
- enhance the rich text editor image tools with replace/crop flows, resize handles, and updated upload handling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1c55423148322904c920b740c00a7