### PR TITLE
Improve concept map filters and navigation interactions

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -1,4 +1,31 @@
-(() => {
+var Sevenn = (() => {
+  var __defProp = Object.defineProperty;
+  var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+  var __getOwnPropNames = Object.getOwnPropertyNames;
+  var __hasOwnProp = Object.prototype.hasOwnProperty;
+  var __export = (target, all) => {
+    for (var name in all)
+      __defProp(target, name, { get: all[name], enumerable: true });
+  };
+  var __copyProps = (to, from, except, desc) => {
+    if (from && typeof from === "object" || typeof from === "function") {
+      for (let key of __getOwnPropNames(from))
+        if (!__hasOwnProp.call(to, key) && key !== except)
+          __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+    }
+    return to;
+  };
+  var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+  // js/main.js
+  var main_exports = {};
+  __export(main_exports, {
+    render: () => renderApp,
+    renderApp: () => renderApp,
+    resolveListKind: () => resolveListKind,
+    tabs: () => tabs
+  });
+
   // js/storage/preferences.js
   var STORAGE_KEY = "sevenn-ui-preferences";
   var cache = null;
@@ -17243,6 +17270,8 @@
       23
     )
   };
+  var PAN_ACCELERATION = 1.12;
+  var ZOOM_INTENSITY = 32e-4;
   var ICONS = {
     sliders: '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 7h12" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" /><path d="M6 12h8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" /><path d="M6 17h14" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" /><circle cx="16" cy="7" r="2.5" stroke="currentColor" stroke-width="1.6" /><circle cx="11" cy="12" r="2.5" stroke="currentColor" stroke-width="1.6" /><circle cx="19" cy="17" r="2.5" stroke="currentColor" stroke-width="1.6" /></svg>',
     close: '<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M5 5l10 10M15 5L5 15" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" /></svg>',
@@ -17365,7 +17394,9 @@
     nodeLayer: null,
     lineMarkers: /* @__PURE__ */ new Map(),
     edgeRefs: /* @__PURE__ */ new Map(),
-    allEdges: /* @__PURE__ */ new Set()
+    allEdges: /* @__PURE__ */ new Set(),
+    pendingNodeUpdates: /* @__PURE__ */ new Map(),
+    nodeUpdateFrame: null
   };
   function normalizeMapTab(tab = {}) {
     const filter = tab.filter && typeof tab.filter === "object" ? tab.filter : {};
@@ -17389,14 +17420,82 @@
       layoutSeeded: tab.layoutSeeded === true,
       filter: {
         blockId: filter.blockId || "",
-        week: Number.isFinite(filter.week) ? filter.week : typeof filter.week === "string" && filter.week.trim() ? Number(filter.week) : "",
-        lectureKey: filter.lectureKey || ""
+        weeks: getFilterWeeks(filter),
+        lectureKeys: getFilterLectureKeys(filter)
       }
     };
-    if (!Number.isFinite(normalized2.filter.week)) {
-      normalized2.filter.week = "";
-    }
     return normalized2;
+  }
+  function parseWeekValue(value) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === "string" && value.trim()) {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+    return null;
+  }
+  function normalizeWeekArray(values = []) {
+    const seen = /* @__PURE__ */ new Set();
+    const result = [];
+    values.forEach((value) => {
+      const week = parseWeekValue(value);
+      if (!Number.isFinite(week) || seen.has(week)) return;
+      seen.add(week);
+      result.push(week);
+    });
+    result.sort((a, b) => a - b);
+    return result;
+  }
+  function normalizeLectureKeyArray(values = []) {
+    const seen = /* @__PURE__ */ new Set();
+    const result = [];
+    values.forEach((value) => {
+      const key = typeof value === "string" ? value.trim() : "";
+      if (!key || seen.has(key)) return;
+      seen.add(key);
+      result.push(key);
+    });
+    return result;
+  }
+  function getFilterWeeks(filter = {}) {
+    if (!filter || typeof filter !== "object") {
+      return [];
+    }
+    const weeks = normalizeWeekArray(filter.weeks);
+    if (weeks.length) {
+      return weeks;
+    }
+    const legacy = parseWeekValue(filter.week);
+    return Number.isFinite(legacy) ? [legacy] : [];
+  }
+  function getFilterLectureKeys(filter = {}) {
+    if (!filter || typeof filter !== "object") {
+      return [];
+    }
+    const keys = normalizeLectureKeyArray(filter.lectureKeys);
+    if (keys.length) {
+      return keys;
+    }
+    const legacy = typeof filter.lectureKey === "string" ? filter.lectureKey.trim() : "";
+    return legacy ? [legacy] : [];
+  }
+  function setFilterWeeks(targetFilter, weeks = []) {
+    if (!targetFilter || typeof targetFilter !== "object") return;
+    targetFilter.weeks = normalizeWeekArray(weeks);
+    if ("week" in targetFilter) {
+      targetFilter.week = "";
+    }
+  }
+  function setFilterLectureKeys(targetFilter, keys = []) {
+    if (!targetFilter || typeof targetFilter !== "object") return;
+    targetFilter.lectureKeys = normalizeLectureKeyArray(keys);
+    if ("lectureKey" in targetFilter) {
+      targetFilter.lectureKey = "";
+    }
   }
   function deriveItemGroupKeys(item) {
     const groups = [];
@@ -17531,7 +17630,7 @@
       manualMode: false,
       manualIds: [],
       layoutSeeded: true,
-      filter: { blockId: "", week: "", lectureKey: "" }
+      filter: { blockId: "", weeks: [], lectureKeys: [] }
     });
     config.tabs.push(tab);
     config.activeTabId = tab.id;
