### PR TITLE
Refine lecture pass chips layout

### DIFF
--- a/js/ui/components/lectures.js
+++ b/js/ui/components/lectures.js
@@ -487,16 +487,19 @@ function createPassChipDisplay(info, now = Date.now(), options = {}) {
   const badge = document.createElement('span');
   badge.className = 'lecture-pass-chip-order';
   badge.textContent = `P${info?.order ?? ''}`;
-  const labelEl = document.createElement('span');
-  labelEl.className = 'lecture-pass-chip-label';
-  labelEl.textContent = passTitle;
-  header.append(badge, labelEl);
-  body.appendChild(header);
+  header.appendChild(badge);
 
-  const functionLine = document.createElement('div');
-  functionLine.className = 'lecture-pass-chip-function';
-  functionLine.textContent = info?.action || info?.label || '';
-  body.appendChild(functionLine);
+  const defaultLabel = `Pass ${info?.order ?? ''}`.trim();
+  const primaryText = (info?.action || '').trim();
+  const fallbackText = (info?.label || '').trim();
+  const functionText = primaryText || (fallbackText && fallbackText !== defaultLabel ? fallbackText : '');
+  if (functionText) {
+    const functionEl = document.createElement('span');
+    functionEl.className = 'lecture-pass-chip-function';
+    functionEl.textContent = functionText;
+    header.appendChild(functionEl);
+  }
+  body.appendChild(header);
 
   const timing = document.createElement('div');
   timing.className = 'lecture-pass-chip-due';

--- a/style.css
+++ b/style.css
@@ -8596,22 +8596,22 @@ body.map-toolbox-dragging {
 .lecture-pass-chips {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 0.65rem;
 }
 
 
 .lecture-pass-chip {
   display: flex;
   align-items: center;
-  gap: 0.45rem;
-  flex: 0 0 210px;
+  gap: 0.35rem;
+  flex: 1 1 190px;
   min-width: 0;
-  width: 210px;
-  padding: 0.5rem 0.75rem;
-  border-radius: 16px;
-  border: 1px solid color-mix(in srgb, var(--chip-accent) 48%, rgba(148, 163, 184, 0.28));
-  background: linear-gradient(140deg, color-mix(in srgb, var(--chip-accent) 52%, rgba(8, 12, 22, 0.88)), rgba(4, 8, 16, 0.93));
-  box-shadow: 0 18px 32px color-mix(in srgb, var(--chip-accent) 24%, rgba(2, 6, 23, 0.32));
+  width: auto;
+  padding: 0.45rem 0.65rem;
+  border-radius: 14px;
+  border: 1px solid color-mix(in srgb, var(--chip-accent) 46%, rgba(148, 163, 184, 0.26));
+  background: linear-gradient(140deg, color-mix(in srgb, var(--chip-accent) 48%, rgba(8, 12, 22, 0.88)), rgba(4, 8, 16, 0.93));
+  box-shadow: 0 14px 28px color-mix(in srgb, var(--chip-accent) 22%, rgba(2, 6, 23, 0.28));
   color: #f8fafc;
   scroll-snap-align: start;
   cursor: pointer;
@@ -8628,7 +8628,7 @@ body.map-toolbox-dragging {
 .lecture-pass-chip-body {
   display: flex;
   flex-direction: column;
-  gap: 0.24rem;
+  gap: 0.18rem;
   min-width: 0;
 }
 
@@ -8703,34 +8703,30 @@ body.map-toolbox-dragging {
 
 .lecture-pass-chip-header {
   display: flex;
-  align-items: center;
-  gap: 0.45rem;
+  align-items: baseline;
+  gap: 0.35rem;
   font-weight: 600;
   min-width: 0;
 }
 
 .lecture-pass-chip-order {
-  padding: 0.15rem 0.55rem;
+  padding: 0.08rem 0.48rem;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--chip-accent) 28%, rgba(148, 163, 184, 0.18));
-  font-size: 0.72rem;
-  letter-spacing: 0.04em;
-}
-
-.lecture-pass-chip-label {
-  font-size: 0.85rem;
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  background: color-mix(in srgb, var(--chip-accent) 26%, rgba(148, 163, 184, 0.18));
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
 }
 
 .lecture-pass-chip-function {
-  font-size: 0.72rem;
-  letter-spacing: 0.05em;
+  flex: 1;
+  min-width: 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--chip-accent) 70%, white 28%);
+  color: color-mix(in srgb, var(--chip-accent) 72%, white 26%);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .lecture-pass-chip-due {


### PR DESCRIPTION
## Summary
- condense the lecture pass chip header to only show the colored title alongside the pass badge
- suppress duplicate default pass labels while leaving accessibility metadata intact
- tighten chip spacing, padding, and typography for slimmer lecture pass pills

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d21521e5f08322a0b3b538556fc440