### PR TITLE
Fix timed exam timer causing app rerenders

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -14231,6 +14231,20 @@ var Sevenn = (() => {
   var keyHandler = null;
   var keyHandlerSession = null;
   var lastExamStatusMessage = "";
+  function setTimerElement(sess, element) {
+    if (!sess) return;
+    sess.__timerElement = element || null;
+    if (element) {
+      updateTimerElement(sess);
+    }
+  }
+  function updateTimerElement(sess) {
+    if (!sess) return;
+    const el = sess.__timerElement;
+    if (!el) return;
+    const remaining = typeof sess.remainingMs === "number" ? Math.max(0, sess.remainingMs) : totalExamTimeMs(sess.exam);
+    el.textContent = formatCountdown(remaining);
+  }
   function ensureQuestionStats(sess) {
     const questionCount = sess?.exam?.questions?.length || 0;
     if (!sess) return;
@@ -14512,6 +14526,7 @@ var Sevenn = (() => {
         sess.remainingMs = Math.max(0, sess.remainingMs - delta);
       }
       sess.startedAt = null;
+      updateTimerElement(sess);
     }
   }
   function ensureTimer(sess, render) {
@@ -14533,7 +14548,7 @@ var Sevenn = (() => {
         stopTimer(sess);
         finalizeExam(sess, render, { autoSubmit: true });
       } else {
-        render();
+        updateTimerElement(sess);
       }
     }, 1e3);
     timerHandles.set(sess, handle);
@@ -15335,7 +15350,10 @@ var Sevenn = (() => {
       timerEl.className = "exam-timer";
       const remainingMs = typeof sess.remainingMs === "number" ? sess.remainingMs : totalExamTimeMs(sess.exam);
       timerEl.textContent = formatCountdown(remainingMs);
+      setTimerElement(sess, timerEl);
       top.appendChild(timerEl);
+    } else {
+      setTimerElement(sess, null);
     }
     main.appendChild(top);
     const stem = document.createElement("div");

--- a/js/ui/components/exams.js
+++ b/js/ui/components/exams.js
@@ -10,6 +10,24 @@ let keyHandler = null;
 let keyHandlerSession = null;
 let lastExamStatusMessage = '';
 
+function setTimerElement(sess, element) {
+  if (!sess) return;
+  sess.__timerElement = element || null;
+  if (element) {
+    updateTimerElement(sess);
+  }
+}
+
+function updateTimerElement(sess) {
+  if (!sess) return;
+  const el = sess.__timerElement;
+  if (!el) return;
+  const remaining = typeof sess.remainingMs === 'number'
+    ? Math.max(0, sess.remainingMs)
+    : totalExamTimeMs(sess.exam);
+  el.textContent = formatCountdown(remaining);
+}
+
 function ensureQuestionStats(sess) {
   const questionCount = sess?.exam?.questions?.length || 0;
   if (!sess) return;
@@ -333,6 +351,7 @@ function stopTimer(sess) {
       sess.remainingMs = Math.max(0, sess.remainingMs - delta);
     }
     sess.startedAt = null;
+    updateTimerElement(sess);
   }
 }
 
@@ -355,7 +374,7 @@ function ensureTimer(sess, render) {
       stopTimer(sess);
       finalizeExam(sess, render, { autoSubmit: true });
     } else {
-      render();
+      updateTimerElement(sess);
     }
   }, 1000);
   timerHandles.set(sess, handle);
@@ -1213,7 +1232,10 @@ export function renderExamRunner(root, render) {
     timerEl.className = 'exam-timer';
     const remainingMs = typeof sess.remainingMs === 'number' ? sess.remainingMs : totalExamTimeMs(sess.exam);
     timerEl.textContent = formatCountdown(remainingMs);
+    setTimerElement(sess, timerEl);
     top.appendChild(timerEl);
+  } else {
+    setTimerElement(sess, null);
   }
   main.appendChild(top);
 


### PR DESCRIPTION
## Summary
- track the active exam timer element and update it in-place instead of rerendering the whole app
- update the timed exam interval to refresh only the timer text while still finalizing the exam when time expires
- regenerate the production bundle with the new timer update logic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1fe4be9f083228573d6c537cbe426