### PR TITLE
Improve concept map interaction performance

### DIFF
--- a/style.css
+++ b/style.css
@@ -4628,6 +4628,8 @@ button.builder-pill.builder-pill-outline {
   width: 100%;
   height: 100%;
   cursor: grab;
+  touch-action: none;
+  user-select: none;
   background:
     radial-gradient(circle at 18% 22%, rgba(148, 163, 184, 0.12), transparent 58%),
     linear-gradient(160deg, #0b1422 0%, #0a101b 45%, #05070d 100%);


### PR DESCRIPTION
## Summary
- cache SVG geometry, throttle viewBox updates, and smooth zooming to reduce map lag
- disable default touch and selection behaviors on the map canvas to improve pointer handling
- rebuild the front-end bundle

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db0fcf9eec8322b0e551125a1d65ca