### PR TITLE
Improve concept map performance

### DIFF
--- a/style.css
+++ b/style.css
@@ -4633,6 +4633,11 @@ button.builder-pill.builder-pill-outline {
     linear-gradient(160deg, #0b1422 0%, #0a101b 45%, #05070d 100%);
   border-top: 1px solid rgba(148, 163, 184, 0.24);
 }
+.map-layer--edges,
+.map-layer--nodes {
+  will-change: transform;
+  contain: layout paint;
+}
 .map-node {
   cursor: inherit;
   stroke: rgba(15, 23, 42, 0.82);


### PR DESCRIPTION
## Summary
- cache concept map edge elements so drag and zoom updates no longer query the DOM on every frame
- reuse the cached edge set when scaling and rebuild the distribution bundle with the optimized logic
- add CSS rendering hints for the SVG layers to keep the map responsive

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68db0c1a85a88322858f794d982a66a0