### PR TITLE
Refactor study setup to auto-sync and stabilize sessions

### DIFF
--- a/js/ui/components/block-mode.js
+++ b/js/ui/components/block-mode.js
@@ -16,7 +16,7 @@ function drawBlockMode(shell, globalRedraw) {
   const items = state.cohort || [];
 
   if (!items.length) {
-    shell.appendChild(messageCard('Build a study set to unlock Blocks mode. Use the filters above to assemble a cohort.'));
+    shell.appendChild(messageCard('Select study cards to unlock Blocks mode. Use the filters above to assemble a cohort.'));
     return;
   }
 

--- a/js/ui/components/flashcards.js
+++ b/js/ui/components/flashcards.js
@@ -122,7 +122,7 @@ export function renderFlashcards(root, redraw) {
 
   if (!items.length) {
     const msg = document.createElement('div');
-    msg.textContent = 'No items in cohort.';
+    msg.textContent = 'No cards selected. Adjust the filters above to add cards.';
     root.appendChild(msg);
     return;
   }
@@ -178,11 +178,6 @@ export function renderFlashcards(root, redraw) {
     const alreadyQueued = !isReview && Boolean(snapshot && snapshot.last && !snapshot.retired);
     const requiresRating = isReview || !alreadyQueued;
     sectionRequirements.set(key, requiresRating);
-    if (!requiresRating && !ratedSections.has(key)) {
-      const recorded = snapshot?.lastRating || 'queued';
-      ratedSections.set(key, recorded);
-    }
-
     const sec = document.createElement('div');
     sec.className = 'flash-section';
     sec.setAttribute('role', 'button');

--- a/js/ui/components/quiz.js
+++ b/js/ui/components/quiz.js
@@ -108,7 +108,7 @@ export function renderQuiz(root, redraw) {
 
   if (!pool.length) {
     const empty = document.createElement('div');
-    empty.textContent = 'No questions available. Build a study set to begin.';
+    empty.textContent = 'No questions available. Select study cards to begin.';
     root.appendChild(empty);
     return;
   }

--- a/style.css
+++ b/style.css
@@ -2554,8 +2554,7 @@ input[type="checkbox"]:checked::after {
   gap: var(--pad-lg);
 }
 
-.builder-filter-card,
-.builder-summary-card {
+.builder-filter-card {
   display: flex;
   flex-direction: column;
   gap: var(--pad);
@@ -2582,11 +2581,7 @@ input[type="checkbox"]:checked::after {
   color: var(--gray);
 }
 
-.builder-count {
-  font-weight: 600;
-}
-
-.builder-summary-actions {
+.builder-filter-actions {
   display: flex;
   flex-direction: column;
   gap: var(--pad-sm);
@@ -2597,6 +2592,32 @@ input[type="checkbox"]:checked::after {
   display: flex;
   flex-direction: column;
   gap: var(--pad);
+}
+
+.builder-mode-status {
+  font-size: 0.9rem;
+  color: var(--gray);
+}
+
+.builder-mode-status.is-error {
+  color: var(--pink);
+}
+
+.builder-mode-status.is-warning {
+  color: var(--yellow);
+}
+
+.builder-mode-count {
+  font-size: 0.85rem;
+  color: var(--gray);
+}
+
+.builder-mode-count.is-loading {
+  font-style: italic;
+}
+
+.builder-mode-count.is-error {
+  color: var(--pink);
 }
 
 .builder-mode-layout {


### PR DESCRIPTION
## Summary
- auto-sync the study cohort with the current builder selections and surface card counts directly on the study tab
- fix flashcard and quiz session issues around stale ratings while clarifying the empty cohort messaging
- align Blocks guidance and styling with the new automated workflow and ensure review data persists across exports

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d21820781883228fbc5235f523d6ae