### PR TITLE
Preserve lecture view state and persist filters

### DIFF
--- a/js/storage/preferences.js
+++ b/js/storage/preferences.js
@@ -1,0 +1,65 @@
+const STORAGE_KEY = 'sevenn-ui-preferences';
+let cache = null;
+
+function canUseStorage() {
+  try {
+    return typeof localStorage !== 'undefined';
+  } catch (err) {
+    return false;
+  }
+}
+
+function readPreferences() {
+  if (cache) {
+    return cache;
+  }
+  if (!canUseStorage()) {
+    cache = {};
+    return cache;
+  }
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      cache = {};
+      return cache;
+    }
+    const parsed = JSON.parse(raw);
+    cache = parsed && typeof parsed === 'object' ? parsed : {};
+  } catch (err) {
+    console.warn('Failed to read UI preferences', err);
+    cache = {};
+  }
+  return cache;
+}
+
+export function loadUIPreferences() {
+  const stored = readPreferences();
+  return stored ? { ...stored } : {};
+}
+
+export function updateUIPreferences(patch) {
+  if (!patch || typeof patch !== 'object') {
+    return loadUIPreferences();
+  }
+  const current = { ...readPreferences() };
+  let changed = false;
+  for (const [key, value] of Object.entries(patch)) {
+    if (typeof value === 'undefined') continue;
+    if (current[key] !== value) {
+      current[key] = value;
+      changed = true;
+    }
+  }
+  if (!changed) {
+    return current;
+  }
+  cache = current;
+  if (canUseStorage()) {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(current));
+    } catch (err) {
+      console.warn('Failed to persist UI preferences', err);
+    }
+  }
+  return current;
+}

--- a/style.css
+++ b/style.css
@@ -176,6 +176,7 @@ button:not(.tab):not(.fab-btn):not(.builder-pill):not(.builder-mode-toggle):not(
   align-items: center;
   justify-content: space-between;
   gap: 24px;
+  flex-wrap: wrap;
 }
 
 .header-left {
@@ -183,16 +184,18 @@ button:not(.tab):not(.fab-btn):not(.builder-pill):not(.builder-mode-toggle):not(
   align-items: center;
   gap: 16px;
   flex-wrap: wrap;
-  flex-shrink: 0;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .header-right {
   display: flex;
   align-items: center;
   gap: 16px;
-  flex: 1;
+  flex: 1 1 320px;
   justify-content: flex-end;
-  min-width: 0;
+  min-width: 220px;
+  flex-wrap: wrap;
 }
 
 .row {
@@ -217,6 +220,11 @@ button:not(.tab):not(.fab-btn):not(.builder-pill):not(.builder-mode-toggle):not(
   border: 1px solid rgba(148, 163, 184, 0.24);
   box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.45);
   flex-wrap: wrap;
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: thin;
+  -webkit-overflow-scrolling: touch;
 }
 
 
@@ -719,6 +727,7 @@ button:not(.tab):not(.fab-btn):not(.builder-pill):not(.builder-mode-toggle):not(
     justify-content: space-between;
     gap: 12px;
     flex-wrap: wrap;
+    min-width: 0;
   }
 
   .search-field {
@@ -726,7 +735,7 @@ button:not(.tab):not(.fab-btn):not(.builder-pill):not(.builder-mode-toggle):not(
   }
 
   .tabs {
-    justify-content: center;
+    justify-content: flex-start;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a UI preferences store and hook global state setters so lecture and entry filters persist across sessions
- capture and restore lecture list expansion/scroll state during redraws, respecting active filters after interactions
- tweak header layout styles for better tab/search responsiveness and refresh the bundled output

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da8f870ee4832283742ca172c3227b