@@ -17694,10 +17793,32 @@
     const config = mapState.mapConfig || { tabs: [] };
     const tabsWrap = document.createElement("div");
     tabsWrap.className = "map-tabs";
+    const header = document.createElement("div");
+    header.className = "map-tabs-header";
     const heading = document.createElement("div");
     heading.className = "map-tabs-heading";
-    heading.textContent = "Concept maps";
-    tabsWrap.appendChild(heading);
+    const title = document.createElement("h2");
+    title.className = "map-tabs-title";
+    title.textContent = "Concept maps";
+    heading.appendChild(title);
+    const subtitle = document.createElement("p");
+    subtitle.className = "map-tabs-subtitle";
+    subtitle.textContent = "Jump between saved layouts or spin up a fresh canvas.";
+    heading.appendChild(subtitle);
+    header.appendChild(heading);
+    const actions = document.createElement("div");
+    actions.className = "map-tab-actions";
+    const addBtn = document.createElement("button");
+    addBtn.type = "button";
+    addBtn.className = "map-pill-btn map-tab-add";
+    addBtn.setAttribute("aria-label", "Create new map tab");
+    addBtn.innerHTML = `${ICONS.plus}<span>New map</span>`;
+    addBtn.addEventListener("click", () => {
+      createMapTab();
+    });
+    actions.appendChild(addBtn);
+    header.appendChild(actions);
+    tabsWrap.appendChild(header);
     const tabList = document.createElement("div");
     tabList.className = "map-tab-list";
     config.tabs.forEach((tab) => {
@@ -17713,30 +17834,6 @@
       tabList.appendChild(btn);
     });
     tabsWrap.appendChild(tabList);
