### PR TITLE
Add cloze editing and collapsible lecture sections

### DIFF
--- a/js/ui/components/flashcards.js
+++ b/js/ui/components/flashcards.js
@@ -209,7 +209,7 @@ export function renderFlashcards(root, redraw) {
 
     const body = document.createElement('div');
     body.className = 'flash-body';
-    renderRichText(body, item[key] || '');
+    renderRichText(body, item[key] || '', { clozeMode: 'interactive' });
 
     const ratingRow = document.createElement('div');
     ratingRow.className = 'flash-rating';
@@ -342,7 +342,10 @@ export function renderFlashcards(root, redraw) {
       setToggleState(sec, next, 'revealed');
     };
     sec.addEventListener('click', (event) => {
-      if (event.target instanceof HTMLElement && event.target.closest('.flash-rating')) return;
+      if (event.target instanceof HTMLElement) {
+        if (event.target.closest('.flash-rating')) return;
+        if (event.target.closest('[data-cloze]')) return;
+      }
       toggleReveal();
     });
     sec.addEventListener('keydown', (e) => {

--- a/js/ui/components/rich-text.js
+++ b/js/ui/components/rich-text.js
@@ -7,7 +7,7 @@ const allowedTags = new Set([
 const allowedAttributes = {
   'a': ['href', 'title', 'target', 'rel'],
   'img': ['src', 'alt', 'title', 'width', 'height'],
-  'span': ['style'],
+  'span': ['style', 'data-cloze'],
   'div': ['style'],
   'p': ['style'],
   'font': ['style', 'color', 'face', 'size'],
@@ -24,6 +24,7 @@ const allowedStyles = new Set([
   'color',
   'background-color',
   'font-size',
+  'font-family',
   'font-weight',
   'font-style',
   'text-decoration-line',
@@ -142,10 +143,72 @@ function sanitizeNode(node){
   Array.from(node.childNodes).forEach(sanitizeNode);
 }
 
+const CLOZE_ATTR = 'data-cloze';
+const CLOZE_VALUE = 'true';
+const CLOZE_SELECTOR = `[${CLOZE_ATTR}="${CLOZE_VALUE}"]`;
+
+function createClozeSpan(content){
+  const span = document.createElement('span');
+  span.setAttribute(CLOZE_ATTR, CLOZE_VALUE);
+  span.textContent = content;
+  return span;
+}
+
+function upgradeClozeSyntax(root){
+  if (!root) return;
+  const braceRegex = /\{([^{}]+)\}/g;
+  const walker = document.createTreeWalker(
+    root,
+    NodeFilter.SHOW_TEXT,
+    {
+      acceptNode: (node) => {
+        if (!node?.nodeValue || node.nodeValue.indexOf('{') === -1) {
+          return NodeFilter.FILTER_SKIP;
+        }
+        if (node.parentElement?.closest(CLOZE_SELECTOR)) {
+          return NodeFilter.FILTER_SKIP;
+        }
+        return NodeFilter.FILTER_ACCEPT;
+      }
+    }
+  );
+  const targets = [];
+  while (walker.nextNode()) targets.push(walker.currentNode);
+  targets.forEach(node => {
+    const text = node.nodeValue || '';
+    let match;
+    braceRegex.lastIndex = 0;
+    let lastIndex = 0;
+    let replaced = false;
+    const fragment = document.createDocumentFragment();
+    while ((match = braceRegex.exec(text))) {
+      const before = text.slice(lastIndex, match.index);
+      if (before) fragment.appendChild(document.createTextNode(before));
+      const inner = match[1];
+      const trimmed = inner.trim();
+      if (trimmed) {
+        fragment.appendChild(createClozeSpan(trimmed));
+        replaced = true;
+      } else {
+        fragment.appendChild(document.createTextNode(match[0]));
+      }
+      lastIndex = match.index + match[0].length;
+    }
+    if (!replaced) return;
+    const after = text.slice(lastIndex);
+    if (after) fragment.appendChild(document.createTextNode(after));
+    const parent = node.parentNode;
+    if (!parent) return;
+    parent.insertBefore(fragment, node);
+    parent.removeChild(node);
+  });
+}
+
 export function sanitizeHtml(html = ''){
   const template = document.createElement('template');
   template.innerHTML = html;
   Array.from(template.content.childNodes).forEach(sanitizeNode);
+  upgradeClozeSyntax(template.content);
   return template.innerHTML;
 }
 
@@ -158,6 +221,17 @@ function normalizeInput(value = ''){
   const decoded = decodeHtmlEntities(str);
   return sanitizeHtml(escapeHtml(decoded).replace(/\r?\n/g, '<br>'));
 }
+
+const FONT_SIZE_VALUES = [10, 12, 14, 16, 18, 20, 22, 24, 28, 32, 36, 40, 48];
+
+const FONT_OPTIONS = [
+  { value: '', label: 'Default' },
+  { value: '"Inter", "Segoe UI", sans-serif', label: 'Modern Sans' },
+  { value: '"Helvetica Neue", Arial, sans-serif', label: 'Classic Sans' },
+  { value: '"Times New Roman", Times, serif', label: 'Serif' },
+  { value: '"Source Code Pro", Menlo, monospace', label: 'Monospace' },
+  { value: '"Comic Neue", "Comic Sans MS", cursive', label: 'Handwriting' }
+];
 
 function isEmptyHtml(html = ''){
   if (!html) return true;
@@ -565,9 +639,11 @@ export function createRichTextEditor({ value = '', onChange, ariaLabel, ariaLabe
   }
 
   const commandButtons = [];
-  let sizeInput = null;
+  let sizeSelect = null;
+  let fontSelect = null;
   let fontNameLabel = null;
   let fontSizeLabel = null;
+  let clozeButton = null;
 
   function focusEditor(){
     editable.focus({ preventScroll: false });
@@ -769,6 +845,18 @@ export function createRichTextEditor({ value = '', onChange, ariaLabel, ariaLabe
 
     const style = inEditor ? computeSelectionStyle() : null;
     updateTypographyState(style);
+
+    if (clozeButton) {
+      const saved = getSavedRange({ requireSelection: false });
+      const startNode = saved?.startContainer || null;
+      const endNode = saved?.endContainer || null;
+      const startCloze = startNode ? findClozeAncestor(startNode) : null;
+      const endCloze = endNode ? findClozeAncestor(endNode) : null;
+      const active = Boolean(startCloze && startCloze === endCloze);
+      clozeButton.classList.toggle('is-active', active);
+      clozeButton.dataset.active = active ? 'true' : 'false';
+      clozeButton.setAttribute('aria-pressed', active ? 'true' : 'false');
+    }
   }
 
   function styleForNode(node) {
@@ -799,6 +887,74 @@ export function createRichTextEditor({ value = '', onChange, ariaLabel, ariaLabe
     return styleForNode(range.commonAncestorContainer);
   }
 
+  function findClozeAncestor(node) {
+    let current = node;
+    while (current && current !== editable) {
+      if (current instanceof HTMLElement && current.getAttribute?.(CLOZE_ATTR) === CLOZE_VALUE) {
+        return current;
+      }
+      current = current.parentNode;
+    }
+    return null;
+  }
+
+  function unwrapClozeElement(element) {
+    const parent = element.parentNode;
+    if (!parent) return;
+    const selection = window.getSelection();
+    const range = document.createRange();
+    let firstChild = null;
+    let lastChild = null;
+    while (element.firstChild) {
+      const child = element.firstChild;
+      parent.insertBefore(child, element);
+      if (!firstChild) firstChild = child;
+      lastChild = child;
+    }
+    const nextSibling = element.nextSibling;
+    parent.removeChild(element);
+    if (firstChild && lastChild) {
+      range.setStartBefore(firstChild);
+      range.setEndAfter(lastChild);
+    } else {
+      const index = Array.prototype.indexOf.call(parent.childNodes, nextSibling);
+      range.setStart(parent, index >= 0 ? index : parent.childNodes.length);
+      range.collapse(true);
+    }
+    if (selection) {
+      selection.removeAllRanges();
+      selection.addRange(range);
+    }
+  }
+
+  function toggleClozeFormatting() {
+    const range = getSavedRange({ requireSelection: false });
+    if (!range) return;
+    const startCloze = findClozeAncestor(range.startContainer);
+    const endCloze = findClozeAncestor(range.endContainer);
+    if (startCloze && startCloze === endCloze) {
+      runCommand(() => {
+        unwrapClozeElement(startCloze);
+      });
+      return;
+    }
+    if (range.collapsed) return;
+    runCommand(() => {
+      const selection = window.getSelection();
+      if (!selection?.rangeCount) return;
+      const activeRange = selection.getRangeAt(0);
+      const fragment = activeRange.extractContents();
+      const span = document.createElement('span');
+      span.setAttribute(CLOZE_ATTR, CLOZE_VALUE);
+      span.appendChild(fragment);
+      activeRange.insertNode(span);
+      selection.removeAllRanges();
+      const newRange = document.createRange();
+      newRange.selectNode(span);
+      selection.addRange(newRange);
+    }, { requireSelection: true });
+  }
+
   function formatFontFamily(value = '') {
     if (!value) return 'Default';
     const primary = value.split(',')[0] || value;
@@ -806,14 +962,18 @@ export function createRichTextEditor({ value = '', onChange, ariaLabel, ariaLabe
   }
 
   function updateTypographyState(style) {
-    if (!fontNameLabel || !fontSizeLabel || !sizeInput) return;
-    const editingSize = document.activeElement === sizeInput;
+    if (!fontNameLabel || !fontSizeLabel || !sizeSelect) return;
+    const editingSize = document.activeElement === sizeSelect;
+    const editingFont = document.activeElement === fontSelect;
     if (!style) {
       fontNameLabel.textContent = 'Font: Default';
       fontSizeLabel.textContent = 'Size: —';
+      if (!editingFont && fontSelect) {
+        fontSelect.value = '';
+      }
       if (!editingSize) {
-        sizeInput.value = '';
-        sizeInput.placeholder = 'Size (px)';
+        sizeSelect.value = '';
+        if (sizeSelect) delete sizeSelect.dataset.customValue;
       }
       return;
     }
@@ -821,11 +981,34 @@ export function createRichTextEditor({ value = '', onChange, ariaLabel, ariaLabe
     const sizeText = style.fontSize || '';
     fontNameLabel.textContent = `Font: ${family}`;
     fontSizeLabel.textContent = `Size: ${sizeText || '—'}`;
+    if (!editingFont && fontSelect) {
+      const normalized = (style.fontFamily || '').trim().toLowerCase();
+      const match = FONT_OPTIONS.find(option => option.value.trim().toLowerCase() === normalized);
+      if (match) {
+        fontSelect.value = match.value;
+      } else if (normalized) {
+        fontSelect.value = 'custom';
+        fontSelect.dataset.customValue = style.fontFamily || '';
+      } else {
+        fontSelect.value = '';
+      }
+    }
     if (!editingSize) {
       const numeric = Number.parseFloat(sizeText);
-      sizeInput.value = Number.isFinite(numeric) ? String(Math.round(numeric)) : '';
+      if (Number.isFinite(numeric)) {
+        const rounded = Math.round(numeric);
+        const optionMatch = FONT_SIZE_VALUES.find(val => val === rounded);
+        if (optionMatch) {
+          sizeSelect.value = String(optionMatch);
+        } else {
+          sizeSelect.value = 'custom';
+          sizeSelect.dataset.customValue = String(rounded);
+        }
+      } else {
+        sizeSelect.value = '';
+        delete sizeSelect.dataset.customValue;
+      }
     }
-    sizeInput.placeholder = sizeText || 'Size (px)';
   }
 
   function collectElementsInRange(range) {
@@ -867,6 +1050,23 @@ export function createRichTextEditor({ value = '', onChange, ariaLabel, ariaLabe
     });
   }
 
+  function removeFontFamilyFromRange(range) {
+    const elements = collectElementsInRange(range);
+    elements.forEach(node => {
+      if (!(node instanceof HTMLElement)) return;
+      if (node.style && node.style.fontFamily) {
+        node.style.removeProperty('font-family');
+        if (!node.style.length) node.removeAttribute('style');
+      }
+      if (node.tagName?.toLowerCase() === 'font') {
+        const parent = node.parentNode;
+        if (!parent) return;
+        while (node.firstChild) parent.insertBefore(node.firstChild, node);
+        parent.removeChild(node);
+      }
+    });
+  }
+
   function applyFontSizeValue(value) {
     runCommand(() => {
       const selection = window.getSelection();
@@ -886,6 +1086,30 @@ export function createRichTextEditor({ value = '', onChange, ariaLabel, ariaLabe
         if (!parent) return;
         const span = document.createElement('span');
         span.style.fontSize = `${numeric}px`;
+        while (node.firstChild) span.appendChild(node.firstChild);
+        parent.replaceChild(span, node);
+      });
+    }, { requireSelection: true });
+  }
+
+  function applyFontFamilyValue(value) {
+    runCommand(() => {
+      const selection = window.getSelection();
+      if (!selection?.rangeCount) return;
+      const range = selection.getRangeAt(0);
+      removeFontFamilyFromRange(range);
+      const trimmed = typeof value === 'string' ? value.trim() : '';
+      if (!trimmed) {
+        return;
+      }
+      document.execCommand('styleWithCSS', false, true);
+      document.execCommand('fontName', false, trimmed);
+      const fonts = editable.querySelectorAll('font');
+      fonts.forEach(node => {
+        const parent = node.parentNode;
+        if (!parent) return;
+        const span = document.createElement('span');
+        span.style.fontFamily = trimmed;
         while (node.firstChild) span.appendChild(node.firstChild);
         parent.replaceChild(span, node);
       });
@@ -1023,42 +1247,96 @@ export function createRichTextEditor({ value = '', onChange, ariaLabel, ariaLabe
   fontInfo.appendChild(fontSizeLabel);
   typographyGroup.appendChild(fontInfo);
 
-  sizeInput = document.createElement('input');
-  sizeInput.type = 'number';
-  sizeInput.className = 'rich-editor-size rich-editor-size-input';
-  sizeInput.placeholder = 'Size (px)';
-  sizeInput.min = '8';
-  sizeInput.max = '96';
-  sizeInput.step = '1';
-  sizeInput.setAttribute('aria-label', 'Font size in pixels');
-
-  const commitFontSize = () => {
+  fontSelect = document.createElement('select');
+  fontSelect.className = 'rich-editor-select rich-editor-font-select';
+  fontSelect.setAttribute('aria-label', 'Font family');
+  FONT_OPTIONS.forEach(option => {
+    const opt = document.createElement('option');
+    opt.value = option.value;
+    opt.textContent = option.label;
+    fontSelect.appendChild(opt);
+  });
+  const customFontOption = document.createElement('option');
+  customFontOption.value = 'custom';
+  customFontOption.textContent = 'Custom…';
+  fontSelect.appendChild(customFontOption);
+  ['mousedown', 'focus', 'keydown'].forEach(evt => {
+    fontSelect.addEventListener(evt, () => captureSelectionRange());
+  });
+  fontSelect.addEventListener('change', () => {
     if (!hasActiveSelection()) {
-      sizeInput.value = '';
+      updateInlineState();
       return;
     }
-    const raw = sizeInput.value.trim();
-    if (!raw) {
-      applyFontSizeValue(null);
-    } else {
-      applyFontSizeValue(raw);
+    let selected = fontSelect.value;
+    if (selected === 'custom') {
+      const current = fontSelect.dataset.customValue || '';
+      const custom = prompt('Enter font family (CSS value)', current || '');
+      if (!custom) {
+        updateInlineState();
+        return;
+      }
+      fontSelect.dataset.customValue = custom;
+      selected = custom;
+    } else if (!selected) {
+      delete fontSelect.dataset.customValue;
     }
-  };
-
-  sizeInput.addEventListener('change', commitFontSize);
-  sizeInput.addEventListener('keydown', (event) => {
-    if (event.key === 'Enter') {
-      event.preventDefault();
-      commitFontSize();
-      sizeInput.blur();
-    }
+    applyFontFamilyValue(selected);
+    focusEditor();
   });
-  typographyGroup.appendChild(sizeInput);
+  typographyGroup.appendChild(fontSelect);
+
+  sizeSelect = document.createElement('select');
+  sizeSelect.className = 'rich-editor-select rich-editor-size';
+  sizeSelect.setAttribute('aria-label', 'Font size');
+  const defaultSizeOption = document.createElement('option');
+  defaultSizeOption.value = '';
+  defaultSizeOption.textContent = 'Size';
+  sizeSelect.appendChild(defaultSizeOption);
+  FONT_SIZE_VALUES.forEach(val => {
+    const opt = document.createElement('option');
+    opt.value = String(val);
+    opt.textContent = `${val}px`;
+    sizeSelect.appendChild(opt);
+  });
+  const customSizeOption = document.createElement('option');
+  customSizeOption.value = 'custom';
+  customSizeOption.textContent = 'Custom…';
+  sizeSelect.appendChild(customSizeOption);
+  ['mousedown', 'focus', 'keydown'].forEach(evt => {
+    sizeSelect.addEventListener(evt, () => captureSelectionRange());
+  });
+  sizeSelect.addEventListener('change', () => {
+    if (!hasActiveSelection()) {
+      updateInlineState();
+      return;
+    }
+    let selected = sizeSelect.value;
+    if (selected === 'custom') {
+      const current = sizeSelect.dataset.customValue || '';
+      const custom = prompt('Enter font size in pixels', current || '16');
+      const numeric = Number.parseFloat(custom || '');
+      if (!custom || !Number.isFinite(numeric) || numeric <= 0) {
+        updateInlineState();
+        return;
+      }
+      const rounded = Math.round(numeric);
+      sizeSelect.dataset.customValue = String(rounded);
+      selected = String(rounded);
+    } else if (!selected) {
+      delete sizeSelect.dataset.customValue;
+    }
+    applyFontSizeValue(selected || null);
+    focusEditor();
+  });
+  typographyGroup.appendChild(sizeSelect);
 
   const resetSizeBtn = createToolbarButton('↺', 'Reset font size', () => {
     if (!hasActiveSelection()) return;
-    sizeInput.value = '';
+    sizeSelect.value = '';
+    delete sizeSelect.dataset.customValue;
     applyFontSizeValue(null);
+    focusEditor();
   });
   typographyGroup.appendChild(resetSizeBtn);
 
@@ -1105,8 +1383,14 @@ export function createRichTextEditor({ value = '', onChange, ariaLabel, ariaLabe
   });
   mediaGroup.appendChild(mediaBtn);
 
+  const clozeTool = createToolbarButton('⧉', 'Toggle cloze (hide selected text until clicked)', () => {
+    toggleClozeFormatting();
+    focusEditor();
+  });
+  clozeButton = clozeTool;
   const clearBtn = createToolbarButton('⌫', 'Clear formatting', () => exec('removeFormat', null, { requireSelection: true, styleWithCss: false }));
   const utilityGroup = createGroup('rich-editor-utility-group');
+  utilityGroup.appendChild(clozeTool);
   utilityGroup.appendChild(clearBtn);
 
   let settingValue = false;
@@ -1164,6 +1448,105 @@ export function createRichTextEditor({ value = '', onChange, ariaLabel, ariaLabe
   };
 }
 
+const CLOZE_STATE_HIDDEN = 'hidden';
+const CLOZE_STATE_REVEALED = 'revealed';
+
+function setClozeState(node, state){
+  if (!(node instanceof HTMLElement)) return;
+  const next = state === CLOZE_STATE_REVEALED ? CLOZE_STATE_REVEALED : CLOZE_STATE_HIDDEN;
+  node.setAttribute('data-cloze-state', next);
+  if (next === CLOZE_STATE_REVEALED) {
+    node.classList.add('is-cloze-revealed');
+    node.classList.remove('is-cloze-hidden');
+  } else {
+    node.classList.add('is-cloze-hidden');
+    node.classList.remove('is-cloze-revealed');
+  }
+  if (node.classList.contains('cloze-text-interactive')) {
+    node.setAttribute('aria-pressed', next === CLOZE_STATE_REVEALED ? 'true' : 'false');
+  } else if (node.hasAttribute('aria-pressed')) {
+    node.removeAttribute('aria-pressed');
+  }
+}
+
+function toggleCloze(node){
+  if (!(node instanceof HTMLElement)) return;
+  const current = node.getAttribute('data-cloze-state');
+  const next = current === CLOZE_STATE_REVEALED ? CLOZE_STATE_HIDDEN : CLOZE_STATE_REVEALED;
+  setClozeState(node, next);
+}
+
+function handleClozeClick(event){
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) return;
+  const cloze = target.closest(CLOZE_SELECTOR);
+  if (!cloze) return;
+  event.stopPropagation();
+  toggleCloze(cloze);
+}
+
+function handleClozeKey(event){
+  if (event.key !== 'Enter' && event.key !== ' ') return;
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) return;
+  const cloze = target.closest(CLOZE_SELECTOR);
+  if (!cloze) return;
+  event.preventDefault();
+  event.stopPropagation();
+  toggleCloze(cloze);
+}
+
+function detachClozeHandlers(container){
+  const handlers = container.__clozeHandlers;
+  if (!handlers) return;
+  container.removeEventListener('click', handlers.click);
+  container.removeEventListener('keydown', handlers.key);
+  delete container.__clozeHandlers;
+}
+
+function enhanceClozeContent(target, { clozeMode = 'static' } = {}){
+  const nodes = target.querySelectorAll(CLOZE_SELECTOR);
+  if (!nodes.length) {
+    target.classList.remove('rich-content-with-cloze');
+    detachClozeHandlers(target);
+    return;
+  }
+  target.classList.add('rich-content-with-cloze');
+  const interactive = clozeMode === 'interactive';
+  nodes.forEach(node => {
+    node.classList.add('cloze-text');
+    if (interactive) {
+      node.classList.add('cloze-text-interactive');
+      if (!node.hasAttribute('tabindex')) node.setAttribute('tabindex', '0');
+      node.setAttribute('role', 'button');
+      const current = node.getAttribute('data-cloze-state');
+      if (current !== CLOZE_STATE_REVEALED && current !== CLOZE_STATE_HIDDEN) {
+        setClozeState(node, CLOZE_STATE_HIDDEN);
+      } else {
+        setClozeState(node, current);
+      }
+    } else {
+      node.classList.remove('cloze-text-interactive');
+      if (node.getAttribute('tabindex') === '0') node.removeAttribute('tabindex');
+      if (node.getAttribute('role') === 'button') node.removeAttribute('role');
+      setClozeState(node, CLOZE_STATE_REVEALED);
+    }
+  });
+  if (interactive) {
+    if (!target.__clozeHandlers) {
+      const handlers = {
+        click: handleClozeClick,
+        key: handleClozeKey
+      };
+      target.addEventListener('click', handlers.click);
+      target.addEventListener('keydown', handlers.key);
+      target.__clozeHandlers = handlers;
+    }
+  } else {
+    detachClozeHandlers(target);
+  }
+}
+
 function normalizedFromCache(value){
   if (!value) return '';
   const key = typeof value === 'string' ? value : null;
@@ -1184,15 +1567,17 @@ function normalizedFromCache(value){
   return normalized;
 }
 
-export function renderRichText(target, value){
+export function renderRichText(target, value, options = {}){
   const normalized = normalizedFromCache(value);
   if (!normalized) {
     target.textContent = '';
     target.classList.remove('rich-content');
+    detachClozeHandlers(target);
     return;
   }
   target.classList.add('rich-content');
   target.innerHTML = normalized;
+  enhanceClozeContent(target, options);
 }
 
 export function hasRichTextContent(value){

--- a/style.css
+++ b/style.css
@@ -2058,25 +2058,53 @@ input[type="checkbox"]:checked::after {
   color: var(--text);
 }
 
-.rich-editor-size {
-  background: rgba(15, 23, 42, 0.5);
+.rich-editor-select {
+  background: rgba(15, 23, 42, 0.52);
   border: 1px solid rgba(148, 163, 184, 0.22);
   border-radius: var(--radius-sm);
   color: var(--text);
-  padding: 4px 8px;
+  padding: 6px 32px 6px 12px;
   font-size: 0.85rem;
+  line-height: 1.3;
   min-width: 0;
-}
-
-.rich-editor-size-input {
-  width: 84px;
-  -moz-appearance: textfield;
-}
-
-.rich-editor-size-input::-webkit-outer-spin-button,
-.rich-editor-size-input::-webkit-inner-spin-button {
+  font-family: inherit;
+  appearance: none;
   -webkit-appearance: none;
-  margin: 0;
+  -moz-appearance: none;
+  background-image: linear-gradient(45deg, rgba(148, 163, 184, 0.42) 50%, transparent 50%),
+    linear-gradient(135deg, rgba(148, 163, 184, 0.42) 50%, transparent 50%);
+  background-position: calc(100% - 14px) calc(50% - 3px), calc(100% - 8px) calc(50% - 3px);
+  background-size: 7px 7px;
+  background-repeat: no-repeat;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.rich-editor-select:hover {
+  border-color: rgba(148, 163, 184, 0.35);
+}
+
+.rich-editor-select:focus-visible {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.45);
+  box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.25);
+}
+
+.rich-editor-select option {
+  background: rgb(15, 23, 42);
+  color: var(--text);
+}
+
+.rich-editor-select::-ms-expand {
+  display: none;
+}
+
+.rich-editor-font-select {
+  min-width: 160px;
+}
+
+.rich-editor-size {
+  min-width: 110px;
 }
 
 .rich-editor-font-info {
@@ -2111,6 +2139,32 @@ input[type="checkbox"]:checked::after {
   font-size: 0.95rem;
   line-height: 1.55;
   font-weight: 400;
+}
+
+.rich-editor-area [data-cloze="true"] {
+  position: relative;
+  padding: 0 0.2em;
+  border-radius: 6px;
+  border-bottom: 1.5px dashed rgba(148, 163, 184, 0.55);
+  background: rgba(30, 41, 59, 0.45);
+  color: var(--text);
+}
+
+.rich-editor-area [data-cloze="true"]::before,
+.rich-editor-area [data-cloze="true"]::after {
+  position: relative;
+  font-weight: 600;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.rich-editor-area [data-cloze="true"]::before {
+  content: '{';
+  margin-right: 2px;
+}
+
+.rich-editor-area [data-cloze="true"]::after {
+  content: '}';
+  margin-left: 2px;
 }
 
 .rich-editor-area:focus {
@@ -3776,6 +3830,52 @@ button.builder-pill.builder-pill-outline {
   word-break: break-word;
 }
 
+.rich-content-with-cloze .cloze-text {
+  position: relative;
+  padding: 0 0.15em;
+  border-bottom: 1.5px dotted rgba(148, 163, 184, 0.4);
+  border-radius: 4px;
+  transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.rich-content-with-cloze .cloze-text-interactive {
+  cursor: pointer;
+  border-bottom-style: dashed;
+  border-bottom-color: rgba(94, 234, 212, 0.45);
+}
+
+.rich-content-with-cloze .cloze-text-interactive:focus-visible {
+  outline: 2px solid rgba(56, 189, 248, 0.45);
+  outline-offset: 2px;
+}
+
+.rich-content-with-cloze .cloze-text-interactive.is-cloze-hidden {
+  color: transparent;
+  background: linear-gradient(120deg, rgba(148, 163, 184, 0.28), rgba(59, 130, 246, 0.18));
+  border-bottom-color: rgba(148, 163, 184, 0.55);
+  box-shadow: inset 0 -1px 0 rgba(15, 23, 42, 0.32);
+}
+
+.rich-content-with-cloze .cloze-text-interactive.is-cloze-hidden:hover,
+.rich-content-with-cloze .cloze-text-interactive.is-cloze-hidden:focus-visible {
+  background: linear-gradient(120deg, rgba(59, 130, 246, 0.32), rgba(14, 165, 233, 0.25));
+  border-bottom-color: rgba(59, 130, 246, 0.62);
+}
+
+.rich-content-with-cloze .cloze-text-interactive.is-cloze-hidden::selection {
+  background: rgba(59, 130, 246, 0.3);
+}
+
+.rich-content-with-cloze .cloze-text-interactive.is-cloze-hidden::-moz-selection {
+  background: rgba(59, 130, 246, 0.3);
+}
+
+.rich-content-with-cloze .cloze-text-interactive.is-cloze-revealed {
+  color: inherit;
+  background: none;
+  border-bottom-color: rgba(94, 234, 212, 0.45);
+}
+
 .rich-content p {
   margin: 0 0 0.75em;
 }
@@ -4528,11 +4628,47 @@ button.builder-pill.builder-pill-outline {
   background: linear-gradient(160deg, rgba(14, 22, 40, 0.82), rgba(14, 22, 40, 0.65));
   border: 1px solid rgba(148, 163, 184, 0.18);
   border-radius: var(--radius);
-  padding: clamp(16px, 2vw, 22px);
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
   box-shadow: inset 3px 0 0 color-mix(in srgb, var(--section-accent, var(--accent)) 55%, transparent), inset 0 0 0 1px rgba(15, 23, 42, 0.32);
+  overflow: hidden;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.deck-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  padding: clamp(16px, 2vw, 22px);
+  background: transparent;
+  border: none;
+  color: rgba(248, 250, 252, 0.78);
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+}
+
+.deck-section-header:hover,
+.deck-section-header:focus-visible {
+  color: rgba(248, 250, 252, 0.92);
+}
+
+.deck-section-header:focus-visible {
+  outline: 2px solid rgba(56, 189, 248, 0.45);
+  outline-offset: 2px;
+}
+
+.deck-section-header .card-collapse-icon {
+  width: 30px;
+  height: 30px;
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.deck-section-header:hover .card-collapse-icon,
+.deck-section-header:focus-visible .card-collapse-icon {
+  background: rgba(56, 189, 248, 0.2);
+  border-color: rgba(56, 189, 248, 0.35);
 }
 
 .deck-section-title {
@@ -4542,7 +4678,7 @@ button.builder-pill.builder-pill-outline {
   font-size: 0.95rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgba(248, 250, 252, 0.78);
+  color: inherit;
   margin: 0;
 }
 
@@ -4556,6 +4692,12 @@ button.builder-pill.builder-pill-outline {
   background: color-mix(in srgb, var(--section-accent, var(--accent)) 18%, rgba(15, 23, 42, 0.6));
   font-size: 1rem;
   line-height: 1;
+}
+
+.deck-section-body {
+  padding: 0 clamp(18px, 2vw, 26px) clamp(20px, 2vw, 28px);
+  border-top: 1px solid rgba(148, 163, 184, 0.18);
+  background: linear-gradient(160deg, rgba(14, 22, 40, 0.82), rgba(14, 22, 40, 0.58));
 }
 
 .deck-section-content {
@@ -4572,6 +4714,14 @@ button.builder-pill.builder-pill-outline {
   margin: 0;
   font-size: 0.95rem;
   color: rgba(248, 250, 252, 0.6);
+}
+
+.deck-section.is-collapsed .deck-section-body {
+  display: none;
+}
+
+.deck-section.is-collapsed .card-collapse-icon {
+  transform: rotate(-90deg);
 }
 
 .deck-related-panel {


### PR DESCRIPTION
## Summary
- sort lecture deck cards by creation date and add collapsible section panels with interactive cloze reveals
- enhance the rich text editor with dropdown font controls, a cloze toggle button, and automatic brace-to-cloze sanitizing
- update flashcards and styles to support the new cloze presentation and refreshed typography controls

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de7b59614c8322bf7f4a0d6f244cfe