### PR TITLE
Improve card editing UI and map interactions

### DIFF
--- a/js/ui/components/cardlist.js
+++ b/js/ui/components/cardlist.js
@@ -85,18 +85,6 @@ export function createItemCard(item, onChange){
   });
   header.appendChild(mainBtn);
 
-  const quickEdit = document.createElement('button');
-  quickEdit.type = 'button';
-  quickEdit.className = 'icon-btn card-quick-edit';
-  quickEdit.title = 'Edit entry';
-  quickEdit.setAttribute('aria-label', 'Edit entry');
-  quickEdit.innerHTML = '✏️';
-  quickEdit.addEventListener('click', e => {
-    e.stopPropagation();
-    openEditor(item.kind, onChange, item);
-  });
-  header.appendChild(quickEdit);
-
   const settings = document.createElement('div');
   settings.className = 'card-settings';
   const menu = document.createElement('div');

--- a/style.css
+++ b/style.css
@@ -3555,12 +3555,6 @@ button.builder-pill.builder-pill-outline {
   position: relative;
 }
 
-.card-quick-edit {
-  flex-shrink: 0;
-  width: 40px;
-  height: 40px;
-}
-
 .card-title-btn {
   background: none;
   border: none;
@@ -4429,6 +4423,39 @@ button.builder-pill.builder-pill-outline {
   gap: 8px;
   position: relative;
   z-index: 1;
+}
+
+.deck-slide-edit {
+  align-self: flex-end;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.6);
+  color: rgba(248, 250, 252, 0.85);
+  font-size: 0.82rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.deck-slide-edit:hover,
+.deck-slide-edit:focus-visible {
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 65%, rgba(148, 163, 184, 0.35));
+  background: rgba(8, 47, 73, 0.55);
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.25);
+}
+
+.deck-slide-edit:focus-visible {
+  outline: none;
+}
+
+.deck-slide-edit-icon {
+  font-size: 1rem;
+  line-height: 1;
 }
 
 .deck-slide-crumb {


### PR DESCRIPTION
## Summary
- remove the inline quick-edit button from list cards for a cleaner header
- add edit controls to the cards deck, refreshing the active slide and tab after changes
- tighten map dragging and auto-pan logic so nodes track the cursor and selections stay accurate

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de70c7713c8322ad23de7ee7ae27dc