### PR TITLE
Handle lecture changes in review metadata and relax quiz ratings

### DIFF
--- a/js/review/sr-data.js
+++ b/js/review/sr-data.js
@@ -14,7 +14,9 @@ export function defaultSectionState() {
     lastRating: null,
     last: 0,
     due: 0,
-    retired: false
+    retired: false,
+    contentDigest: null,
+    lectureScope: []
   };
 }
 
@@ -33,6 +35,15 @@ export function normalizeSectionRecord(record) {
   base.last = sanitizeNumber(record.last, 0);
   base.due = sanitizeNumber(record.due, 0);
   base.retired = Boolean(record.retired);
+  if (typeof record.contentDigest === 'string' && record.contentDigest) {
+    base.contentDigest = record.contentDigest;
+  }
+  if (Array.isArray(record.lectureScope) && record.lectureScope.length) {
+    const normalizedScope = record.lectureScope
+      .map(entry => (typeof entry === 'string' ? entry.trim() : ''))
+      .filter(Boolean);
+    base.lectureScope = Array.from(new Set(normalizedScope)).sort();
+  }
   return base;
 }
 

--- a/js/ui/components/quiz.js
+++ b/js/ui/components/quiz.js
@@ -304,6 +304,7 @@ export function renderQuiz(root, redraw) {
 
   const status = document.createElement('span');
   status.className = 'quiz-rating-status';
+  status.textContent = 'Optional: rate your confidence after answering.';
   ratingRow.appendChild(status);
 
   const ratingId = ratingKey(item, '__overall__');
@@ -493,13 +494,13 @@ export function renderQuiz(root, redraw) {
   function updateNavState() {
     const currentAnswer = session.answers[session.idx];
     const solved = Boolean(currentAnswer && currentAnswer.checked && (currentAnswer.isCorrect || currentAnswer.revealed));
-    const hasRating = !sections.length || Boolean(selectedRating);
-    nextBtn.disabled = !(solved && hasRating);
+    nextBtn.disabled = !solved;
     Array.from(options.querySelectorAll('button')).forEach(btn => {
       btn.disabled = !solved;
     });
     if (!solved) {
-      status.textContent = '';
+      status.classList.remove('is-error');
+      status.textContent = 'Optional: rate your confidence after answering.';
     } else {
       revealBtn.hidden = true;
     }


### PR DESCRIPTION
## Summary
- track per-section content hashes and lecture scope to preserve ratings when lectures are added and reset them when content changes or lectures are removed
- refresh the scheduler to apply the new metadata and rebuild the bundle, so cards only re-enter the queue when their information truly changed
- allow quiz navigation to continue without choosing a rating while keeping rating buttons optional, and add regression tests for the new behaviors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d22a5cdef08322989ded30a2fbbeab