### PR TITLE
Improve question map review indicators and scroll retention

### DIFF
--- a/js/ui/components/exams.js
+++ b/js/ui/components/exams.js
@@ -870,14 +870,15 @@ function renderPalette(sidebar, sess, render) {
     const answered = answer != null && question.options.some(opt => opt.id === answer);
 
     const tooltipParts = [];
+    let status = 'unanswered';
 
     if (isReview) {
       if (answered) {
         const isCorrect = answer === question.answer;
-        btn.classList.add(isCorrect ? 'correct' : 'incorrect');
+        status = isCorrect ? 'correct' : 'incorrect';
         tooltipParts.push(isCorrect ? 'Answered correctly' : 'Answered incorrectly');
       } else {
-        btn.classList.add('unanswered', 'review-unanswered');
+        status = 'review-unanswered';
         tooltipParts.push('Not answered');
       }
 
@@ -896,14 +897,31 @@ function renderPalette(sidebar, sess, render) {
         }
         tooltipParts.push(changeTitle);
       }
-    } else if (answered) {
+    } else {
+      status = answered ? 'answered' : 'unanswered';
+      tooltipParts.push(answered ? 'Answered' : 'Not answered');
+    }
+
+    if (status === 'correct') {
+      btn.classList.add('correct');
+    } else if (status === 'incorrect') {
+      btn.classList.add('incorrect');
+    } else if (status === 'answered') {
       btn.classList.add('answered');
-      tooltipParts.push('Answered');
+    } else if (status === 'review-unanswered') {
+      btn.classList.add('unanswered', 'review-unanswered');
     } else {
       btn.classList.add('unanswered');
-      tooltipParts.push('Not answered');
     }
-    if (flaggedSet.has(idx)) btn.classList.add('flagged');
+
+    btn.dataset.status = status;
+
+    if (flaggedSet.has(idx)) {
+      btn.classList.add('flagged');
+      btn.dataset.flagged = 'true';
+    } else {
+      btn.dataset.flagged = 'false';
+    }
     if (tooltipParts.length) {
       btn.title = tooltipParts.join(' · ');
     }
@@ -944,6 +962,11 @@ export function renderExamRunner(root, render) {
     teardownKeyboardNavigation();
     return;
   }
+  const hasWindow = typeof window !== 'undefined';
+  const prevIdx = sess.__lastRenderedIdx;
+  const prevMode = sess.__lastRenderedMode;
+  const prevScrollX = hasWindow ? window.scrollX : 0;
+  const prevScrollY = hasWindow ? window.scrollY : 0;
   root.innerHTML = '';
   root.className = 'exam-session';
 
@@ -1273,6 +1296,24 @@ export function renderExamRunner(root, render) {
   }
 
   root.appendChild(nav);
+
+  const sameQuestion = prevIdx === sess.idx && prevMode === sess.mode;
+  sess.__lastRenderedIdx = sess.idx;
+  sess.__lastRenderedMode = sess.mode;
+  if (hasWindow && typeof window.scrollTo === 'function') {
+    const restore = () => {
+      if (sameQuestion) {
+        window.scrollTo(prevScrollX, prevScrollY);
+      } else {
+        window.scrollTo({ left: 0, top: 0, behavior: 'auto' });
+      }
+    };
+    if (typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(restore);
+    } else {
+      setTimeout(restore, 0);
+    }
+  }
 }
 function renderSidebarMeta(sidebar, sess, changeSummary) {
   const info = document.createElement('div');

--- a/style.css
+++ b/style.css
@@ -5907,32 +5907,39 @@ body.map-toolbox-dragging {
   box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8);
 }
 
-.palette-button.unanswered {
-  background: linear-gradient(135deg, rgba(148, 163, 184, 0.22), rgba(100, 116, 139, 0.28));
-  border-color: rgba(100, 116, 139, 0.35);
-  color: rgba(15, 23, 42, 0.55);
+.palette-button.unanswered,
+.palette-button[data-status='unanswered'] {
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.16), rgba(100, 116, 139, 0.22));
+  border-color: rgba(100, 116, 139, 0.3);
+  color: rgba(15, 23, 42, 0.48);
+  filter: saturate(0.75);
 }
 
-.palette-button.review-unanswered {
-  background: linear-gradient(135deg, rgba(148, 163, 184, 0.18), rgba(71, 85, 105, 0.25));
-  border-color: rgba(71, 85, 105, 0.35);
-  color: rgba(15, 23, 42, 0.5);
+.palette-button.review-unanswered,
+.palette-button[data-status='review-unanswered'] {
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.1), rgba(71, 85, 105, 0.18));
+  border-color: rgba(71, 85, 105, 0.25);
+  color: rgba(15, 23, 42, 0.4);
+  filter: saturate(0.65);
 }
 
-.palette-button.answered {
+.palette-button.answered,
+.palette-button[data-status='answered'] {
   background: linear-gradient(135deg, #dbeafe, #bfdbfe);
   border-color: rgba(59, 130, 246, 0.55);
   color: #0f172a;
 }
 
-.palette-button.correct {
+.palette-button.correct,
+.palette-button[data-status='correct'] {
   background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
   border-color: rgba(34, 197, 94, 0.75);
   color: #022c22;
   box-shadow: inset 0 0 12px rgba(15, 118, 110, 0.15);
 }
 
-.palette-button.incorrect {
+.palette-button.incorrect,
+.palette-button[data-status='incorrect'] {
   background: linear-gradient(135deg, #fb7185 0%, #ef4444 100%);
   border-color: rgba(239, 68, 68, 0.75);
   color: #7f1d1d;
@@ -5956,19 +5963,22 @@ body.map-toolbox-dragging {
   filter: drop-shadow(0 1px 0 rgba(15, 23, 42, 0.2));
 }
 
-.palette-button.flagged.answered {
+.palette-button.flagged.answered,
+.palette-button.flagged[data-status='answered'] {
   background: linear-gradient(135deg, #fef3c7 0%, #fde68a 45%, #bfdbfe 100%);
   border-color: rgba(251, 191, 36, 0.65);
   color: #78350f;
 }
 
-.palette-button.flagged.correct {
+.palette-button.flagged.correct,
+.palette-button.flagged[data-status='correct'] {
   background: linear-gradient(135deg, #fef3c7 0%, #fde68a 35%, #16a34a 100%);
   border-color: rgba(251, 191, 36, 0.65);
   color: #78350f;
 }
 
-.palette-button.flagged.incorrect {
+.palette-button.flagged.incorrect,
+.palette-button.flagged[data-status='incorrect'] {
   background: linear-gradient(135deg, #fef3c7 0%, #fde68a 35%, #ef4444 100%);
   border-color: rgba(251, 191, 36, 0.65);
   color: #78350f;


### PR DESCRIPTION
## Summary
- update exam question map rendering to attach explicit status metadata so review buttons can colorize correctly and flagged states persist
- adjust palette styling so correct/incorrect tiles fill with green/red and unanswered entries are visibly muted, and rebuild the bundle
- restore the reader's scroll position across rerenders to stop the exam view from jumping to the top while scrolling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1e7f9e794832298d136d0facad39a