-    const actions = document.createElement("div");
-    actions.className = "map-tab-actions";
-    const addBtn = document.createElement("button");
-    addBtn.type = "button";
-    addBtn.className = "map-icon-btn map-tab-add";
-    addBtn.setAttribute("aria-label", "Create new map tab");
-    addBtn.innerHTML = `${ICONS.plus}`;
-    addBtn.addEventListener("click", () => {
-      createMapTab();
-    });
-    actions.appendChild(addBtn);
-    const settingsBtn = document.createElement("button");
-    settingsBtn.type = "button";
-    settingsBtn.className = "map-icon-btn map-tab-settings";
-    settingsBtn.setAttribute("aria-label", "Open settings");
-    settingsBtn.innerHTML = `${ICONS.gear}`;
-    settingsBtn.addEventListener("click", () => {
-      const headerSettings = document.querySelector(".header-settings-btn");
-      if (headerSettings) {
-        headerSettings.click();
-      }
-    });
-    actions.appendChild(settingsBtn);
-    tabsWrap.appendChild(actions);
     return tabsWrap;
   }
   function createSearchOverlay() {
@@ -17873,8 +17970,8 @@
       activeTab.manualMode = manualInput.checked;
       if (manualInput.checked) {
         activeTab.filter.blockId = "";
-        activeTab.filter.week = "";
-        activeTab.filter.lectureKey = "";
+        setFilterWeeks(activeTab.filter, []);
+        setFilterLectureKeys(activeTab.filter, []);
         activeTab.includeLinked = false;
       } else {
         activeTab.includeLinked = true;
@@ -17906,8 +18003,11 @@
     const filterRow = document.createElement("div");
     filterRow.className = "map-controls-row";
     const blockWrap = document.createElement("label");
-    blockWrap.className = "map-control";
-    blockWrap.textContent = "Block";
+    blockWrap.className = "map-control map-control-group";
+    const blockLabel = document.createElement("span");
+    blockLabel.className = "map-control-label";
+    blockLabel.textContent = "Block";
+    blockWrap.appendChild(blockLabel);
     const blockSelect = document.createElement("select");
     blockSelect.className = "map-select";
     const blocks = mapState.blocks || [];
@@ -17925,85 +18025,168 @@
     blockSelect.disabled = Boolean(activeTab.manualMode);
     blockSelect.addEventListener("change", async () => {
       activeTab.filter.blockId = blockSelect.value;
-      activeTab.filter.week = "";
-      activeTab.filter.lectureKey = "";
+      setFilterWeeks(activeTab.filter, []);
+      setFilterLectureKeys(activeTab.filter, []);
       await persistMapConfig();
       await renderMap(mapState.root);
     });
     blockWrap.appendChild(blockSelect);
     filterRow.appendChild(blockWrap);
-    const weekWrap = document.createElement("label");
-    weekWrap.className = "map-control";
-    weekWrap.textContent = "Week";
-    const weekSelect = document.createElement("select");
-    weekSelect.className = "map-select";
-    const weekBlock = blocks.find((b) => b.blockId === blockSelect.value);
-    const weekDefault = document.createElement("option");
-    weekDefault.value = "";
-    weekDefault.textContent = blockSelect.value ? "All weeks" : "Select a block";
-    weekSelect.appendChild(weekDefault);
-    if (weekBlock && blockSelect.value) {
-      const weekNumbers = /* @__PURE__ */ new Set();
-      if (Number(weekBlock.weeks)) {
-        for (let i = 1; i <= Number(weekBlock.weeks); i++) {
-          weekNumbers.add(i);
-        }
+    const makeChip = ({ label, active = false, onToggle, disabled = false, title }) => {
+      const chip = document.createElement("button");
+      chip.type = "button";
+      chip.className = "map-chip" + (active ? " active" : "");
+      chip.textContent = label;
+      chip.setAttribute("aria-pressed", active ? "true" : "false");
+      if (title) {
+        chip.title = title;
       }
-      (weekBlock.lectures || []).forEach((lec) => {
-        if (Number.isFinite(lec?.week)) {
-          weekNumbers.add(lec.week);
-        }
-      });
-      Array.from(weekNumbers).sort((a, b) => a - b).forEach((num) => {
-        const opt = document.createElement("option");
-        opt.value = String(num);
-        opt.textContent = `Week ${num}`;
-        weekSelect.appendChild(opt);
-      });
-    }
-    if (blockSelect.value && activeTab.filter.week) {
-      weekSelect.value = String(activeTab.filter.week);
+      if (disabled) {
+        chip.disabled = true;
+        chip.classList.add("disabled");
+      } else if (typeof onToggle === "function") {
+        chip.addEventListener("click", onToggle);
+      }
+      return chip;
+    };
+    const selectedWeeks = new Set(getFilterWeeks(activeTab.filter));
+    const selectedLectures = new Set(getFilterLectureKeys(activeTab.filter));
+    const weekBlock = blocks.find((b) => b.blockId === blockSelect.value);
+    const filtersDisabled = Boolean(activeTab.manualMode);
+    const hasBlock = Boolean(blockSelect.value);
+    const weekWrap = document.createElement("div");
+    weekWrap.className = "map-control map-control-group";
+    const weekLabel = document.createElement("div");
+    weekLabel.className = "map-control-label";
+    weekLabel.textContent = "Weeks";
+    weekWrap.appendChild(weekLabel);
+    const weekList = document.createElement("div");
+    weekList.className = "map-chip-list";
+    weekWrap.appendChild(weekList);
+    const applyWeeks = async (nextWeeks) => {
+      setFilterWeeks(activeTab.filter, nextWeeks);
+      setFilterLectureKeys(activeTab.filter, []);
+      await persistMapConfig();
+      await renderMap(mapState.root);
+    };
+    if (!hasBlock || filtersDisabled) {
+      const message = document.createElement("div");
+      message.className = "map-chip-empty";
+      message.textContent = filtersDisabled ? "Disabled in manual mode." : "Choose a block to filter weeks.";
+      weekList.appendChild(message);
     } else {
-      weekSelect.value = "";
+      const weekNumbers = /* @__PURE__ */ new Set();
+      if (weekBlock) {
+        if (Number(weekBlock.weeks)) {
+          for (let i = 1; i <= Number(weekBlock.weeks); i++) {
+            weekNumbers.add(i);
+          }
+        }
+        (weekBlock.lectures || []).forEach((lec) => {
+          if (Number.isFinite(lec?.week)) {
+            weekNumbers.add(lec.week);
+          }
+        });
+      }
+      const sortedWeeks = Array.from(weekNumbers).sort((a, b) => a - b);
+      weekList.appendChild(
+        makeChip({
+          label: "All weeks",
+          active: selectedWeeks.size === 0,
+          onToggle: () => applyWeeks([])
+        })
+      );
+      if (!sortedWeeks.length) {
+        const empty = document.createElement("div");
+        empty.className = "map-chip-empty";
+        empty.textContent = "No weeks found for this block.";
+        weekList.appendChild(empty);
+      } else {
+        sortedWeeks.forEach((num) => {
+          weekList.appendChild(
+            makeChip({
+              label: `Week ${num}`,
+              active: selectedWeeks.has(num),
+              onToggle: () => {
+                const next = new Set(selectedWeeks);
+                if (next.has(num)) {
+                  next.delete(num);
+                } else {
+                  next.add(num);
+                }
+                applyWeeks(Array.from(next).sort((a, b) => a - b));
+              }
+            })
+          );
+        });
+      }
     }
-    weekSelect.disabled = !blockSelect.value || Boolean(activeTab.manualMode);
-    weekSelect.addEventListener("change", async () => {
-      const val = weekSelect.value;
-      activeTab.filter.week = val ? Number(val) : "";
-      activeTab.filter.lectureKey = "";
-      await persistMapConfig();
-      await renderMap(mapState.root);
-    });
-    weekWrap.appendChild(weekSelect);
     filterRow.appendChild(weekWrap);
-    const lectureWrap = document.createElement("label");
-    lectureWrap.className = "map-control";
-    lectureWrap.textContent = "Lecture";
-    const lectureSelect = document.createElement("select");
-    lectureSelect.className = "map-select";
-    const lectureDefault = document.createElement("option");
-    lectureDefault.value = "";
-    lectureDefault.textContent = blockSelect.value ? "All lectures" : "Select a block";
-    lectureSelect.appendChild(lectureDefault);
-    if (weekBlock && blockSelect.value) {
-      const lectures = Array.isArray(weekBlock.lectures) ? weekBlock.lectures : [];
-      const weekFilter = activeTab.filter.week;
-      lectures.filter((lec) => !weekFilter || lec.week === weekFilter).forEach((lec) => {
-        const opt = document.createElement("option");
-        opt.value = `${weekBlock.blockId}|${lec.id}`;
-        const label = lec.name ? `${lec.name} (Week ${lec.week})` : `Lecture ${lec.id}`;
-        opt.textContent = label;
-        lectureSelect.appendChild(opt);
-      });
-    }
-    lectureSelect.value = activeTab.filter.lectureKey || "";
-    lectureSelect.disabled = !blockSelect.value || Boolean(activeTab.manualMode);
-    lectureSelect.addEventListener("change", async () => {
-      activeTab.filter.lectureKey = lectureSelect.value || "";
+    const lectureWrap = document.createElement("div");
+    lectureWrap.className = "map-control map-control-group";
+    const lectureLabel = document.createElement("div");
+    lectureLabel.className = "map-control-label";
+    lectureLabel.textContent = "Lectures";
+    lectureWrap.appendChild(lectureLabel);
+    const lectureList = document.createElement("div");
+    lectureList.className = "map-chip-list";
+    lectureWrap.appendChild(lectureList);
+    const applyLectures = async (nextKeys) => {
+      setFilterLectureKeys(activeTab.filter, nextKeys);
       await persistMapConfig();
       await renderMap(mapState.root);
-    });
-    lectureWrap.appendChild(lectureSelect);
+    };
+    if (!hasBlock || filtersDisabled) {
+      const message = document.createElement("div");
+      message.className = "map-chip-empty";
+      message.textContent = filtersDisabled ? "Disabled in manual mode." : "Choose a block first.";
+      lectureList.appendChild(message);
+    } else {
+      const lectures = Array.isArray(weekBlock?.lectures) ? weekBlock.lectures : [];
+      const filteredLectures = lectures.filter((lec) => !selectedWeeks.size || selectedWeeks.has(Number(lec.week))).sort((a, b) => {
+        const weekA = Number(a.week) || 0;
+        const weekB = Number(b.week) || 0;
+        if (weekA !== weekB) return weekA - weekB;
+        const idA = Number(a.id) || 0;
+        const idB = Number(b.id) || 0;
+        return idA - idB;
+      });
+      lectureList.appendChild(
+        makeChip({
+          label: "All lectures",
+          active: selectedLectures.size === 0,
+          onToggle: () => applyLectures([])
+        })
+      );
+      if (!filteredLectures.length) {
+        const empty = document.createElement("div");
+        empty.className = "map-chip-empty";
+        empty.textContent = selectedWeeks.size ? "No lectures match the selected weeks." : "No lectures found for this block.";
+        lectureList.appendChild(empty);
+      } else {
+        filteredLectures.forEach((lec) => {
+          const key = `${weekBlock.blockId}|${lec.id}`;
+          const label = lec.name ? lec.name : `Lecture ${lec.id}`;
+          const weekLabel2 = Number.isFinite(lec.week) ? `Week ${lec.week}` : "";
+          lectureList.appendChild(
+            makeChip({
+              label: weekLabel2 ? `${label} \xB7 ${weekLabel2}` : label,
+              title: weekLabel2 ? `${label} (${weekLabel2})` : label,
+              active: selectedLectures.has(key),
+              onToggle: () => {
+                const next = new Set(selectedLectures);
+                if (next.has(key)) {
+                  next.delete(key);
+                } else {
+                  next.add(key);
+                }
+                applyLectures(Array.from(next));
+              }
+            })
+          );
+        });
+      }
+    }
     filterRow.appendChild(lectureWrap);
     const resetBtn = document.createElement("button");
     resetBtn.type = "button";
@@ -18012,8 +18195,8 @@
     resetBtn.disabled = Boolean(activeTab.manualMode);
     resetBtn.addEventListener("click", async () => {
       activeTab.filter.blockId = "";
-      activeTab.filter.week = "";
-      activeTab.filter.lectureKey = "";
+      setFilterWeeks(activeTab.filter, []);
+      setFilterLectureKeys(activeTab.filter, []);
       await persistMapConfig();
       await renderMap(mapState.root);
     });
@@ -18167,37 +18350,42 @@
   function matchesFilter(item, filter = {}) {
     if (!filter) return true;
     const blockId = filter.blockId || "";
-    const week = filter.week;
-    const lectureKey2 = filter.lectureKey || "";
+    const weeks = getFilterWeeks(filter);
+    const lectureKeys = getFilterLectureKeys(filter);
     if (blockId) {
       const inBlock = (item.blocks || []).includes(blockId) || (item.lectures || []).some((lec) => lec.blockId === blockId);
       if (!inBlock) return false;
     }
-    if (week !== "" && week !== null && week !== void 0) {
-      const weekNum = Number(week);
-      if (Number.isFinite(weekNum)) {
+    if (weeks.length) {
+      const satisfiesWeek = weeks.some((weekNum) => {
+        if (!Number.isFinite(weekNum)) return false;
         if (blockId) {
-          const matchesWeek = (item.lectures || []).some((lec) => lec.blockId === blockId && lec.week === weekNum) || (item.weeks || []).includes(weekNum);
-          if (!matchesWeek) return false;
-        } else if (!(item.weeks || []).includes(weekNum)) {
-          return false;
+          const inLectures = (item.lectures || []).some((lec) => lec.blockId === blockId && Number(lec.week) === weekNum);
+          const inWeeks = Array.isArray(item.weeks) && item.weeks.includes(weekNum);
+          return inLectures || inWeeks;
         }
-      }
+        const directWeek = Array.isArray(item.weeks) && item.weeks.includes(weekNum);
+        if (directWeek) return true;
+        return (item.lectures || []).some((lec) => Number(lec.week) === weekNum);
+      });
+      if (!satisfiesWeek) return false;
     }
-    if (lectureKey2) {
-      const [blk, lecStr] = lectureKey2.split("|");
-      const lecId = Number(lecStr);
-      if (Number.isFinite(lecId)) {
-        const blockMatch = blk || blockId;
-        const hasLecture = (item.lectures || []).some((lec) => {
-          if (!Number.isFinite(lec.id)) return false;
+    if (lectureKeys.length) {
+      const satisfiesLecture = lectureKeys.some((rawKey) => {
+        if (!rawKey) return false;
+        const [blk, lecStr] = String(rawKey).split("|");
+        const lecId = Number(lecStr);
+        if (!Number.isFinite(lecId)) return false;
+        const blockMatch = blk || blockId || "";
+        return (item.lectures || []).some((lec) => {
+          if (!Number.isFinite(lec?.id)) return false;
           if (blockMatch) {
             return lec.blockId === blockMatch && lec.id === lecId;
           }
           return lec.id === lecId;
         });
-        if (!hasLecture) return false;
-      }
+      });
+      if (!satisfiesLecture) return false;
     }
     return true;
   }
@@ -18343,6 +18531,10 @@
     setAreaInteracting(false);
     mapState.edgeLayer = null;
     mapState.nodeLayer = null;
+    flushNodePositionUpdates({ cancelFrame: true });
+    if (mapState.pendingNodeUpdates) {
+      mapState.pendingNodeUpdates.clear();
+    }
     ensureListeners();
     await ensureMapConfig();
     const catalog = await loadBlockCatalog();
@@ -18380,6 +18572,14 @@
     container.className = "map-container";
     stage.appendChild(container);
     mapState.container = container;
+    container.addEventListener("pointerdown", (e) => {
+      if (mapState.tool === TOOL.AREA) return;
+      if (e.button !== 0) return;
+      if (e.target !== container) return;
+      if (beginViewDrag(e)) {
+        e.preventDefault();
+      }
+    });
     const overlay = document.createElement("div");
     overlay.className = "map-overlay";
     stage.appendChild(overlay);
@@ -18403,7 +18603,14 @@
     closeBtn.className = "map-menu-close";
     closeBtn.setAttribute("aria-label", "Hide map controls");
     closeBtn.innerHTML = `<span class="sr-only">Hide map controls</span>${ICONS.close}`;
-    panel.appendChild(closeBtn);
+    const panelHeader = document.createElement("div");
+    panelHeader.className = "map-menu-header";
+    const panelTitle = document.createElement("div");
+    panelTitle.className = "map-menu-title";
+    panelTitle.textContent = "Map controls";
+    panelHeader.appendChild(panelTitle);
+    panelHeader.appendChild(closeBtn);
+    panel.appendChild(panelHeader);
     const tabsPanel = createMapTabsPanel(activeTab);
     panel.appendChild(tabsPanel);
     const controlsPanel = createMapControlsPanel(activeTab);
@@ -19036,11 +19243,11 @@
       text.setAttribute("x", pos.x);
       text.setAttribute("y", pos.y - (baseR + 12));
       text.setAttribute("class", "map-label");
-      text.setAttribute("font-size", "14");
+      text.setAttribute("font-size", "16");
       text.dataset.id = it.id;
       text.textContent = it.name || it.concept || "?";
-      text.addEventListener("mousedown", handleNodePointerDown);
-      text.addEventListener("click", (e) => {
+      text.addEventListener("pointerdown", handleNodePointerDown);
+      text.addEventListener("click", async (e) => {
         e.stopPropagation();
         if (mapState.suppressNextClick) {
           mapState.suppressNextClick = false;
@@ -19049,6 +19256,13 @@
         }
         if (mapState.tool === TOOL.NAVIGATE && !mapState.nodeWasDragged) {
           openItemPopup(it.id);
+        } else if (mapState.tool === TOOL.HIDE) {
+          if (confirm(`Remove ${titleOf4(it)} from the map?`)) {
+            await setNodeHidden(it.id, true);
+            await renderMap(root);
+          }
+        } else if (mapState.tool === TOOL.ADD_LINK) {
+          await handleAddLinkClick(it.id);
         }
         mapState.nodeWasDragged = false;
       });
@@ -19163,6 +19377,30 @@
       }
     });
   }
+  function beginViewDrag(e) {
+    if (!mapState.svg || !mapState.viewBox) return false;
+    if (e.button !== 0) return false;
+    mapState.justCompletedSelection = false;
+    getSvgRect({ force: true });
+    const startMap = clientToMap(e.clientX, e.clientY);
+    mapState.draggingView = true;
+    mapState.viewPointerId = e.pointerId;
+    mapState.lastPointer = {
+      x: e.clientX,
+      y: e.clientY,
+      mapX: startMap.x,
+      mapY: startMap.y
+    };
+    if (e.currentTarget?.setPointerCapture) {
+      try {
+        e.currentTarget.setPointerCapture(e.pointerId);
+      } catch {
+      }
+    }
+    setAreaInteracting(true);
+    refreshCursor({ keepOverride: false });
+    return true;
+  }
   function attachSvgEvents(svg) {
     svg.addEventListener("pointerdown", (e) => {
       if (e.button !== 0) return;
@@ -19171,23 +19409,7 @@
       getSvgRect({ force: true });
       if (mapState.tool !== TOOL.AREA) {
         e.preventDefault();
-        const startMap = clientToMap(e.clientX, e.clientY);
-        mapState.draggingView = true;
-        mapState.viewPointerId = e.pointerId;
-        mapState.lastPointer = {
-          x: e.clientX,
-          y: e.clientY,
-          mapX: startMap.x,
-          mapY: startMap.y
-        };
-        if (svg.setPointerCapture) {
-          try {
-            svg.setPointerCapture(e.pointerId);
-          } catch {
-          }
-        }
-        setAreaInteracting(true);
-        refreshCursor({ keepOverride: false });
+        beginViewDrag(e);
       } else {
         e.preventDefault();
         mapState.selectionRect = {
@@ -19226,12 +19448,28 @@
       if (!mapState.viewBox) return;
       const rect = getSvgRect({ force: true });
       if (!rect || !rect.width || !rect.height) return;
+      const pixelMode = e.deltaMode === 0;
+      const wantsZoom = e.ctrlKey || e.metaKey || e.altKey || !pixelMode;
+      if (!wantsZoom) {
+        const scaleX = rect.width ? mapState.viewBox.w / rect.width : 0;
+        const scaleY = rect.height ? mapState.viewBox.h / rect.height : 0;
+        mapState.viewBox.x += e.deltaX * scaleX * PAN_ACCELERATION;
+        mapState.viewBox.y += e.deltaY * scaleY * PAN_ACCELERATION;
+        constrainViewBox();
+        mapState.updateViewBox({ immediate: true });
+        return;
+      }
       const ratioX = (e.clientX - rect.left) / rect.width;
       const ratioY = (e.clientY - rect.top) / rect.height;
       const mx = mapState.viewBox.x + ratioX * mapState.viewBox.w;
       const my = mapState.viewBox.y + ratioY * mapState.viewBox.h;
-      const intensity = 18e-4;
-      const rawFactor = Math.exp(e.deltaY * intensity);
+      let deltaY = e.deltaY;
+      if (e.deltaMode === 1) {
+        deltaY *= 16;
+      } else if (e.deltaMode === 2) {
+        deltaY *= rect.height;
+      }
+      const rawFactor = Math.exp(deltaY * ZOOM_INTENSITY);
       const factor = Number.isFinite(rawFactor) && rawFactor > 0 ? rawFactor : 1;
       const maxSize = mapState.sizeLimit || 2e3;
       const minSize = mapState.minView || 100;
@@ -19240,12 +19478,7 @@
       mapState.viewBox.h = nextW;
       mapState.viewBox.x = mx - ratioX * nextW;
       mapState.viewBox.y = my - ratioY * nextW;
-      if (maxSize > 0) {
-        const maxX = Math.max(0, maxSize - mapState.viewBox.w);
-        const maxY = Math.max(0, maxSize - mapState.viewBox.h);
-        mapState.viewBox.x = clamp2(mapState.viewBox.x, 0, maxX);
-        mapState.viewBox.y = clamp2(mapState.viewBox.y, 0, maxY);
-      }
+      constrainViewBox();
       mapState.updateViewBox();
     }, { passive: false });
   }
@@ -19294,9 +19527,7 @@
       const { x, y } = clientToMap(e.clientX, e.clientY);
       const nx = x - mapState.nodeDrag.offset.x;
       const ny = y - mapState.nodeDrag.offset.y;
-      mapState.positions[mapState.nodeDrag.id] = { x: nx, y: ny };
-      updateNodeGeometry(mapState.nodeDrag.id, entry);
-      updateEdgesFor(mapState.nodeDrag.id);
+      scheduleNodePositionUpdate(mapState.nodeDrag.id, { x: nx, y: ny });
       mapState.nodeWasDragged = true;
       return;
     }
@@ -19309,9 +19540,7 @@
       mapState.areaDrag.origin.forEach(({ id, pos }) => {
         const nx = pos.x + dx;
         const ny = pos.y + dy;
-        mapState.positions[id] = { x: nx, y: ny };
-        updateNodeGeometry(id);
-        updateEdgesFor(id);
+        scheduleNodePositionUpdate(id, { x: nx, y: ny });
       });
       mapState.nodeWasDragged = true;
       return;
@@ -19319,8 +19548,12 @@
     if (mapState.draggingView && mapState.viewPointerId === e.pointerId) {
       const prev = Number.isFinite(mapState.lastPointer.mapX) ? { x: mapState.lastPointer.mapX, y: mapState.lastPointer.mapY } : clientToMap(mapState.lastPointer.x, mapState.lastPointer.y);
       const current = clientToMap(e.clientX, e.clientY);
-      mapState.viewBox.x += prev.x - current.x;
-      mapState.viewBox.y += prev.y - current.y;
+      if (typeof e.preventDefault === "function") {
+        e.preventDefault();
+      }
+      mapState.viewBox.x += (prev.x - current.x) * PAN_ACCELERATION;
+      mapState.viewBox.y += (prev.y - current.y) * PAN_ACCELERATION;
+      constrainViewBox();
       mapState.lastPointer = { x: e.clientX, y: e.clientY, mapX: current.x, mapY: current.y };
       mapState.updateViewBox({ immediate: true });
       if (mapState.selectionRect) {
@@ -19337,6 +19570,7 @@
   }
   async function handlePointerUp(e) {
     if (!mapState.svg) return;
+    flushNodePositionUpdates({ cancelFrame: true });
     if (mapState.toolboxDrag) {
       stopToolboxDrag();
     }
@@ -19446,6 +19680,40 @@
       refreshCursor({ keepOverride: true });
     }
   }
+  function scheduleNodePositionUpdate(id, pos) {
+    if (!id || !pos) return;
+    if (!mapState.pendingNodeUpdates) {
+      mapState.pendingNodeUpdates = /* @__PURE__ */ new Map();
+    }
+    mapState.positions[id] = pos;
+    mapState.pendingNodeUpdates.set(id, pos);
+    if (typeof window === "undefined" || typeof window.requestAnimationFrame !== "function") {
+      flushNodePositionUpdates();
+      return;
+    }
+    if (mapState.nodeUpdateFrame) {
+      return;
+    }
+    mapState.nodeUpdateFrame = window.requestAnimationFrame(() => {
+      mapState.nodeUpdateFrame = null;
+      flushNodePositionUpdates();
+    });
+  }
+  function flushNodePositionUpdates({ cancelFrame = false } = {}) {
+    if (cancelFrame && mapState.nodeUpdateFrame && typeof window !== "undefined" && typeof window.cancelAnimationFrame === "function") {
+      window.cancelAnimationFrame(mapState.nodeUpdateFrame);
+      mapState.nodeUpdateFrame = null;
+    }
+    const updates = mapState.pendingNodeUpdates;
+    if (!updates || !updates.size) return;
+    updates.forEach((_, id) => {
+      const entry = mapState.elements.get(id);
+      if (!entry) return;
+      updateNodeGeometry(id, entry);
+      updateEdgesFor(id);
+    });
+    updates.clear();
+  }
   function getNow() {
     if (typeof performance !== "undefined" && typeof performance.now === "function") {
       return performance.now();
@@ -19471,6 +19739,17 @@
       mapState.svgRectTime = now;
     }
     return mapState.svgRect;
+  }
+  function constrainViewBox() {
+    const viewBox = mapState.viewBox;
+    if (!viewBox) return;
+    const maxSize = mapState.sizeLimit || 0;
+    if (maxSize > 0) {
+      const maxX = Math.max(0, maxSize - viewBox.w);
+      const maxY = Math.max(0, maxSize - viewBox.h);
+      viewBox.x = clamp2(viewBox.x, 0, maxX);
+      viewBox.y = clamp2(viewBox.y, 0, maxY);
+    }
   }
   function clientToMap(clientX, clientY) {
     const viewBox = mapState.viewBox;
@@ -19662,7 +19941,7 @@
       label.setAttribute("x", pos.x);
       const offset = (baseR + 12) * nodeScale;
       label.setAttribute("y", pos.y - offset);
-      const fontSize = Math.max(12, 14 * labelScale);
+      const fontSize = Math.max(14, 16 * labelScale);
       label.setAttribute("font-size", fontSize);
     }
   }
@@ -21142,4 +21421,5 @@
   if (typeof window !== "undefined" && !globalThis.__SEVENN_TEST__) {
     bootstrap();
   }
+  return __toCommonJS(main_exports);
 })();

--- a/style.css
+++ b/style.css
@@ -4759,15 +4759,34 @@ button.builder-pill.builder-pill-outline {
 .map-tabs {
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 18px;
+}
+
+.map-tabs-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px 16px;
 }
 
 .map-tabs-heading {
-  font-size: 12px;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: rgba(226, 232, 240, 0.58);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.map-tabs-title {
+  margin: 0;
+  font-size: 16px;
   font-weight: 600;
+  color: #f8fafc;
+}
+
+.map-tabs-subtitle {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(226, 232, 240, 0.72);
 }
 
 .map-tab-list {
@@ -4812,15 +4831,52 @@ button.builder-pill.builder-pill-outline {
 
 .map-tab-actions {
   display: flex;
-  gap: 12px;
+  align-items: center;
+  gap: 10px;
+}
+
+.map-pill-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(30, 41, 59, 0.72);
+  color: #f8fafc;
+  font-weight: 500;
+  font-size: 13px;
+  line-height: 1;
+  letter-spacing: 0.01em;
+  transition: transform 0.18s ease, background 0.18s ease, border-color 0.18s ease, color 0.18s ease;
+  backdrop-filter: blur(12px);
+}
+
+.map-pill-btn svg {
+  width: 18px;
+  height: 18px;
+}
+
+.map-pill-btn:hover,
+.map-pill-btn:focus-visible {
+  transform: translateY(-1px);
+  background: rgba(51, 65, 85, 0.92);
+  border-color: rgba(148, 163, 184, 0.55);
+  color: #ffffff;
+}
+
+.map-pill-btn:focus-visible {
+  outline: 2px solid rgba(56, 189, 248, 0.45);
+  outline-offset: 2px;
 }
 
 .map-icon-btn {
   width: 38px;
   height: 38px;
   border-radius: 12px;
-  display: grid;
-  place-items: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   border: 1px solid rgba(148, 163, 184, 0.32);
   background: rgba(15, 23, 42, 0.65);
   color: rgba(226, 232, 240, 0.82);
@@ -4833,6 +4889,7 @@ button.builder-pill.builder-pill-outline {
 .map-icon-btn svg {
   width: 20px;
   height: 20px;
+  display: block;
 }
 
 .map-delete-tab svg {
@@ -5080,6 +5137,71 @@ button.builder-pill.builder-pill-outline {
   color: var(--text-muted);
 }
 
+.map-control-group {
+  flex: 1;
+  min-width: 220px;
+}
+
+.map-control-label {
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.68);
+  font-weight: 600;
+}
+
+.map-chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.map-chip {
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  background: rgba(15, 23, 42, 0.5);
+  color: rgba(226, 232, 240, 0.82);
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-size: 13px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  transition: transform 0.18s ease, background 0.18s ease, border-color 0.18s ease, color 0.18s ease, box-shadow 0.18s ease;
+}
+
+.map-chip:hover,
+.map-chip:focus-visible {
+  background: rgba(30, 41, 59, 0.92);
+  border-color: rgba(148, 163, 184, 0.55);
+  color: #ffffff;
+  transform: translateY(-1px);
+}
+
+.map-chip:focus-visible {
+  outline: 2px solid rgba(56, 189, 248, 0.45);
+  outline-offset: 2px;
+}
+
+.map-chip.active {
+  background: rgba(56, 189, 248, 0.22);
+  border-color: rgba(56, 189, 248, 0.45);
+  color: #f8fafc;
+  box-shadow: 0 12px 28px rgba(56, 189, 248, 0.2);
+}
+
+.map-chip.disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.map-chip-empty {
+  font-size: 13px;
+  color: rgba(226, 232, 240, 0.6);
+  padding: 4px 0;
+}
+
 .map-control-name {
   flex: 1;
   min-width: 220px;
@@ -5196,7 +5318,7 @@ button.builder-pill.builder-pill-outline {
   transform: translateY(-50%) translateX(24px);
   width: 340px;
   max-height: 78vh;
-  padding: 48px 26px 26px;
+  padding: 34px 26px 26px;
   display: flex;
   flex-direction: column;
   gap: 24px;
@@ -5217,25 +5339,44 @@ button.builder-pill.builder-pill-outline {
   transform: translateY(-50%) translateX(0);
 }
 
+.map-menu-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.map-menu-title {
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.66);
+  font-weight: 600;
+}
+
 .map-menu-close {
-  position: absolute;
-  top: 18px;
-  right: 18px;
-  width: 34px;
-  height: 34px;
+  width: 32px;
+  height: 32px;
   border-radius: 50%;
-  display: grid;
-  place-items: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   background: none;
-  border: none;
+  border: 1px solid transparent;
   color: rgba(226, 232, 240, 0.7);
-  transition: color 0.2s ease, background 0.2s ease;
+  transition: color 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+}
+
+.map-menu-close svg {
+  width: 18px;
+  height: 18px;
 }
 
 .map-menu-close:hover,
 .map-menu-close:focus-visible {
   color: #ffffff;
-  background: rgba(148, 163, 184, 0.2);
+  background: rgba(148, 163, 184, 0.18);
+  border-color: rgba(148, 163, 184, 0.28);
 }
 
 .map-menu-close svg {


### PR DESCRIPTION
## Summary
- add reusable helpers for map tab filters and allow choosing multiple weeks or lectures with chip-style controls
- tune concept map navigation with accelerated pan/zoom handling and support background drags
- refresh the map sidebar presentation with updated tab header, button styling, and regenerated bundle

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbedc2583c8322a64701cd1bc624d1