### PR TITLE
Refine map search UI and stabilize arrow markers

### DIFF
--- a/js/ui/components/map.js
+++ b/js/ui/components/map.js
@@ -70,6 +70,16 @@ const ICONS = {
     '<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">'
     + '<path d="M10 4v12M4 10h12" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />'
     + '</svg>',
+  search:
+    '<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">'
+    + '<circle cx="9" cy="9" r="5.2" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />'
+    + '<path d="M12.8 12.8L16.5 16.5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />'
+    + '</svg>',
+  arrowRight:
+    '<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">'
+    + '<path d="M4 10h10" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />'
+    + '<path d="M10 6l4 4-4 4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />'
+    + '</svg>',
   gear:
     '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">'
     + '<path d="M12 8.5a3.5 3.5 0 1 0 0 7 3.5 3.5 0 0 0 0-7z" stroke="currentColor" stroke-width="1.6" />'
@@ -165,9 +175,15 @@ const mapState = {
   searchValue: '',
   searchFeedback: null,
   searchInput: null,
+  searchFieldEl: null,
   searchFeedbackEl: null,
+  searchSuggestions: [],
+  searchSuggestionsEl: null,
+  searchActiveIndex: -1,
+  searchSuggestionTimer: null,
   paletteSearch: '',
-  nodeRadii: null
+  nodeRadii: null,
+  lineMarkers: new Map()
 };
 
 function normalizeMapTab(tab = {}) {
@@ -368,10 +384,122 @@ function applyStoredSearchFeedback() {
   }
 }
 
+function updateSearchSuggestions(query) {
+  const container = mapState.searchSuggestionsEl;
+  if (!container) return;
+  if (mapState.searchSuggestionTimer) {
+    clearTimeout(mapState.searchSuggestionTimer);
+    mapState.searchSuggestionTimer = null;
+  }
+  container.innerHTML = '';
+  mapState.searchSuggestions = [];
+  mapState.searchActiveIndex = -1;
+  const field = mapState.searchFieldEl;
+  const trimmed = (query || '').trim();
+  if (!trimmed) {
+    container.classList.remove('visible');
+    if (field) field.classList.remove('has-suggestions');
+    return;
+  }
+  const lower = trimmed.toLowerCase();
+  const items = (mapState.visibleItems || [])
+    .map(item => ({ id: item.id, label: titleOf(item) || '' }))
+    .filter(entry => entry.label && entry.label.toLowerCase().includes(lower));
+  if (!items.length) {
+    container.classList.remove('visible');
+    if (field) field.classList.remove('has-suggestions');
+    return;
+  }
+  const seen = new Set();
+  const unique = [];
+  items.forEach(entry => {
+    if (!entry.id || seen.has(entry.id)) return;
+    seen.add(entry.id);
+    unique.push(entry);
+  });
+  unique.sort((a, b) => {
+    const aIndex = a.label.toLowerCase().indexOf(lower);
+    const bIndex = b.label.toLowerCase().indexOf(lower);
+    if (aIndex !== bIndex) return aIndex - bIndex;
+    return a.label.localeCompare(b.label);
+  });
+  const limited = unique.slice(0, 6);
+  if (!limited.length) {
+    container.classList.remove('visible');
+    if (field) field.classList.remove('has-suggestions');
+    return;
+  }
+  mapState.searchSuggestions = limited;
+  limited.forEach((entry, index) => {
+    const option = document.createElement('button');
+    option.type = 'button';
+    option.className = 'map-search-suggestion';
+    option.textContent = entry.label;
+    option.addEventListener('mousedown', evt => {
+      evt.preventDefault();
+    });
+    option.addEventListener('click', () => {
+      applySearchSuggestion(index);
+    });
+    container.appendChild(option);
+  });
+  container.classList.add('visible');
+  if (field) field.classList.add('has-suggestions');
+}
+
+function clearSearchSuggestions() {
+  const container = mapState.searchSuggestionsEl;
+  if (mapState.searchSuggestionTimer) {
+    clearTimeout(mapState.searchSuggestionTimer);
+    mapState.searchSuggestionTimer = null;
+  }
+  if (container) {
+    container.innerHTML = '';
+    container.classList.remove('visible');
+  }
+  mapState.searchSuggestions = [];
+  mapState.searchActiveIndex = -1;
+  const field = mapState.searchFieldEl;
+  if (field) {
+    field.classList.remove('has-suggestions');
+  }
+}
+
+function highlightSearchSuggestion(index) {
+  const container = mapState.searchSuggestionsEl;
+  if (!container) return;
+  const options = Array.from(container.querySelectorAll('.map-search-suggestion'));
+  if (!options.length) return;
+  const clamped = ((index % options.length) + options.length) % options.length;
+  options.forEach((option, i) => {
+    option.classList.toggle('active', i === clamped);
+    if (i === clamped) {
+      option.scrollIntoView({ block: 'nearest' });
+    }
+  });
+  mapState.searchActiveIndex = clamped;
+}
+
+function applySearchSuggestion(index) {
+  const suggestion = mapState.searchSuggestions?.[index];
+  if (!suggestion) return;
+  if (mapState.searchInput) {
+    mapState.searchInput.value = suggestion.label;
+    mapState.searchValue = suggestion.label;
+    mapState.searchInput.focus();
+  }
+  clearSearchSuggestions();
+  handleSearchSubmit(suggestion.label);
+}
+
 function setSearchInputState({ notFound = false } = {}) {
   const input = mapState.searchInput;
-  if (!input) return;
-  input.classList.toggle('not-found', Boolean(notFound));
+  if (input) {
+    input.classList.toggle('not-found', Boolean(notFound));
+  }
+  if (mapState.searchFieldEl) {
+    mapState.searchFieldEl.classList.toggle('not-found', Boolean(notFound));
+  }
 }
 
 function createMapTabsPanel(activeTab) {
@@ -442,6 +570,14 @@ function createSearchOverlay() {
     handleSearchSubmit(input.value);
   });
 
+  const field = document.createElement('div');
+  field.className = 'map-search-field';
+
+  const icon = document.createElement('span');
+  icon.className = 'map-search-icon';
+  icon.innerHTML = ICONS.search;
+  field.appendChild(icon);
+
   const input = document.createElement('input');
   input.type = 'search';
   input.className = 'input map-search-input';
@@ -453,14 +589,56 @@ function createSearchOverlay() {
     if (!input.value.trim()) {
       updateSearchFeedback('', '');
     }
+    updateSearchSuggestions(input.value);
   });
