### PR TITLE
Improve lecture list sorting and styling

### DIFF
--- a/js/lectures/scheduler.js
+++ b/js/lectures/scheduler.js
@@ -2,16 +2,16 @@ const DAY_MINUTES = 24 * 60;
 const MINUTE_MS = 60 * 1000;
 
 export const DEFAULT_PASS_COLORS = [
-  '#ef4444',
-  '#facc15',
+  '#38bdf8',
+  '#22d3ee',
+  '#34d399',
+  '#4ade80',
+  '#fbbf24',
   '#fb923c',
-  '#22c55e',
-  '#3b82f6',
+  '#f472b6',
   '#a855f7',
-  '#14b8a6',
-  '#ec4899',
   '#6366f1',
-  '#0ea5e9'
+  '#14b8a6'
 ];
 
 function clone(value) {
@@ -79,7 +79,7 @@ export const DEFAULT_PASS_PLAN = {
 
 export const DEFAULT_PLANNER_DEFAULTS = {
   anchorOffsets: {
-    today: 8 * 60,
+    today: 0,
     tomorrow: 8 * 60,
     upcoming: 8 * 60
   },

--- a/js/state.js
+++ b/js/state.js
@@ -12,7 +12,7 @@ export const state = {
   },
   query: "",
   filters: { types:["disease","drug","concept"], block:"", week:"", onlyFav:false, sort:"updated-desc" },
-  lectures: { query: '', blockId: '', week: '', status: '', tag: '' },
+  lectures: { query: '', blockId: '', week: '', status: '', tag: '', sort: 'position-asc' },
   entryLayout: { mode: 'list', columns: 3, scale: 1, controlsVisible: false },
   blockBoard: { collapsedBlocks: [], hiddenTimelines: [] },
   builder: {
@@ -94,7 +94,7 @@ export function setBlockBoardState(patch) {
 export function setLecturesState(patch) {
   if (!patch) return;
   if (!state.lectures) {
-    state.lectures = { query: '', blockId: '', week: '', status: '', tag: '' };
+    state.lectures = { query: '', blockId: '', week: '', status: '', tag: '', sort: 'position-asc' };
   }
   const next = { ...state.lectures };
   if (Object.prototype.hasOwnProperty.call(patch, 'query')) {
@@ -112,11 +112,21 @@ export function setLecturesState(patch) {
   if (Object.prototype.hasOwnProperty.call(patch, 'tag')) {
     next.tag = String(patch.tag ?? '');
   }
+  if (Object.prototype.hasOwnProperty.call(patch, 'sort')) {
+    const value = patch.sort;
+    if (typeof value === 'string') {
+      next.sort = value;
+    } else if (value && typeof value === 'object') {
+      const field = typeof value.field === 'string' && value.field.trim() ? value.field.trim() : 'position';
+      const direction = value.direction === 'desc' ? 'desc' : 'asc';
+      next.sort = `${field}-${direction}`;
+    }
+  }
   state.lectures = next;
 }
 
 export function resetLecturesState() {
-  state.lectures = { query: '', blockId: '', week: '', status: '', tag: '' };
+  state.lectures = { query: '', blockId: '', week: '', status: '', tag: '', sort: 'position-asc' };
 }
 export function setCardsState(patch){
   if (!patch) return;

--- a/style.css
+++ b/style.css
@@ -8206,6 +8206,50 @@ body.map-toolbox-dragging {
   background: rgba(13, 21, 34, 0.88);
 }
 
+.lectures-sort-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.lectures-sort-controls .lectures-sort-field {
+  min-width: 170px;
+}
+
+.lectures-sort-direction {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  min-height: 40px;
+  border-radius: 999px;
+  padding: 0.4rem 1.1rem;
+  background: rgba(148, 163, 184, 0.16);
+  border: 1px solid color-mix(in srgb, var(--border) 68%, transparent);
+  color: var(--text);
+  font-size: 0.8rem;
+  line-height: 1.1;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.lectures-sort-direction::after {
+  content: '↑';
+  font-size: 0.9rem;
+}
+
+.lectures-sort-direction[data-direction="desc"]::after {
+  content: '↓';
+}
+
+.lectures-sort-direction:hover,
+.lectures-sort-direction:focus-visible {
+  background: rgba(148, 163, 184, 0.28);
+  border-color: color-mix(in srgb, var(--accent) 45%, transparent);
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.25);
+  outline: none;
+  transform: translateY(-1px);
+}
+
 .lectures-add-select {
   min-width: 150px;
   font-size: 0.85rem;
@@ -8320,24 +8364,25 @@ body.map-toolbox-dragging {
 
 .lectures-week-table {
   width: 100%;
-  border-collapse: separate;
-  border-spacing: 0;
+  border-collapse: collapse;
   font-size: 0.88rem;
   border-radius: var(--radius-lg);
   overflow: hidden;
-  background: rgba(8, 12, 22, 0.72);
-  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.6);
+  background: rgba(8, 12, 22, 0.78);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.55);
 }
 
 .lectures-week-table th,
 .lectures-week-table td {
-  padding: 0.6rem 0.9rem;
-  border-bottom: 1px solid color-mix(in srgb, var(--surface-3) 85%, transparent);
+  padding: 0.65rem 0.95rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--surface-3) 88%, transparent);
   vertical-align: top;
 }
 
 .lectures-week-table thead th {
-  border-bottom: 1px solid color-mix(in srgb, var(--surface-3) 92%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--surface-3) 94%, transparent);
+  background: color-mix(in srgb, rgba(11, 18, 30, 0.9) 82%, rgba(45, 64, 89, 0.4));
+  backdrop-filter: blur(10px);
 }
 
 .lectures-week-table tbody tr:last-child td {
@@ -8348,11 +8393,11 @@ body.map-toolbox-dragging {
   font-size: 0.72rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: color-mix(in srgb, var(--text-muted) 85%, white 8%);
+  color: color-mix(in srgb, var(--text-muted) 80%, white 12%);
 }
 
 .lectures-week-table tbody tr:hover {
-  background: rgba(148, 163, 184, 0.06);
+  background: rgba(148, 163, 184, 0.08);
 }
 
 .lecture-overview {
@@ -8522,15 +8567,15 @@ body.map-toolbox-dragging {
   flex: 0 0 210px;
   min-width: 0;
   width: 210px;
-  padding: 0.5rem 0.7rem;
-  border-radius: 14px;
-  border: 1px solid color-mix(in srgb, var(--chip-accent) 52%, rgba(148, 163, 184, 0.2));
-  background: linear-gradient(145deg, color-mix(in srgb, var(--chip-accent) 38%, rgba(8, 12, 22, 0.88)), rgba(4, 8, 16, 0.9));
-  box-shadow: 0 14px 30px rgba(2, 6, 23, 0.32);
+  padding: 0.5rem 0.75rem;
+  border-radius: 16px;
+  border: 1px solid color-mix(in srgb, var(--chip-accent) 48%, rgba(148, 163, 184, 0.28));
+  background: linear-gradient(140deg, color-mix(in srgb, var(--chip-accent) 52%, rgba(8, 12, 22, 0.88)), rgba(4, 8, 16, 0.93));
+  box-shadow: 0 18px 32px color-mix(in srgb, var(--chip-accent) 24%, rgba(2, 6, 23, 0.32));
   color: #f8fafc;
   scroll-snap-align: start;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, background 0.2s ease, filter 0.2s ease;
 }
 
 .lecture-pass-chip-body {
@@ -8548,10 +8593,10 @@ body.map-toolbox-dragging {
   width: 26px;
   height: 26px;
   border-radius: 50%;
-  border: 2px solid color-mix(in srgb, var(--chip-accent) 65%, rgba(255, 255, 255, 0.18));
-  background: color-mix(in srgb, var(--chip-accent) 24%, rgba(6, 12, 22, 0.9));
+  border: 2px solid color-mix(in srgb, var(--chip-accent) 72%, rgba(255, 255, 255, 0.22));
+  background: color-mix(in srgb, var(--chip-accent) 30%, rgba(8, 14, 24, 0.92));
   cursor: pointer;
-  transition: border-color 0.2s ease, background 0.2s ease;
+  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
 }
 
 .lecture-pass-chip-checkbox {
@@ -8593,7 +8638,8 @@ body.map-toolbox-dragging {
 }
 
 .lecture-pass-chip-check:hover {
-  background: color-mix(in srgb, var(--chip-accent) 32%, rgba(6, 12, 22, 0.88));
+  background: color-mix(in srgb, var(--chip-accent) 38%, rgba(8, 14, 24, 0.88));
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--chip-accent) 42%, transparent);
 }
 
 .lecture-pass-chip-checkbox:focus-visible + .lecture-pass-chip-checkmark {
@@ -8602,16 +8648,13 @@ body.map-toolbox-dragging {
 }
 
 .lecture-pass-chip-checkbox:checked + .lecture-pass-chip-checkmark {
-
-  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.18), transparent 55%),
-    linear-gradient(135deg, #22c55e, #16a34a);
-  box-shadow: inset 0 0 0 2px rgba(6, 12, 22, 0.65), 0 10px 18px rgba(34, 197, 94, 0.28);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--chip-accent) 82%, white 16%), color-mix(in srgb, var(--chip-accent) 65%, rgba(6, 15, 28, 0.25)));
+  box-shadow: inset 0 0 0 2px rgba(6, 12, 22, 0.55), 0 10px 22px color-mix(in srgb, var(--chip-accent) 38%, transparent);
 }
 
 .lecture-pass-chip-checkbox:checked + .lecture-pass-chip-checkmark::after {
-  inset: 0;
-  background: linear-gradient(135deg, rgba(74, 222, 128, 0.95), rgba(34, 197, 94, 0.9));
-
+  inset: 3px;
+  background: linear-gradient(135deg, color-mix(in srgb, var(--chip-accent) 90%, white 20%), color-mix(in srgb, var(--chip-accent) 68%, rgba(6, 12, 22, 0.2)));
   opacity: 1;
   transform: scale(1);
 }
@@ -8659,10 +8702,10 @@ body.map-toolbox-dragging {
 }
 
 .lecture-pass-chip.is-complete {
-  background: color-mix(in srgb, var(--chip-accent) 12%, rgba(10, 16, 26, 0.9));
-  border-color: color-mix(in srgb, var(--chip-accent) 22%, rgba(148, 163, 184, 0.26));
-  color: color-mix(in srgb, #f8fafc 76%, rgba(148, 163, 184, 0.55));
-  filter: saturate(65%);
+  background: linear-gradient(140deg, color-mix(in srgb, var(--chip-accent) 18%, rgba(9, 15, 26, 0.94)), rgba(6, 10, 20, 0.9));
+  border-color: color-mix(in srgb, var(--chip-accent) 26%, rgba(148, 163, 184, 0.32));
+  color: color-mix(in srgb, #f8fafc 78%, rgba(148, 163, 184, 0.5));
+  filter: saturate(75%);
 }
 
 .lecture-pass-chip.is-complete .lecture-pass-chip-function {
@@ -8679,21 +8722,18 @@ body.map-toolbox-dragging {
 }
 
 .lecture-pass-chip.is-complete .lecture-pass-chip-check {
-  background: color-mix(in srgb, #22c55e 24%, rgba(12, 19, 30, 0.88));
-  border-color: color-mix(in srgb, #22c55e 58%, rgba(148, 163, 184, 0.24));
+  background: color-mix(in srgb, var(--chip-accent) 28%, rgba(12, 19, 30, 0.88));
+  border-color: color-mix(in srgb, var(--chip-accent) 54%, rgba(148, 163, 184, 0.26));
 }
 
 .lecture-pass-chip.is-complete .lecture-pass-chip-checkmark {
-
-  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.18), transparent 55%),
-    linear-gradient(135deg, #22c55e, #16a34a);
-  box-shadow: inset 0 0 0 2px rgba(6, 12, 22, 0.65), 0 10px 18px rgba(34, 197, 94, 0.28);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--chip-accent) 82%, white 16%), color-mix(in srgb, var(--chip-accent) 65%, rgba(6, 15, 28, 0.25)));
+  box-shadow: inset 0 0 0 2px rgba(6, 12, 22, 0.55), 0 10px 22px color-mix(in srgb, var(--chip-accent) 38%, transparent);
 }
 
 .lecture-pass-chip.is-complete .lecture-pass-chip-checkmark::after {
-  inset: 0;
-  background: linear-gradient(135deg, rgba(74, 222, 128, 0.95), rgba(34, 197, 94, 0.9));
-
+  inset: 3px;
+  background: linear-gradient(135deg, color-mix(in srgb, var(--chip-accent) 90%, white 20%), color-mix(in srgb, var(--chip-accent) 68%, rgba(6, 12, 22, 0.2)));
   opacity: 1;
   transform: scale(1);
 }


### PR DESCRIPTION
## Summary
- add configurable lecture sorting, defaulting to manual order while enabling created date and next pass ordering in both directions
- reverse week grouping order so the newest weeks surface first
- refresh lecture pass styling, colors, and table layout while shifting day-zero passes to midnight

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d201d54f108322987df35027219916