### PR TITLE
Preserve quiz scroll and enhance question map styling

### DIFF
--- a/js/ui/components/quiz.js
+++ b/js/ui/components/quiz.js
@@ -88,11 +88,23 @@ function renderCompletion(root, session, redraw) {
 
 export function renderQuiz(root, redraw) {
   const session = state.quizSession;
-  if (!session) return;
+  if (!session) {
+    if (root?.dataset) delete root.dataset.questionIdx;
+    return;
+  }
   ensureSessionDefaults(session);
+
+  const hasWindow = typeof window !== 'undefined';
+  const docScroller = typeof document !== 'undefined' ? (document.scrollingElement || document.documentElement) : null;
+  const previousIdxRaw = root?.dataset?.questionIdx;
+  const previousIdx = previousIdxRaw !== undefined && previousIdxRaw !== '' && !Number.isNaN(Number(previousIdxRaw))
+    ? Number(previousIdxRaw)
+    : null;
+  const prevScrollY = hasWindow ? window.scrollY : docScroller ? docScroller.scrollTop : 0;
 
   const pool = Array.isArray(session.pool) ? session.pool : [];
   root.innerHTML = '';
+  if (root?.dataset) delete root.dataset.questionIdx;
 
   if (!pool.length) {
     const empty = document.createElement('div');
@@ -429,6 +441,27 @@ export function renderQuiz(root, redraw) {
   card.appendChild(footer);
 
   updateNavState();
+
+  if (root?.dataset) root.dataset.questionIdx = String(session.idx);
+  const shouldRestore = previousIdx === session.idx;
+  const targetY = shouldRestore ? prevScrollY : 0;
+  const canRestore = hasWindow || docScroller;
+  if (canRestore) {
+    const applyScroll = () => {
+      if (hasWindow && typeof window.scrollTo === 'function') {
+        window.scrollTo({ left: 0, top: targetY, behavior: 'auto' });
+      } else if (docScroller) {
+        docScroller.scrollTop = targetY;
+      }
+    };
+    if (hasWindow && typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(applyScroll);
+    } else if (typeof setTimeout === 'function') {
+      setTimeout(applyScroll, 0);
+    } else {
+      applyScroll();
+    }
+  }
 
   function gradeAnswer() {
     const guess = input.value.trim();

--- a/style.css
+++ b/style.css
@@ -5911,19 +5911,19 @@ body.map-toolbox-dragging {
 .palette-button.unanswered,
 .palette-button[data-status='unanswered'] {
   background: #e2e8f0;
-  border-color: rgba(148, 163, 184, 0.35);
-  color: rgba(15, 23, 42, 0.45);
-  opacity: 0.55;
-  filter: saturate(0.55) brightness(0.96);
+  border-color: rgba(148, 163, 184, 0.45);
+  color: rgba(15, 23, 42, 0.64);
+  opacity: 1;
+  filter: none;
 }
 
 .palette-button.review-unanswered,
 .palette-button[data-status='review-unanswered'] {
   background: #dbe3ef;
-  border-color: rgba(100, 116, 139, 0.28);
-  color: rgba(15, 23, 42, 0.4);
-  opacity: 0.6;
-  filter: saturate(0.5);
+  border-color: rgba(100, 116, 139, 0.34);
+  color: rgba(15, 23, 42, 0.5);
+  opacity: 0.85;
+  filter: none;
 }
 
 .palette-button.answered,
@@ -6009,17 +6009,17 @@ body.map-toolbox-dragging {
 
 .palette-button[data-mode='taking'][data-status='unanswered'] {
   background: #e2e8f0;
-  border-color: rgba(148, 163, 184, 0.3);
-  color: rgba(15, 23, 42, 0.4);
-  filter: saturate(0.45) brightness(0.95);
-  opacity: 0.58;
+  border-color: rgba(148, 163, 184, 0.45);
+  color: rgba(15, 23, 42, 0.64);
+  filter: none;
+  opacity: 1;
 }
 
 .palette-button[data-mode='review'][data-status='review-unanswered'] {
   background: #d8dee8;
-  border-color: rgba(100, 116, 139, 0.3);
-  color: rgba(15, 23, 42, 0.42);
-  opacity: 0.6;
+  border-color: rgba(100, 116, 139, 0.32);
+  color: rgba(15, 23, 42, 0.5);
+  opacity: 0.85;
 }
 
 .palette-button[data-change-direction]::after {


### PR DESCRIPTION
## Summary
- preserve the learner's scroll position on a quiz card so checking answers no longer jumps the view to the top
- refresh question map styling so unanswered buttons stay legible and review states show their green/red feedback
- update the compiled bundle to reflect the quiz logic tweaks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d1f2fc1abc83228bec66561b31777a