-  form.appendChild(input);
+  input.addEventListener('focus', () => {
+    if (mapState.searchSuggestionTimer) {
+      clearTimeout(mapState.searchSuggestionTimer);
+      mapState.searchSuggestionTimer = null;
+    }
+    updateSearchSuggestions(input.value);
+  });
+  input.addEventListener('blur', () => {
+    if (mapState.searchSuggestionTimer) {
+      clearTimeout(mapState.searchSuggestionTimer);
+    }
+    mapState.searchSuggestionTimer = setTimeout(() => {
+      clearSearchSuggestions();
+    }, 120);
+  });
+  input.addEventListener('keydown', evt => {
+    if (!mapState.searchSuggestions || mapState.searchSuggestions.length === 0) return;
+    if (evt.key === 'ArrowDown') {
+      evt.preventDefault();
+      const next = (mapState.searchActiveIndex + 1) % mapState.searchSuggestions.length;
+      highlightSearchSuggestion(next);
+    } else if (evt.key === 'ArrowUp') {
+      evt.preventDefault();
+      const total = mapState.searchSuggestions.length;
+      const next = (mapState.searchActiveIndex - 1 + total) % total;
+      highlightSearchSuggestion(next);
+    } else if (evt.key === 'Enter') {
+      if (mapState.searchActiveIndex >= 0 && mapState.searchActiveIndex < mapState.searchSuggestions.length) {
+        evt.preventDefault();
+        applySearchSuggestion(mapState.searchActiveIndex);
+      }
+    } else if (evt.key === 'Escape') {
+      clearSearchSuggestions();
+    }
+  });
+  field.appendChild(input);
 
   const submit = document.createElement('button');
   submit.type = 'submit';
