### PR TITLE
Improve concept map scaling and navigation performance

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -17360,6 +17360,7 @@ var Sevenn = (() => {
     baseCursor: "grab",
     cursorOverride: null,
     defaultViewSize: null,
+    lastScaleSize: null,
     justCompletedSelection: false,
     edgeTooltip: null,
     hoveredEdge: null,
@@ -18523,9 +18524,20 @@ var Sevenn = (() => {
     if (!Number.isFinite(mapState.defaultViewSize)) {
       mapState.defaultViewSize = viewBox.w;
     }
-    const updateViewBox = () => {
+    const updateViewBox = (options = {}) => {
       svg.setAttribute("viewBox", `${viewBox.x} ${viewBox.y} ${viewBox.w} ${viewBox.h}`);
-      adjustScale();
+      const { forceScale = false } = options;
+      if (forceScale) {
+        mapState.lastScaleSize = { w: viewBox.w, h: viewBox.h };
+        adjustScale();
+        return;
+      }
+      const prev = mapState.lastScaleSize;
+      const sizeChanged = !prev || Math.abs(prev.w - viewBox.w) > 0.5 || Math.abs(prev.h - viewBox.h) > 0.5;
+      if (sizeChanged) {
+        mapState.lastScaleSize = { w: viewBox.w, h: viewBox.h };
+        adjustScale();
+      }
     };
     mapState.updateViewBox = updateViewBox;
     const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
@@ -19001,7 +19013,7 @@ var Sevenn = (() => {
       text.setAttribute("x", pos.x);
       text.setAttribute("y", pos.y - (baseR + 12));
       text.setAttribute("class", "map-label");
-      text.setAttribute("font-size", "16");
+      text.setAttribute("font-size", "14");
       text.dataset.id = it.id;
       text.textContent = it.name || it.concept || "?";
       text.addEventListener("mousedown", handleNodePointerDown);
@@ -19022,7 +19034,7 @@ var Sevenn = (() => {
     });
     updateSelectionHighlight();
     updatePendingHighlight();
-    updateViewBox();
+    updateViewBox({ forceScale: true });
     refreshCursor();
   }
   function ensureListeners() {
@@ -19178,7 +19190,7 @@ var Sevenn = (() => {
     });
     svg.addEventListener("wheel", (e) => {
       e.preventDefault();
-      const factor = e.deltaY < 0 ? 0.96 : 1.04;
+      const factor = e.deltaY < 0 ? 0.97 : 1.03;
       const rect = svg.getBoundingClientRect();
       const mx = mapState.viewBox.x + (e.clientX - rect.left) / rect.width * mapState.viewBox.w;
       const my = mapState.viewBox.y + (e.clientY - rect.top) / rect.height * mapState.viewBox.h;
@@ -19582,9 +19594,9 @@ var Sevenn = (() => {
     circle.setAttribute("r", baseR * nodeScale);
     if (label) {
       label.setAttribute("x", pos.x);
-      const offset = (baseR + 16) * nodeScale;
+      const offset = (baseR + 12) * nodeScale;
       label.setAttribute("y", pos.y - offset);
-      const fontSize = Math.max(14, 16 * labelScale);
+      const fontSize = Math.max(12, 14 * labelScale);
       label.setAttribute("font-size", fontSize);
     }
   }
@@ -20120,13 +20132,16 @@ var Sevenn = (() => {
     if (!svg) return;
     const vb = svg.getAttribute("viewBox");
     if (!vb) return;
-    const [, , w] = vb.split(" ").map(Number);
+    const parts = vb.split(/\s+/).map(Number);
+    const [, , w, h] = parts;
     if (!Number.isFinite(w) || w <= 0) return;
+    const height = Number.isFinite(h) && h > 0 ? h : w;
     const defaultSize = Number.isFinite(mapState.defaultViewSize) ? mapState.defaultViewSize : w;
     const zoomRatio = w / defaultSize;
-    const nodeScale = clamp2(Math.pow(zoomRatio, 0.04), 0.92, 1.6);
-    const labelScale = clamp2(Math.pow(zoomRatio, 0.28), 1.1, 3.2);
-    const lineScale = clamp2(Math.pow(zoomRatio, 0.05), 0.95, 1.35);
+    const nodeScale = clamp2(Math.pow(zoomRatio, 0.02), 0.85, 1.35);
+    const labelScale = clamp2(Math.pow(zoomRatio, 0.18), 0.95, 2.6);
+    const lineScale = clamp2(Math.pow(zoomRatio, 0.04), 0.92, 1.28);
+    mapState.lastScaleSize = { w, h: height };
     mapState.currentScales = { nodeScale, labelScale, lineScale, zoomRatio };
     updateMarkerSizes();
     mapState.elements.forEach((entry, id) => {


### PR DESCRIPTION
## Summary
- reduce map label sizing and offsets so more concepts fit on screen without sacrificing readability
- slow down zoom increments and adjust node scaling factors to keep the layout clean while zooming
- skip expensive scale recalculations when panning by tracking the last viewbox dimensions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db09a9eb40832288fa3ceb80b21101