### PR TITLE
Improve exam answer tracking and palette styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -5910,20 +5910,20 @@ body.map-toolbox-dragging {
 
 .palette-button.unanswered,
 .palette-button[data-status='unanswered'] {
-  background: #e2e8f0;
-  border-color: rgba(148, 163, 184, 0.45);
-  color: rgba(15, 23, 42, 0.64);
-  opacity: 1;
-  filter: none;
+  background: #e2e8f0 !important;
+  border-color: rgba(148, 163, 184, 0.45) !important;
+  color: rgba(15, 23, 42, 0.58) !important;
+  opacity: 0.55;
+  filter: grayscale(0.35);
 }
 
 .palette-button.review-unanswered,
 .palette-button[data-status='review-unanswered'] {
-  background: #dbe3ef;
-  border-color: rgba(100, 116, 139, 0.34);
-  color: rgba(15, 23, 42, 0.5);
-  opacity: 0.85;
-  filter: none;
+  background: #dbe3ef !important;
+  border-color: rgba(100, 116, 139, 0.34) !important;
+  color: rgba(15, 23, 42, 0.5) !important;
+  opacity: 0.45;
+  filter: grayscale(0.4);
 }
 
 .palette-button.answered,
@@ -5939,10 +5939,10 @@ body.map-toolbox-dragging {
 
 .palette-button.correct,
 .palette-button[data-status='correct'] {
-  background: linear-gradient(135deg, #22c55e 0%, #15803d 100%);
-  border-color: rgba(21, 128, 61, 0.85);
-  color: #f0fdf4;
-  box-shadow: inset 0 0 0 1px rgba(240, 253, 244, 0.45);
+  background: linear-gradient(135deg, #16a34a 0%, #0f766e 100%) !important;
+  border-color: rgba(22, 163, 74, 0.9) !important;
+  color: #f0fdf4 !important;
+  box-shadow: inset 0 0 0 1px rgba(240, 253, 244, 0.5);
   text-shadow: 0 1px 2px rgba(4, 47, 46, 0.35);
   opacity: 1;
   filter: none;
@@ -5950,11 +5950,11 @@ body.map-toolbox-dragging {
 
 .palette-button.incorrect,
 .palette-button[data-status='incorrect'] {
-  background: linear-gradient(135deg, #f97316 0%, #dc2626 55%, #991b1b 100%);
-  border-color: rgba(220, 38, 38, 0.85);
-  color: #fee2e2;
-  box-shadow: inset 0 0 0 1px rgba(254, 226, 226, 0.45);
-  text-shadow: 0 1px 2px rgba(76, 5, 25, 0.35);
+  background: linear-gradient(135deg, #fb7185 0%, #dc2626 55%, #991b1b 100%) !important;
+  border-color: rgba(220, 38, 38, 0.9) !important;
+  color: #fee2e2 !important;
+  box-shadow: inset 0 0 0 1px rgba(254, 226, 226, 0.55);
+  text-shadow: 0 1px 2px rgba(76, 5, 25, 0.4);
   opacity: 1;
   filter: none;
 }
@@ -6008,18 +6008,19 @@ body.map-toolbox-dragging {
 }
 
 .palette-button[data-mode='taking'][data-status='unanswered'] {
-  background: #e2e8f0;
-  border-color: rgba(148, 163, 184, 0.45);
-  color: rgba(15, 23, 42, 0.64);
-  filter: none;
-  opacity: 1;
+  background: #e2e8f0 !important;
+  border-color: rgba(148, 163, 184, 0.45) !important;
+  color: rgba(15, 23, 42, 0.58) !important;
+  filter: grayscale(0.35);
+  opacity: 0.55;
 }
 
 .palette-button[data-mode='review'][data-status='review-unanswered'] {
-  background: #d8dee8;
-  border-color: rgba(100, 116, 139, 0.32);
-  color: rgba(15, 23, 42, 0.5);
-  opacity: 0.85;
+  background: #d8dee8 !important;
+  border-color: rgba(100, 116, 139, 0.32) !important;
+  color: rgba(15, 23, 42, 0.5) !important;
+  opacity: 0.45;
+  filter: grayscale(0.4);
 }
 
 .palette-button[data-change-direction]::after {
@@ -6044,6 +6045,10 @@ body.map-toolbox-dragging {
 
 .palette-button[data-change-direction='changed']::after {
   background: linear-gradient(135deg, #818cf8, #6366f1);
+}
+
+.palette-button[data-change-direction='returned']::after {
+  background: linear-gradient(135deg, #38bdf8, #0284c7);
 }
 
 .exam-review-insights {


### PR DESCRIPTION
## Summary
- preserve initial answer data when resuming exams and analyze full answer sequences to generate accurate change summaries and review messaging
- update the exam runner to avoid scroll resets and highlight answer changes in the question map, including distinguishing returned-to-original choices
- refresh question map styling so unanswered items appear faded and review results clearly show green/red states with change indicators

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1f64d06508322bcccf813efeb46cd