### PR TITLE
Improve study session persistence and quiz suggestion UX

### DIFF
--- a/js/study/study-sessions.js
+++ b/js/study/study-sessions.js
@@ -7,6 +7,102 @@ function clone(value) {
   return JSON.parse(JSON.stringify(value ?? null));
 }
 
+function safeClone(value, fallback = null) {
+  try {
+    const result = clone(value);
+    if (result === null && fallback !== undefined) {
+      return clone(fallback ?? null);
+    }
+    return result;
+  } catch (err) {
+    console.warn('Failed to clone study session value', err);
+    if (fallback === undefined) return null;
+    try {
+      return clone(fallback ?? null);
+    } catch (_) {
+      if (Array.isArray(fallback)) return [];
+      if (fallback && typeof fallback === 'object') return {};
+      return fallback ?? null;
+    }
+  }
+}
+
+function sanitizeRatings(map) {
+  if (!map || typeof map !== 'object' || Array.isArray(map)) return {};
+  const next = {};
+  Object.entries(map).forEach(([key, value]) => {
+    if (typeof key !== 'string') return;
+    if (typeof value === 'string') {
+      next[key] = value;
+    }
+  });
+  return next;
+}
+
+function sanitizeAnswers(map) {
+  if (!map || typeof map !== 'object' || Array.isArray(map)) return {};
+  const next = {};
+  Object.entries(map).forEach(([key, value]) => {
+    if (typeof key !== 'string' || !value || typeof value !== 'object') return;
+    const entry = {
+      value: typeof value.value === 'string' ? value.value : '',
+      isCorrect: Boolean(value.isCorrect),
+      checked: Boolean(value.checked),
+      revealed: Boolean(value.revealed)
+    };
+    next[key] = entry;
+  });
+  return next;
+}
+
+function sanitizePoolEntry(entry) {
+  if (entry === null || entry === undefined) return null;
+  if (typeof entry !== 'object') return entry;
+  return safeClone(entry, {});
+}
+
+function sanitizeSession(mode, session) {
+  const source = safeClone(session, {});
+  const next = source && typeof source === 'object' ? source : {};
+  delete next.dict;
+  if (Array.isArray(next.pool)) {
+    next.pool = next.pool.map(item => sanitizePoolEntry(item)).filter(item => item !== null && item !== undefined);
+  } else {
+    next.pool = [];
+  }
+  if (typeof next.idx !== 'number' || Number.isNaN(next.idx)) {
+    next.idx = 0;
+  }
+  next.idx = next.pool.length ? Math.max(0, Math.min(Math.floor(next.idx), next.pool.length - 1)) : 0;
+  if (next.answers && typeof next.answers === 'object' && !Array.isArray(next.answers)) {
+    next.answers = sanitizeAnswers(next.answers);
+  } else if (next.answers !== undefined) {
+    next.answers = {};
+  }
+  if (next.ratings && typeof next.ratings === 'object' && !Array.isArray(next.ratings)) {
+    next.ratings = sanitizeRatings(next.ratings);
+  } else {
+    next.ratings = {};
+  }
+  if (mode === 'review') {
+    next.mode = 'review';
+  } else if (typeof next.mode !== 'string' || next.mode !== 'review') {
+    next.mode = 'study';
+  }
+  return next;
+}
+
+function sanitizeCohort(list) {
+  const cloned = safeClone(list, []);
+  if (!Array.isArray(cloned)) return [];
+  return cloned.map(item => sanitizePoolEntry(item)).filter(item => item !== null && item !== undefined);
+}
+
+function sanitizeMetadata(meta) {
+  const cloned = safeClone(meta, {});
+  return cloned && typeof cloned === 'object' && !Array.isArray(cloned) ? cloned : {};
+}
+
 export async function hydrateStudySessions(force = false) {
   if (!force && state.studySessionsLoaded) {
     return state.studySessions || {};
@@ -16,7 +112,13 @@ export async function hydrateStudySessions(force = false) {
       const map = {};
       entries.forEach(entry => {
         if (entry && entry.mode) {
-          map[entry.mode] = entry;
+          map[entry.mode] = {
+            mode: entry.mode,
+            updatedAt: entry.updatedAt || Date.now(),
+            session: sanitizeSession(entry.mode, entry.session),
+            cohort: sanitizeCohort(entry.cohort),
+            metadata: sanitizeMetadata(entry.metadata)
+          };
         }
       });
       setStudySessions(map);
@@ -42,9 +144,9 @@ export async function persistStudySession(mode, payload) {
   const entry = {
     mode,
     updatedAt: Date.now(),
-    session: clone(payload?.session ?? {}),
-    cohort: clone(payload?.cohort ?? []),
-    metadata: clone(payload?.metadata ?? {})
+    session: sanitizeSession(mode, payload?.session ?? {}),
+    cohort: sanitizeCohort(payload?.cohort ?? []),
+    metadata: sanitizeMetadata(payload?.metadata ?? {})
   };
   await saveStudySessionRecord(entry);
   setStudySessionEntry(mode, entry);

--- a/style.css
+++ b/style.css
@@ -909,17 +909,33 @@ button:not(.tab):not(.fab-btn):not(.builder-pill):not(.builder-mode-toggle):not(
 }
 
 .quiz-suggestions li {
+  padding: 0;
+}
+
+.quiz-suggestion-btn {
+  display: block;
+  width: 100%;
   background: rgba(30, 41, 59, 0.85);
   border: 1px solid rgba(148, 163, 184, 0.25);
   border-radius: var(--radius-sm);
   padding: 6px 10px;
   cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease;
+  text-align: left;
+  color: inherit;
+  font: inherit;
+  transition: background 0.2s ease, border-color 0.2s ease, outline-color 0.2s ease;
 }
 
-.quiz-suggestions li:hover {
+.quiz-suggestion-btn:hover,
+.quiz-suggestion-btn:focus-visible,
+.quiz-suggestion-btn[aria-selected='true'] {
   background: rgba(56, 189, 248, 0.18);
   border-color: rgba(56, 189, 248, 0.36);
+}
+
+.quiz-suggestion-btn:focus-visible {
+  outline: 2px solid rgba(56, 189, 248, 0.6);
+  outline-offset: 0;
 }
 
 .quiz-answer-actions {


### PR DESCRIPTION
## Summary
- sanitize study session payloads before persistence and when hydrating from storage
- harden cloning logic to gracefully handle malformed data
- improve quiz answer suggestions with accessible buttons and aria wiring, and update styling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d22ed01e608322aa082965f8b68736