### PR TITLE
Fix lecture rich text decoding and neutralize flashcard styling

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -4286,6 +4286,13 @@ var Sevenn = (() => {
   function escapeHtml2(str = "") {
     return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
   }
+  var htmlEntityDecoder = typeof document !== "undefined" ? document.createElement("textarea") : null;
+  function decodeHtmlEntities(str = "") {
+    if (!str) return "";
+    if (!htmlEntityDecoder) return String(str);
+    htmlEntityDecoder.innerHTML = str;
+    return htmlEntityDecoder.value;
+  }
   function isSafeUrl(value = "", { allowData = false, requireHttps = false } = {}) {
     const trimmed = value.trim();
     if (!trimmed) return false;
@@ -4369,10 +4376,13 @@ var Sevenn = (() => {
     return template.innerHTML;
   }
   function normalizeInput(value = "") {
-    if (!value) return "";
-    const looksHtml = /<([a-z][^>]*>)/i.test(value);
-    if (looksHtml) return sanitizeHtml(value);
-    return sanitizeHtml(escapeHtml2(value).replace(/\n/g, "<br>"));
+    if (value == null) return "";
+    const str = String(value);
+    if (!str) return "";
+    const looksHtml = /<([a-z][^>]*>)/i.test(str);
+    if (looksHtml) return sanitizeHtml(str);
+    const decoded = decodeHtmlEntities(str);
+    return sanitizeHtml(escapeHtml2(decoded).replace(/\r?\n/g, "<br>"));
   }
   function isEmptyHtml(html = "") {
     if (!html) return true;

--- a/js/ui/components/rich-text.js
+++ b/js/ui/components/rich-text.js
@@ -46,6 +46,17 @@ function escapeHtml(str = ''){
     .replace(/'/g, '&#39;');
 }
 
+const htmlEntityDecoder = typeof document !== 'undefined'
+  ? document.createElement('textarea')
+  : null;
+
+function decodeHtmlEntities(str = ''){
+  if (!str) return '';
+  if (!htmlEntityDecoder) return String(str);
+  htmlEntityDecoder.innerHTML = str;
+  return htmlEntityDecoder.value;
+}
+
 function isSafeUrl(value = '', { allowData = false, requireHttps = false } = {}){
   const trimmed = value.trim();
   if (!trimmed) return false;
@@ -139,10 +150,13 @@ export function sanitizeHtml(html = ''){
 }
 
 function normalizeInput(value = ''){
-  if (!value) return '';
-  const looksHtml = /<([a-z][^>]*>)/i.test(value);
-  if (looksHtml) return sanitizeHtml(value);
-  return sanitizeHtml(escapeHtml(value).replace(/\n/g, '<br>'));
+  if (value == null) return '';
+  const str = String(value);
+  if (!str) return '';
+  const looksHtml = /<([a-z][^>]*>)/i.test(str);
+  if (looksHtml) return sanitizeHtml(str);
+  const decoded = decodeHtmlEntities(str);
+  return sanitizeHtml(escapeHtml(decoded).replace(/\r?\n/g, '<br>'));
 }
 
 function isEmptyHtml(html = ''){

--- a/style.css
+++ b/style.css
@@ -2932,10 +2932,14 @@ button.builder-pill.builder-pill-outline {
 /* Flashcards */
 .flashcard {
   --flash-accent: var(--accent);
-  --flash-accent-soft: color-mix(in srgb, var(--flash-accent) 18%, rgba(15, 23, 42, 0.06));
-  --flash-accent-strong: color-mix(in srgb, var(--flash-accent) 32%, rgba(15, 23, 42, 0.12));
-  --flash-accent-border: color-mix(in srgb, var(--flash-accent) 42%, rgba(15, 23, 42, 0.2));
-  --flash-accent-subtle: color-mix(in srgb, var(--flash-accent) 10%, rgba(148, 163, 184, 0.16));
+  --flash-neutral-inactive: color-mix(in srgb, var(--surface-2) 92%, rgba(148, 163, 184, 0.16));
+  --flash-neutral-start: color-mix(in srgb, var(--surface-2) 84%, rgba(148, 163, 184, 0.26));
+  --flash-neutral-end: color-mix(in srgb, var(--surface-3) 70%, rgba(148, 163, 184, 0.3));
+  --flash-neutral-border: color-mix(in srgb, var(--surface-3) 92%, transparent);
+  --flash-accent-soft: var(--flash-neutral-start);
+  --flash-accent-strong: var(--flash-neutral-end);
+  --flash-accent-border: var(--flash-neutral-border);
+  --flash-accent-subtle: color-mix(in srgb, var(--flash-neutral-border) 60%, transparent);
   display: flex;
   flex-direction: column;
   gap: var(--pad);
@@ -2947,7 +2951,7 @@ button.builder-pill.builder-pill-outline {
   border-radius: var(--radius);
   padding: var(--pad-sm);
   border: 1px solid var(--flash-accent-subtle);
-  background: color-mix(in srgb, var(--flash-accent) 8%, rgba(15, 23, 42, 0.04));
+  background: var(--flash-neutral-inactive);
   transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
 }
 
@@ -2964,7 +2968,7 @@ button.builder-pill.builder-pill-outline {
 }
 
 .flash-section[data-active="true"] .flash-heading {
-  color: color-mix(in srgb, var(--flash-accent) 82%, #041021);
+  color: color-mix(in srgb, var(--text) 92%, rgba(148, 163, 184, 0.08));
 }
 
 .flash-heading {


### PR DESCRIPTION
## Summary
- decode stored HTML entities before normalizing rich text input so editing keeps existing formatting
- shift flashcard section backgrounds to neutral surfaces while leaving inline content styling intact
- regenerate the prebuilt bundle to capture the updated logic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5aee22d648322a0b89bcdb3127e0e