### PR TITLE
Improve rich content rendering and editor controls

### DIFF
--- a/js/ui/components/section-utils.js
+++ b/js/ui/components/section-utils.js
@@ -8,13 +8,26 @@ function stripHtml(value) {
     .trim();
 }
 
+function hasRichNodes(html = '') {
+  if (!html) return false;
+  if (typeof document === 'undefined') {
+    return /<(img|video|audio|iframe|canvas|svg|source)\b/i.test(html) || stripHtml(html).length > 0;
+  }
+  const template = document.createElement('template');
+  template.innerHTML = html;
+  const media = template.content.querySelector('img,video,audio,iframe,canvas,svg,source');
+  if (media) return true;
+  const text = template.content.textContent?.replace(/\u00a0/g, ' ').trim();
+  return Boolean(text);
+}
+
 export function hasSectionContent(item, key) {
   if (!item || !key) return false;
   const defs = sectionDefsForKind(item.kind);
   if (!defs.some(def => def.key === key)) return false;
   const raw = item[key];
   if (raw === null || raw === undefined) return false;
-  return stripHtml(raw).length > 0;
+  return hasRichNodes(raw);
 }
 
 export function sectionsForItem(item, allowedKeys = null) {

--- a/style.css
+++ b/style.css
@@ -2047,15 +2047,31 @@ input[type="checkbox"]:checked::after {
   color: var(--text);
 }
 
-.rich-editor-size {
+.rich-editor-size-input {
+  width: 68px;
   background: rgba(15, 23, 42, 0.5);
   border: 1px solid rgba(148, 163, 184, 0.22);
   border-radius: var(--radius-sm);
   color: var(--text);
-  padding: 4px 8px;
-  cursor: pointer;
+  padding: 4px 6px;
   font-size: 0.85rem;
+  line-height: 1.2;
   min-width: 0;
+}
+
+.rich-editor-size-input:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.6);
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.25);
+}
+
+.rich-editor-font-display {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .rich-editor-area {


### PR DESCRIPTION
## Summary
- treat rich media as content so image/video-only sections appear across cards, flashcards, quizzes, and the concept map
- enhance the rich text editor with numeric font sizing, live font readouts, and plain-text pasting while keeping formatting in sync
- update toolbar styling to support the new controls and rebuild the bundle

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dddf069a28832297c5351d64df5547