### PR TITLE
Adjust lecture list layout and toggle UI

### DIFF
--- a/js/ui/components/lectures.js
+++ b/js/ui/components/lectures.js
@@ -473,11 +473,8 @@ function createPassChipDisplay(info, now = Date.now(), options = {}) {
   toggleIcon.className = 'lecture-pass-chip-toggle-icon';
   toggleIcon.setAttribute('aria-hidden', 'true');
   toggleIcon.textContent = '✓';
-  const toggleLabel = document.createElement('span');
-  toggleLabel.className = 'lecture-pass-chip-toggle-label';
-  toggleLabel.textContent = 'Done';
 
-  toggleButton.append(toggleIcon, toggleLabel);
+  toggleButton.append(toggleIcon);
   statusWrap.appendChild(toggleButton);
   chip.appendChild(statusWrap);
 

--- a/style.css
+++ b/style.css
@@ -8373,7 +8373,7 @@ body.map-toolbox-dragging {
 
 .lecture-row {
   display: grid;
-  grid-template-columns: minmax(220px, 1.1fr) minmax(0, 2fr) minmax(130px, 0.7fr);
+  grid-template-columns: minmax(220px, 1.05fr) minmax(0, 2.25fr) minmax(90px, 0.5fr);
   gap: 1rem;
   align-items: stretch;
   padding: 0.9rem 1rem;
@@ -8430,13 +8430,13 @@ body.map-toolbox-dragging {
 
 @media (max-width: 1080px) {
   .lecture-row {
-    grid-template-columns: minmax(200px, 1fr) minmax(0, 1.8fr) minmax(120px, 0.65fr);
+    grid-template-columns: minmax(200px, 1fr) minmax(0, 2.05fr) minmax(90px, 0.5fr);
   }
 }
 
 @media (max-width: 860px) {
   .lecture-row {
-    grid-template-columns: minmax(180px, 1fr) minmax(0, 1.6fr) minmax(110px, 0.6fr);
+    grid-template-columns: minmax(180px, 1fr) minmax(0, 1.85fr) minmax(80px, 0.45fr);
     gap: 0.75rem;
   }
 }
@@ -8635,8 +8635,9 @@ body.map-toolbox-dragging {
 .lecture-pass-chip-toggle {
   display: inline-flex;
   align-items: center;
-  gap: 0.45rem;
-  padding: 0.38rem 0.9rem;
+  justify-content: center;
+  gap: 0;
+  padding: 0.4rem;
   border-radius: 999px;
   border: 2px solid color-mix(in srgb, var(--chip-accent) 68%, rgba(148, 163, 184, 0.4));
   background: color-mix(in srgb, var(--chip-accent) 28%, rgba(8, 14, 24, 0.92));
@@ -8662,10 +8663,6 @@ body.map-toolbox-dragging {
   font-size: 0.9em;
   font-weight: 700;
   transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-}
-
-.lecture-pass-chip-toggle-label {
-  pointer-events: none;
 }
 
 .lecture-pass-chip-toggle:hover:not(:disabled),


### PR DESCRIPTION
## Summary
- widen the lecture pass column while shrinking the actions column so passes have more room
- show only the completion toggle button in pass chips and restyle it for the icon-only presentation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2123bb848832292d1e90350c58a1c