### PR TITLE
Fix exam palette change detection and colors

### DIFF
--- a/style.css
+++ b/style.css
@@ -5909,44 +5909,48 @@ body.map-toolbox-dragging {
 
 .palette-button.unanswered,
 .palette-button[data-status='unanswered'] {
-  background: linear-gradient(135deg, rgba(148, 163, 184, 0.16), rgba(100, 116, 139, 0.22));
-  border-color: rgba(100, 116, 139, 0.3);
-  color: rgba(15, 23, 42, 0.48);
-  filter: saturate(0.75);
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.12), rgba(100, 116, 139, 0.18));
+  border-color: rgba(100, 116, 139, 0.28);
+  color: rgba(15, 23, 42, 0.45);
+  filter: saturate(0.7);
 }
 
 .palette-button.review-unanswered,
 .palette-button[data-status='review-unanswered'] {
-  background: linear-gradient(135deg, rgba(148, 163, 184, 0.1), rgba(71, 85, 105, 0.18));
-  border-color: rgba(71, 85, 105, 0.25);
-  color: rgba(15, 23, 42, 0.4);
-  filter: saturate(0.65);
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.08), rgba(71, 85, 105, 0.16));
+  border-color: rgba(71, 85, 105, 0.22);
+  color: rgba(15, 23, 42, 0.38);
+  filter: saturate(0.6);
 }
 
 .palette-button.answered,
 .palette-button[data-status='answered'] {
-  background: linear-gradient(135deg, #dbeafe, #bfdbfe);
-  border-color: rgba(59, 130, 246, 0.55);
-  color: #0f172a;
+  background: linear-gradient(135deg, #60a5fa 0%, #2563eb 100%);
+  border-color: rgba(37, 99, 235, 0.75);
+  color: #f8fafc;
+  font-weight: 600;
+  text-shadow: 0 1px 2px rgba(15, 23, 42, 0.25);
 }
 
 .palette-button.correct,
 .palette-button[data-status='correct'] {
-  background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
-  border-color: rgba(34, 197, 94, 0.75);
-  color: #022c22;
-  box-shadow: inset 0 0 12px rgba(15, 118, 110, 0.15);
+  background: linear-gradient(135deg, #16a34a 0%, #15803d 100%);
+  border-color: rgba(22, 163, 74, 0.75);
+  color: #ecfdf5;
+  box-shadow: inset 0 0 0 1px rgba(236, 253, 245, 0.3);
+  text-shadow: 0 1px 2px rgba(4, 47, 46, 0.35);
 }
 
 .palette-button.incorrect,
 .palette-button[data-status='incorrect'] {
-  background: linear-gradient(135deg, #fb7185 0%, #ef4444 100%);
-  border-color: rgba(239, 68, 68, 0.75);
-  color: #7f1d1d;
-  box-shadow: inset 0 0 12px rgba(127, 29, 29, 0.18);
+  background: linear-gradient(135deg, #ef4444 0%, #b91c1c 100%);
+  border-color: rgba(239, 68, 68, 0.8);
+  color: #fee2e2;
+  box-shadow: inset 0 0 0 1px rgba(254, 226, 226, 0.3);
+  text-shadow: 0 1px 2px rgba(76, 5, 25, 0.35);
 }
 
-.palette-button.flagged {
+.palette-button.flagged[data-mode='taking'] {
   background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
   border-color: rgba(250, 204, 21, 0.6);
   color: #854d0e;
@@ -5963,25 +5967,47 @@ body.map-toolbox-dragging {
   filter: drop-shadow(0 1px 0 rgba(15, 23, 42, 0.2));
 }
 
-.palette-button.flagged.answered,
-.palette-button.flagged[data-status='answered'] {
-  background: linear-gradient(135deg, #fef3c7 0%, #fde68a 45%, #bfdbfe 100%);
+
+.palette-button.flagged[data-mode='taking'].answered,
+.palette-button.flagged[data-mode='taking'][data-status='answered'] {
+  background: linear-gradient(135deg, #fef3c7 0%, #fde68a 45%, #60a5fa 100%);
   border-color: rgba(251, 191, 36, 0.65);
   color: #78350f;
 }
 
-.palette-button.flagged.correct,
-.palette-button.flagged[data-status='correct'] {
+.palette-button.flagged[data-mode='taking'].correct,
+.palette-button.flagged[data-mode='taking'][data-status='correct'] {
   background: linear-gradient(135deg, #fef3c7 0%, #fde68a 35%, #16a34a 100%);
   border-color: rgba(251, 191, 36, 0.65);
   color: #78350f;
 }
 
-.palette-button.flagged.incorrect,
-.palette-button.flagged[data-status='incorrect'] {
+.palette-button.flagged[data-mode='taking'].incorrect,
+.palette-button.flagged[data-mode='taking'][data-status='incorrect'] {
   background: linear-gradient(135deg, #fef3c7 0%, #fde68a 35%, #ef4444 100%);
   border-color: rgba(251, 191, 36, 0.65);
   color: #78350f;
+}
+
+.palette-button.flagged[data-mode='review'] {
+  box-shadow: inset 0 0 0 2px rgba(250, 204, 21, 0.45);
+}
+
+.palette-button.flagged[data-mode='review'][data-status='correct'],
+.palette-button.flagged[data-mode='review'][data-status='incorrect'] {
+  color: inherit;
+}
+
+.palette-button[data-mode='taking'][data-status='unanswered'] {
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.06), rgba(100, 116, 139, 0.12));
+  border-color: rgba(100, 116, 139, 0.2);
+  color: rgba(15, 23, 42, 0.32);
+  filter: saturate(0.45);
+  opacity: 0.82;
+}
+
+.palette-button[data-mode='review'][data-status='review-unanswered'] {
+  opacity: 0.85;
 }
 
 .palette-button[data-change-direction]::after {


### PR DESCRIPTION
## Summary
- ignore initial answer selections when summarizing review changes and surface clearer tooltips
- tag palette buttons with the session mode for styling
- refresh palette color treatments so unanswered questions are muted while answered and review states are bold and legible

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1eb7aaf808322b27c2985cf22570a