### PR TITLE
Improve concept map dragging smoothness and label styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -4642,9 +4642,10 @@ button.builder-pill.builder-pill-outline {
 }
 .map-node {
   cursor: inherit;
-  stroke: rgba(15, 23, 42, 0.82);
-  stroke-width: 2.2;
+  stroke: rgba(255, 255, 255, 0.35);
+  stroke-width: 1.6;
   vector-effect: non-scaling-stroke;
+  filter: drop-shadow(0 8px 18px rgba(15, 23, 42, 0.45));
 }
 .map-edge {
   stroke: var(--gray);
@@ -4698,17 +4699,17 @@ button.builder-pill.builder-pill-outline {
 }
 
 .map-label {
-  fill: var(--text);
+  fill: #ffffff;
   font-size: 16px;
-  font-weight: 600;
+  font-weight: 700;
   text-anchor: middle;
-  pointer-events: none;
-  text-shadow: 0 0 10px rgba(0, 0, 0, 0.55);
-  paint-order: stroke fill;
-  stroke: rgba(6, 11, 23, 0.72);
-  stroke-width: 4px;
-  stroke-linejoin: round;
-  letter-spacing: 0.02em;
+  pointer-events: auto;
+  text-shadow: 0 2px 14px rgba(15, 23, 42, 0.65);
+  paint-order: normal;
+  stroke: none;
+  stroke-width: 0;
+  letter-spacing: 0.01em;
+  text-rendering: geometricPrecision;
 }
 
 .map-edge-tooltip {
@@ -5607,7 +5608,7 @@ body.map-toolbox-dragging {
 
 .map-label.selected {
   fill: var(--yellow);
-  font-weight: 600;
+  font-weight: 700;
 }
 
 .map-node.pending {
@@ -5617,7 +5618,7 @@ body.map-toolbox-dragging {
 
 .map-label.pending {
   fill: var(--pink);
-  font-weight: 600;
+  font-weight: 700;
 }
 
 /* Exams */


### PR DESCRIPTION
## Summary
- throttle concept map node updates with an animation-frame queue for smoother dragging
- flush pending position updates when releasing drags or rerendering the map
- restyle nodes and labels for higher-contrast text and softer outlines

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbd028f8448322b31d485fcc121879