### PR TITLE
Preserve scroll while taking exams

### DIFF
--- a/js/ui/components/exams.js
+++ b/js/ui/components/exams.js
@@ -1445,8 +1445,21 @@ export function renderExamRunner(root, render) {
   sess.__lastRenderedMode = sess.mode;
   if (hasWindow && typeof window.scrollTo === 'function') {
     if (sameQuestion) {
+      const targetY = typeof sess.idx === 'number'
+        ? (getStoredScroll(sess, sess.idx) ?? prevScrollY)
+        : prevScrollY;
       if (typeof sess.idx === 'number') {
-        storeScrollPosition(sess, sess.idx, prevScrollY);
+        storeScrollPosition(sess, sess.idx, targetY);
+      }
+      const restore = () => {
+        if (Math.abs((window.scrollY || 0) - targetY) > 1) {
+          window.scrollTo({ left: 0, top: targetY, behavior: 'auto' });
+        }
+      };
+      if (typeof window.requestAnimationFrame === 'function') {
+        window.requestAnimationFrame(restore);
+      } else {
+        setTimeout(restore, 0);
       }
     } else {
       const storedScroll = getStoredScroll(sess, sess.idx);


### PR DESCRIPTION
## Summary
- restore the user's scroll position when rerendering the exam view for the same question
- keep storing scroll offsets so timed exam ticks no longer jump the viewport to the top

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1f950b5f48322b54d1f1e690207bc