-  submit.className = 'map-search-btn';
-  submit.textContent = 'Go';
-  form.appendChild(submit);
+  submit.className = 'map-search-submit';
+  submit.innerHTML = `${ICONS.arrowRight}<span class="sr-only">Search</span>`;
+  field.appendChild(submit);
+
+  form.appendChild(field);
+
+  const suggestions = document.createElement('div');
+  suggestions.className = 'map-search-suggestions';
+  form.appendChild(suggestions);
 
   searchWrap.appendChild(form);
 
@@ -469,8 +647,13 @@ function createSearchOverlay() {
   searchWrap.appendChild(feedback);
 
   mapState.searchInput = input;
+  mapState.searchFieldEl = field;
   mapState.searchFeedbackEl = feedback;
+  mapState.searchSuggestionsEl = suggestions;
+  mapState.searchSuggestions = [];
+  mapState.searchActiveIndex = -1;
   applyStoredSearchFeedback();
+  updateSearchSuggestions(input.value);
 
   return searchWrap;
 }
@@ -799,6 +982,7 @@ function createMapPalettePanel(items, activeTab) {
 }
 
 function handleSearchSubmit(rawQuery) {
+  clearSearchSuggestions();
   const query = (rawQuery || '').trim();
   if (!query) {
     mapState.searchValue = '';
@@ -962,13 +1146,26 @@ export async function renderMap(root) {
   mapState.nodeWasDragged = false;
   mapState.justCompletedSelection = false;
   mapState.searchInput = null;
+  mapState.searchFieldEl = null;
   mapState.searchFeedbackEl = null;
+  mapState.searchSuggestions = [];
+  mapState.searchSuggestionsEl = null;
+  mapState.searchActiveIndex = -1;
+  if (mapState.searchSuggestionTimer) {
+    clearTimeout(mapState.searchSuggestionTimer);
+    mapState.searchSuggestionTimer = null;
+  }
   stopToolboxDrag();
   mapState.toolboxEl = null;
   mapState.toolboxContainer = null;
   mapState.cursorOverride = null;
   mapState.hoveredEdge = null;
   mapState.hoveredEdgePointer = { x: 0, y: 0 };
+  if (mapState.lineMarkers) {
+    mapState.lineMarkers.clear();
+  } else {
+    mapState.lineMarkers = new Map();
+  }
   stopAutoPan();
   setAreaInteracting(false);
 
@@ -1601,8 +1798,8 @@ function buildLineMarkers(defs) {
       viewBox: '0 0 12 12',
       refX: 12,
       refY: 6,
-      markerWidth: 8,
-      markerHeight: 8,
+      markerWidth: 12,
+      markerHeight: 12,
       path: 'M0,0 L12,6 L0,12 Z'
     },
     {
@@ -1610,21 +1807,30 @@ function buildLineMarkers(defs) {
       viewBox: '0 0 12 12',
       refX: 0,
       refY: 6,
-      markerWidth: 8,
-      markerHeight: 8,
+      markerWidth: 12,
+      markerHeight: 12,
       path: 'M12,0 L0,6 L12,12 Z'
     }
   ];
+  if (!mapState.lineMarkers) {
+    mapState.lineMarkers = new Map();
+  } else {
+    mapState.lineMarkers.clear();
+  }
   configs.forEach(cfg => {
     const marker = document.createElementNS(svgNS, 'marker');
     marker.setAttribute('id', cfg.id);
     marker.setAttribute('viewBox', cfg.viewBox);
+    marker.dataset.baseRefX = String(cfg.refX);
+    marker.dataset.baseRefY = String(cfg.refY);
+    marker.dataset.baseWidth = String(cfg.markerWidth);
+    marker.dataset.baseHeight = String(cfg.markerHeight);
     marker.setAttribute('refX', String(cfg.refX));
     marker.setAttribute('refY', String(cfg.refY));
     marker.setAttribute('markerWidth', String(cfg.markerWidth));
     marker.setAttribute('markerHeight', String(cfg.markerHeight));
     marker.setAttribute('orient', 'auto');
-    marker.setAttribute('markerUnits', 'strokeWidth');
+    marker.setAttribute('markerUnits', 'userSpaceOnUse');
     marker.setAttribute('class', 'map-marker');
     const path = document.createElementNS(svgNS, 'path');
     path.setAttribute('d', cfg.path);
@@ -1633,6 +1839,28 @@ function buildLineMarkers(defs) {
     path.setAttribute('stroke-linejoin', 'round');
     marker.appendChild(path);
     defs.appendChild(marker);
+    mapState.lineMarkers.set(cfg.id, marker);
+  });
+  updateMarkerSizes();
+}
+
+function updateMarkerSizes() {
+  const markers = mapState.lineMarkers;
+  if (!markers || markers.size === 0) return;
+  const { zoomRatio = 1, lineScale = 1 } = getCurrentScales();
+  const ratio = Number.isFinite(zoomRatio) && zoomRatio > 0 ? zoomRatio : 1;
+  const strokeScale = Number.isFinite(lineScale) && lineScale > 0 ? lineScale : 1;
+  markers.forEach(marker => {
+    const baseWidth = Number(marker.dataset.baseWidth) || 12;
+    const baseHeight = Number(marker.dataset.baseHeight) || 12;
+    const baseRefX = Number(marker.dataset.baseRefX) || 0;
+    const baseRefY = Number(marker.dataset.baseRefY) || 0;
+    const width = baseWidth * ratio * strokeScale;
+    const height = baseHeight * ratio * strokeScale;
+    marker.setAttribute('markerWidth', String(width));
+    marker.setAttribute('markerHeight', String(height));
+    marker.setAttribute('refX', String(baseRefX * ratio * strokeScale));
+    marker.setAttribute('refY', String(baseRefY * ratio * strokeScale));
   });
 }
 
@@ -2559,6 +2787,7 @@ function adjustScale() {
   const lineScale = clamp(Math.pow(zoomRatio, 0.06), 0.9, 1.2);
 
   mapState.currentScales = { nodeScale, labelScale, lineScale, zoomRatio };
+  updateMarkerSizes();
 
   mapState.elements.forEach((entry, id) => {
     updateNodeGeometry(id, entry);

--- a/style.css
+++ b/style.css
@@ -4767,46 +4767,154 @@ button.builder-pill.builder-pill-outline {
 }
 
 
+
 .map-search-container {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 4px;
+  gap: 10px;
+  width: min(420px, calc(100vw - 48px));
 }
 
 .map-search {
   display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+}
+
+.map-search-field {
+  display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.86), rgba(30, 41, 59, 0.72));
+  box-shadow: 0 20px 44px rgba(2, 6, 23, 0.55);
+  backdrop-filter: blur(14px);
+  transition: border-color 180ms ease, box-shadow 200ms ease;
 }
 
-.map-search-input {
-  min-width: 200px;
-  padding-block: 6px;
-  background: rgba(15, 23, 42, 0.6);
-  color: #f8fafc;
-  border-color: rgba(148, 163, 184, 0.5);
-  backdrop-filter: blur(6px);
+.map-search-field.has-suggestions {
+  border-bottom-left-radius: 12px;
+  border-bottom-right-radius: 12px;
 }
 
-.map-search-input.not-found {
-  border-color: rgba(248, 113, 113, 0.85);
-  box-shadow: 0 0 0 2px rgba(248, 113, 113, 0.25);
+.map-search-field:focus-within {
+  border-color: color-mix(in srgb, var(--accent) 60%, transparent);
+  box-shadow: 0 24px 50px rgba(8, 145, 178, 0.35);
 }
 
-.map-search-input::placeholder {
+.map-search-field.not-found {
+  border-color: rgba(248, 113, 113, 0.8);
+  box-shadow: 0 0 0 1px rgba(248, 113, 113, 0.35), 0 22px 40px rgba(127, 29, 29, 0.35);
+}
+
+.map-search-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   color: rgba(226, 232, 240, 0.7);
 }
 
-.map-search-btn {
-  padding: 6px 12px;
-  border-radius: 999px;
+.map-search-icon svg {
+  width: 18px;
+  height: 18px;
+}
+
+.map-search-input {
+  flex: 1;
+  min-width: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: #f8fafc;
+  font-size: 15px;
+  box-shadow: none;
+}
+
+.map-search-input:focus {
+  outline: none;
+  box-shadow: none;
+}
+
+.map-search-input::placeholder {
+  color: rgba(226, 232, 240, 0.6);
+}
+
+.map-search-input.not-found {
+  color: rgba(248, 113, 113, 0.9);
+}
+
+.map-search-submit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  margin-left: 6px;
+  border-radius: 14px;
+  border: none;
+  color: rgba(15, 23, 42, 0.95);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 78%, #ffffff 15%), color-mix(in srgb, var(--accent) 45%, rgba(14, 116, 144, 0.65)));
+  box-shadow: 0 18px 32px rgba(8, 145, 178, 0.35);
+  transition: transform 150ms ease, box-shadow 180ms ease;
+}
+
+.map-search-submit:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 40px rgba(8, 145, 178, 0.45);
+}
+
+.map-search-submit:active {
+  transform: translateY(0);
+  box-shadow: 0 14px 28px rgba(8, 145, 178, 0.35);
+}
+
+.map-search-submit svg {
+  width: 16px;
+  height: 16px;
+}
+
+.map-search-suggestions {
+  display: none;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.88);
+  box-shadow: 0 24px 48px rgba(2, 6, 23, 0.55);
+  backdrop-filter: blur(12px);
+  margin-top: -4px;
+}
+
+.map-search-suggestions.visible {
+  display: flex;
+}
+
+.map-search-suggestion {
+  border: none;
+  background: transparent;
+  color: rgba(226, 232, 240, 0.86);
+  text-align: left;
+  padding: 8px 10px;
+  border-radius: 10px;
+  font-size: 14px;
+  transition: background 140ms ease, color 140ms ease;
+}
+
+.map-search-suggestion:hover,
+.map-search-suggestion.active {
+  background: color-mix(in srgb, var(--accent) 32%, rgba(15, 23, 42, 0.82));
+  color: rgba(15, 23, 42, 0.95);
 }
 
 .map-search-feedback {
   font-size: 13px;
   color: var(--text-muted);
   min-height: 18px;
+  text-align: left;
 }
 
 .map-search-feedback.success {
@@ -4822,13 +4930,12 @@ button.builder-pill.builder-pill-outline {
   top: 24px;
   left: 50%;
   transform: translateX(-50%);
-  padding: 9px 14px;
-  min-width: 0;
-  border-radius: 32px;
-  background: rgba(15, 23, 42, 0.75);
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  box-shadow: 0 18px 40px rgba(2, 6, 23, 0.55);
-  backdrop-filter: blur(10px);
+  padding: 18px 20px;
+  border-radius: 24px;
+  background: linear-gradient(150deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.78));
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  box-shadow: 0 26px 60px rgba(2, 6, 23, 0.6);
+  backdrop-filter: blur(18px);
   pointer-events: auto;
   z-index: 2;
 }


### PR DESCRIPTION
## Summary
- restyle the map search overlay with an icon button, glassmorphism treatment, and responsive layout
- add live concept suggestions with keyboard navigation while typing in the map search
- keep arrow markers crisp by switching to user-space markers that decouple head size from zoom scaling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d28fc951948322b888866f8b7c44ba