### PR TITLE
Fix deck collapsibles and expose custom study content

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -4719,6 +4719,15 @@ var Sevenn = (() => {
     toolbar.setAttribute("role", "toolbar");
     toolbar.setAttribute("aria-label", "Text formatting toolbar");
     wrapper.appendChild(toolbar);
+    const toolbarMain = document.createElement("div");
+    toolbarMain.className = "rich-editor-toolbar-row";
+    toolbar.appendChild(toolbarMain);
+    const advancedRow = document.createElement("div");
+    advancedRow.className = "rich-editor-toolbar-row rich-editor-toolbar-advanced";
+    advancedRow.hidden = true;
+    const advancedRowId = `rich-editor-advanced-${Math.random().toString(36).slice(2)}`;
+    advancedRow.id = advancedRowId;
+    toolbar.appendChild(advancedRow);
     const imageFileInput = document.createElement("input");
     imageFileInput.type = "file";
     imageFileInput.accept = "image/*";
@@ -5489,11 +5498,11 @@ var Sevenn = (() => {
         });
       }, { requireSelection: true });
     }
-    function createGroup(extraClass) {
+    function createGroup(extraClass, target = toolbarMain) {
       const group = document.createElement("div");
       group.className = "rich-editor-group";
       if (extraClass) group.classList.add(extraClass);
-      toolbar.appendChild(group);
+      target.appendChild(group);
       return group;
     }
     const inlineGroup = createGroup();
@@ -5525,7 +5534,7 @@ var Sevenn = (() => {
       colorInput.dataset.lastColor = colorInput.value;
     });
     colorWrap.appendChild(colorInput);
-    const colorGroup = createGroup("rich-editor-color-group");
+    const colorGroup = createGroup("rich-editor-color-group", advancedRow);
     colorGroup.appendChild(colorWrap);
     const highlightRow = document.createElement("div");
     highlightRow.className = "rich-editor-highlight-row";
@@ -5595,7 +5604,7 @@ var Sevenn = (() => {
       const btn = createToolbarButton(label, title, handler);
       listGroup.appendChild(btn);
     });
-    const typographyGroup = createGroup("rich-editor-typography-group");
+    const typographyGroup = createGroup("rich-editor-typography-group", advancedRow);
     const fontInfo = document.createElement("div");
     fontInfo.className = "rich-editor-font-info";
     fontNameLabel = document.createElement("span");
@@ -5745,6 +5754,31 @@ var Sevenn = (() => {
     const utilityGroup = createGroup("rich-editor-utility-group");
     utilityGroup.appendChild(clozeTool);
     utilityGroup.appendChild(clearBtn);
+    let advancedOpen = false;
+    const advancedToggle = createToolbarButton("\u22EF", "More formatting options", (event) => {
+      event.preventDefault();
+      setAdvancedOpen(!advancedOpen);
+    });
+    advancedToggle.classList.add("rich-editor-more-btn");
+    advancedToggle.dataset.toggle = "false";
+    advancedToggle.dataset.active = "false";
+    advancedToggle.setAttribute("aria-expanded", "false");
+    advancedToggle.setAttribute("aria-controls", advancedRowId);
+    utilityGroup.appendChild(advancedToggle);
+    function setAdvancedOpen(open) {
+      advancedOpen = Boolean(open);
+      advancedRow.hidden = !advancedOpen;
+      advancedToggle.dataset.active = advancedOpen ? "true" : "false";
+      advancedToggle.setAttribute("aria-pressed", advancedOpen ? "true" : "false");
+      advancedToggle.setAttribute("aria-expanded", advancedOpen ? "true" : "false");
+      advancedToggle.classList.toggle("is-active", advancedOpen);
+      if (!advancedOpen) {
+        advancedRow.setAttribute("aria-hidden", "true");
+      } else {
+        advancedRow.removeAttribute("aria-hidden");
+      }
+    }
+    setAdvancedOpen(false);
     let settingValue = false;
     editable.addEventListener("input", () => {
       if (settingValue) return;
@@ -8282,7 +8316,9 @@ var Sevenn = (() => {
         bodyWrap.appendChild(content);
         section.appendChild(headerBtn);
         section.appendChild(bodyWrap);
-        headerBtn.addEventListener("click", () => {
+        headerBtn.addEventListener("click", (event) => {
+          event.preventDefault();
+          event.stopPropagation();
           const collapsed = section.classList.toggle("is-collapsed");
           headerBtn.setAttribute("aria-expanded", collapsed ? "false" : "true");
         });
@@ -12863,6 +12899,39 @@ var Sevenn = (() => {
   }
 
   // js/ui/components/section-utils.js
+  var EXTRA_PREFIX = "extra:";
+  function escapeHtml6(str = "") {
+    return String(str).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+  }
+  function normalizeExtras(item) {
+    if (Array.isArray(item?.extras) && item.extras.length) {
+      return item.extras.map((extra, index) => {
+        if (!extra || typeof extra !== "object") return null;
+        const body = typeof extra.body === "string" ? extra.body : "";
+        if (!hasRichTextContent(body)) return null;
+        const id = extra.id != null ? String(extra.id) : String(index);
+        return {
+          id,
+          title: typeof extra.title === "string" && extra.title.trim() ? extra.title.trim() : "Additional Section",
+          body
+        };
+      }).filter(Boolean);
+    }
+    if (Array.isArray(item?.facts) && item.facts.length) {
+      return [
+        {
+          id: "legacy-facts",
+          title: "Highlights",
+          body: `<ul>${item.facts.map((fact) => `<li>${escapeHtml6(fact)}</li>`).join("")}</ul>`
+        }
+      ];
+    }
+    return [];
+  }
+  function extraKeyFor(extra, index) {
+    const rawId = extra?.id != null ? String(extra.id) : String(index);
+    return `${EXTRA_PREFIX}${rawId}`;
+  }
   function hasSectionContent(item, key) {
     if (!item || !key) return false;
     const defs = sectionDefsForKind(item.kind);
@@ -12874,12 +12943,35 @@ var Sevenn = (() => {
   function sectionsForItem(item, allowedKeys = null) {
     const defs = sectionDefsForKind(item.kind);
     const allowSet = allowedKeys ? new Set(allowedKeys) : null;
-    return defs.filter((def) => (!allowSet || allowSet.has(def.key)) && hasSectionContent(item, def.key)).map((def) => ({ key: def.key, label: def.label }));
+    const sections = defs.filter((def) => (!allowSet || allowSet.has(def.key)) && hasSectionContent(item, def.key)).map((def) => ({
+      key: def.key,
+      label: def.label,
+      body: item?.[def.key] || "",
+      isExtra: false
+    }));
+    const extras = normalizeExtras(item);
+    extras.forEach((extra, index) => {
+      const key = extraKeyFor(extra, index);
+      sections.push({
+        key,
+        label: extra.title || "Additional Section",
+        body: extra.body,
+        isExtra: true
+      });
+    });
+    return sections;
   }
   function getSectionLabel(item, key) {
     const defs = sectionDefsForKind(item.kind);
     const def = defs.find((entry) => entry.key === key);
-    return def ? def.label : key;
+    if (def) return def.label;
+    if (typeof key === "string" && key.startsWith(EXTRA_PREFIX)) {
+      const extras = normalizeExtras(item);
+      const match = extras.find((extra, index) => extraKeyFor(extra, index) === key);
+      if (match) return match.title || "Custom Section";
+      return "Custom Section";
+    }
+    return key;
   }
 
   // js/ui/components/flashcards.js
@@ -13037,13 +13129,14 @@ var Sevenn = (() => {
       empty.textContent = "No content available for this card.";
       card.appendChild(empty);
     }
-    sectionBlocks.forEach(({ key, label }) => {
+    sectionBlocks.forEach((section) => {
+      const { key, label, body: sectionBody = "", isExtra } = section;
       const ratingId = ratingKey(item, key);
       const previousRating = active.ratings[ratingId] || null;
-      const snapshot = getSectionStateSnapshot(item, key);
-      const lockedByQueue = !isReview && Boolean(snapshot && snapshot.last && !snapshot.retired);
-      const alreadyQueued = !isReview && Boolean(snapshot && snapshot.last && !snapshot.retired);
-      const requiresRating = isReview || !alreadyQueued;
+      const snapshot = isExtra ? null : getSectionStateSnapshot(item, key);
+      const lockedByQueue = !isExtra && !isReview && Boolean(snapshot && snapshot.last && !snapshot.retired);
+      const alreadyQueued = !isExtra && !isReview && Boolean(snapshot && snapshot.last && !snapshot.retired);
+      const requiresRating = !isExtra && (isReview || !alreadyQueued);
       sectionRequirements.set(key, requiresRating);
       const sec = document.createElement("div");
       sec.className = "flash-section";
@@ -13054,114 +13147,119 @@ var Sevenn = (() => {
       head.textContent = label;
       const body = document.createElement("div");
       body.className = "flash-body";
-      renderRichText(body, item[key] || "", { clozeMode: "interactive" });
-      const ratingRow = document.createElement("div");
-      ratingRow.className = "flash-rating";
-      const ratingButtons = document.createElement("div");
-      ratingButtons.className = "flash-rating-options";
-      const status = document.createElement("span");
-      status.className = "flash-rating-status";
-      let ratingLocked = lockedByQueue;
-      const selectRating = (value) => {
-        active.ratings[ratingId] = value;
-        Array.from(ratingButtons.querySelectorAll("button")).forEach((btn) => {
-          const btnValue = btn.dataset.value;
-          const isSelected = btnValue === value;
-          btn.classList.toggle("is-selected", isSelected);
-          if (isSelected) {
-            ratingButtons.dataset.selected = value;
-          } else if (ratingButtons.dataset.selected === btnValue) {
-            delete ratingButtons.dataset.selected;
-          }
-          btn.setAttribute("aria-pressed", isSelected ? "true" : "false");
-        });
-        status.classList.remove("is-error");
-        commitSession({ ratings: { ...active.ratings } });
-      };
-      const handleRating = async (value) => {
-        if (ratingLocked) return;
-        const durations = await durationsPromise;
-        setToggleState(sec, true, "revealed");
-        ratingRow.classList.add("is-saving");
-        status.textContent = "Saving\u2026";
-        status.classList.remove("is-error");
-        try {
-          rateSection(item, key, value, durations, Date.now());
-          await upsertItem(item);
-          selectRating(value);
-          status.textContent = "Saved";
+      renderRichText(body, sectionBody, { clozeMode: "interactive" });
+      let ratingRow = null;
+      if (!isExtra) {
+        ratingRow = document.createElement("div");
+        ratingRow.className = "flash-rating";
+        const ratingButtons = document.createElement("div");
+        ratingButtons.className = "flash-rating-options";
+        const status = document.createElement("span");
+        status.className = "flash-rating-status";
+        let ratingLocked = lockedByQueue;
+        const selectRating = (value) => {
+          active.ratings[ratingId] = value;
+          Array.from(ratingButtons.querySelectorAll("button")).forEach((btn) => {
+            const btnValue = btn.dataset.value;
+            const isSelected = btnValue === value;
+            btn.classList.toggle("is-selected", isSelected);
+            if (isSelected) {
+              ratingButtons.dataset.selected = value;
+            } else if (ratingButtons.dataset.selected === btnValue) {
+              delete ratingButtons.dataset.selected;
+            }
+            btn.setAttribute("aria-pressed", isSelected ? "true" : "false");
+          });
           status.classList.remove("is-error");
-        } catch (err) {
-          console.error("Failed to record rating", err);
-          status.textContent = "Save failed";
-          status.classList.add("is-error");
-        } finally {
-          ratingRow.classList.remove("is-saving");
-        }
-      };
-      REVIEW_RATINGS.forEach((value) => {
-        const btn = document.createElement("button");
-        btn.type = "button";
-        btn.dataset.value = value;
-        btn.dataset.rating = value;
-        btn.className = "flash-rating-btn";
-        const variant = RATING_CLASS[value];
-        if (variant) btn.classList.add(variant);
-        btn.textContent = RATING_LABELS[value];
-        btn.setAttribute("aria-pressed", "false");
-        btn.addEventListener("click", (event) => {
-          event.stopPropagation();
-          handleRating(value);
-        });
-        btn.addEventListener("keydown", (event) => {
-          event.stopPropagation();
-          if (event.key === "Enter" || event.key === " ") {
-            event.preventDefault();
+          commitSession({ ratings: { ...active.ratings } });
+        };
+        const handleRating = async (value) => {
+          if (ratingLocked) return;
+          const durations = await durationsPromise;
+          setToggleState(sec, true, "revealed");
+          ratingRow.classList.add("is-saving");
+          status.textContent = "Saving\u2026";
+          status.classList.remove("is-error");
+          try {
+            rateSection(item, key, value, durations, Date.now());
+            await upsertItem(item);
+            selectRating(value);
+            status.textContent = "Saved";
+            status.classList.remove("is-error");
+          } catch (err) {
+            console.error("Failed to record rating", err);
+            status.textContent = "Save failed";
+            status.classList.add("is-error");
+          } finally {
+            ratingRow.classList.remove("is-saving");
+          }
+        };
+        REVIEW_RATINGS.forEach((value) => {
+          const btn = document.createElement("button");
+          btn.type = "button";
+          btn.dataset.value = value;
+          btn.dataset.rating = value;
+          btn.className = "flash-rating-btn";
+          const variant = RATING_CLASS[value];
+          if (variant) btn.classList.add(variant);
+          btn.textContent = RATING_LABELS[value];
+          btn.setAttribute("aria-pressed", "false");
+          btn.addEventListener("click", (event) => {
+            event.stopPropagation();
             handleRating(value);
-          }
+          });
+          btn.addEventListener("keydown", (event) => {
+            event.stopPropagation();
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              handleRating(value);
+            }
+          });
+          ratingButtons.appendChild(btn);
         });
-        ratingButtons.appendChild(btn);
-      });
-      const unlockRating = () => {
-        if (!ratingLocked) return;
-        ratingLocked = false;
-        ratingRow.classList.remove("is-locked");
-        ratingButtons.hidden = false;
-        status.classList.remove("flash-rating-status-action");
-        status.removeAttribute("role");
-        status.removeAttribute("tabindex");
-        status.textContent = previousRating ? "Update rating" : "Select a rating (optional)";
-      };
-      if (lockedByQueue) {
-        ratingLocked = true;
-        ratingRow.classList.add("is-locked");
-        ratingButtons.hidden = true;
-        const label2 = queueStatusLabel(snapshot);
-        status.textContent = `${label2} \u2014 click to adjust`;
-        status.classList.add("flash-rating-status-action");
-        status.setAttribute("role", "button");
-        status.setAttribute("tabindex", "0");
-        status.setAttribute("aria-label", "Update review rating");
-        status.addEventListener("click", (event) => {
-          event.stopPropagation();
-          unlockRating();
-        });
-        status.addEventListener("keydown", (event) => {
-          if (event.key === "Enter" || event.key === " ") {
-            event.preventDefault();
+        const unlockRating = () => {
+          if (!ratingLocked) return;
+          ratingLocked = false;
+          ratingRow.classList.remove("is-locked");
+          ratingButtons.hidden = false;
+          status.classList.remove("flash-rating-status-action");
+          status.removeAttribute("role");
+          status.removeAttribute("tabindex");
+          status.textContent = previousRating ? "Update rating" : "Select a rating (optional)";
+        };
+        if (lockedByQueue) {
+          ratingLocked = true;
+          ratingRow.classList.add("is-locked");
+          ratingButtons.hidden = true;
+          const label2 = queueStatusLabel(snapshot);
+          status.textContent = `${label2} \u2014 click to adjust`;
+          status.classList.add("flash-rating-status-action");
+          status.setAttribute("role", "button");
+          status.setAttribute("tabindex", "0");
+          status.setAttribute("aria-label", "Update review rating");
+          status.addEventListener("click", (event) => {
+            event.stopPropagation();
             unlockRating();
-          }
-        });
-      } else if (previousRating) {
-        status.textContent = "Saved";
+          });
+          status.addEventListener("keydown", (event) => {
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              unlockRating();
+            }
+          });
+        } else if (previousRating) {
+          status.textContent = "Saved";
+        } else {
+          status.textContent = "Select a rating (optional)";
+        }
+        if (previousRating) {
+          selectRating(previousRating);
+        }
+        ratingRow.appendChild(ratingButtons);
+        ratingRow.appendChild(status);
       } else {
-        status.textContent = "Select a rating (optional)";
+        sec.classList.add("flash-section-extra");
       }
-      if (previousRating) {
-        selectRating(previousRating);
-      }
-      ratingRow.appendChild(ratingButtons);
-      ratingRow.appendChild(status);
       setToggleState(sec, false, "revealed");
       const toggleReveal = () => {
         if (sec.classList.contains("flash-section-disabled")) return;
@@ -13185,7 +13283,7 @@ var Sevenn = (() => {
       });
       sec.appendChild(head);
       sec.appendChild(body);
-      sec.appendChild(ratingRow);
+      if (ratingRow) sec.appendChild(ratingRow);
       card.appendChild(sec);
     });
     const controls = document.createElement("div");
@@ -13767,7 +13865,7 @@ var Sevenn = (() => {
       emptySection.textContent = "No card content available for this entry.";
       details.appendChild(emptySection);
     } else {
-      sections.forEach(({ key, label }) => {
+      sections.forEach(({ key, label, body: sectionBody = "", isExtra }) => {
         const block = document.createElement("div");
         block.className = "quiz-section";
         const head = document.createElement("div");
@@ -13776,7 +13874,10 @@ var Sevenn = (() => {
         block.appendChild(head);
         const body = document.createElement("div");
         body.className = "quiz-section-body";
-        renderRichText(body, item[key] || "");
+        renderRichText(body, sectionBody || "");
+        if (isExtra) {
+          block.classList.add("quiz-section-extra");
+        }
         block.appendChild(body);
         details.appendChild(block);
       });
@@ -17732,7 +17833,7 @@ var Sevenn = (() => {
       ["mnemonic", "Mnemonic"]
     ]
   };
-  function escapeHtml6(str = "") {
+  function escapeHtml7(str = "") {
     return String(str).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
   }
   function collectExtras(item) {
@@ -17741,7 +17842,7 @@ var Sevenn = (() => {
       return [{
         id: "legacy-facts",
         title: "Highlights",
-        body: `<ul>${item.facts.map((f) => `<li>${escapeHtml6(f)}</li>`).join("")}</ul>`
+        body: `<ul>${item.facts.map((f) => `<li>${escapeHtml7(f)}</li>`).join("")}</ul>`
       }];
     }
     return [];

--- a/js/ui/components/cards.js
+++ b/js/ui/components/cards.js
@@ -938,7 +938,9 @@ export async function renderCards(container, items, onChange) {
       section.appendChild(headerBtn);
       section.appendChild(bodyWrap);
 
-      headerBtn.addEventListener('click', () => {
+      headerBtn.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
         const collapsed = section.classList.toggle('is-collapsed');
         headerBtn.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
       });

--- a/js/ui/components/flashcards.js
+++ b/js/ui/components/flashcards.js
@@ -190,13 +190,14 @@ export function renderFlashcards(root, redraw) {
     card.appendChild(empty);
   }
 
-  sectionBlocks.forEach(({ key, label }) => {
+  sectionBlocks.forEach(section => {
+    const { key, label, body: sectionBody = '', isExtra } = section;
     const ratingId = ratingKey(item, key);
     const previousRating = active.ratings[ratingId] || null;
-    const snapshot = getSectionStateSnapshot(item, key);
-    const lockedByQueue = !isReview && Boolean(snapshot && snapshot.last && !snapshot.retired);
-    const alreadyQueued = !isReview && Boolean(snapshot && snapshot.last && !snapshot.retired);
-    const requiresRating = isReview || !alreadyQueued;
+    const snapshot = isExtra ? null : getSectionStateSnapshot(item, key);
+    const lockedByQueue = !isExtra && !isReview && Boolean(snapshot && snapshot.last && !snapshot.retired);
+    const alreadyQueued = !isExtra && !isReview && Boolean(snapshot && snapshot.last && !snapshot.retired);
+    const requiresRating = !isExtra && (isReview || !alreadyQueued);
     sectionRequirements.set(key, requiresRating);
     const sec = document.createElement('div');
     sec.className = 'flash-section';
@@ -209,130 +210,133 @@ export function renderFlashcards(root, redraw) {
 
     const body = document.createElement('div');
     body.className = 'flash-body';
-    renderRichText(body, item[key] || '', { clozeMode: 'interactive' });
+    renderRichText(body, sectionBody, { clozeMode: 'interactive' });
 
-    const ratingRow = document.createElement('div');
-    ratingRow.className = 'flash-rating';
+    let ratingRow = null;
+    if (!isExtra) {
+      ratingRow = document.createElement('div');
+      ratingRow.className = 'flash-rating';
 
-    const ratingButtons = document.createElement('div');
-    ratingButtons.className = 'flash-rating-options';
+      const ratingButtons = document.createElement('div');
+      ratingButtons.className = 'flash-rating-options';
 
-    const status = document.createElement('span');
-    status.className = 'flash-rating-status';
+      const status = document.createElement('span');
+      status.className = 'flash-rating-status';
 
-    let ratingLocked = lockedByQueue;
+      let ratingLocked = lockedByQueue;
 
-    const selectRating = (value) => {
-      active.ratings[ratingId] = value;
-      Array.from(ratingButtons.querySelectorAll('button')).forEach(btn => {
-        const btnValue = btn.dataset.value;
-        const isSelected = btnValue === value;
-        btn.classList.toggle('is-selected', isSelected);
+      const selectRating = (value) => {
+        active.ratings[ratingId] = value;
+        Array.from(ratingButtons.querySelectorAll('button')).forEach(btn => {
+          const btnValue = btn.dataset.value;
+          const isSelected = btnValue === value;
+          btn.classList.toggle('is-selected', isSelected);
 
-        if (isSelected) {
-          ratingButtons.dataset.selected = value;
-        } else if (ratingButtons.dataset.selected === btnValue) {
-          delete ratingButtons.dataset.selected;
-        }
+          if (isSelected) {
+            ratingButtons.dataset.selected = value;
+          } else if (ratingButtons.dataset.selected === btnValue) {
+            delete ratingButtons.dataset.selected;
+          }
 
-        btn.setAttribute('aria-pressed', isSelected ? 'true' : 'false');
-      });
-      status.classList.remove('is-error');
-      commitSession({ ratings: { ...active.ratings } });
-
-    };
-
-    const handleRating = async (value) => {
-      if (ratingLocked) return;
-
-      const durations = await durationsPromise;
-      setToggleState(sec, true, 'revealed');
-      ratingRow.classList.add('is-saving');
-      status.textContent = 'Saving…';
-      status.classList.remove('is-error');
-      try {
-        rateSection(item, key, value, durations, Date.now());
-        await upsertItem(item);
-        selectRating(value);
-        status.textContent = 'Saved';
+          btn.setAttribute('aria-pressed', isSelected ? 'true' : 'false');
+        });
         status.classList.remove('is-error');
-      } catch (err) {
-        console.error('Failed to record rating', err);
-        status.textContent = 'Save failed';
-        status.classList.add('is-error');
-      } finally {
-        ratingRow.classList.remove('is-saving');
-      }
-    };
+        commitSession({ ratings: { ...active.ratings } });
+      };
 
-    REVIEW_RATINGS.forEach(value => {
-      const btn = document.createElement('button');
-      btn.type = 'button';
-      btn.dataset.value = value;
-      btn.dataset.rating = value;
-      btn.className = 'flash-rating-btn';
-      const variant = RATING_CLASS[value];
-      if (variant) btn.classList.add(variant);
-      btn.textContent = RATING_LABELS[value];
-      btn.setAttribute('aria-pressed', 'false');
-      btn.addEventListener('click', (event) => {
-        event.stopPropagation();
-        handleRating(value);
-      });
-      btn.addEventListener('keydown', (event) => {
-        event.stopPropagation();
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault();
+      const handleRating = async (value) => {
+        if (ratingLocked) return;
+
+        const durations = await durationsPromise;
+        setToggleState(sec, true, 'revealed');
+        ratingRow.classList.add('is-saving');
+        status.textContent = 'Saving…';
+        status.classList.remove('is-error');
+        try {
+          rateSection(item, key, value, durations, Date.now());
+          await upsertItem(item);
+          selectRating(value);
+          status.textContent = 'Saved';
+          status.classList.remove('is-error');
+        } catch (err) {
+          console.error('Failed to record rating', err);
+          status.textContent = 'Save failed';
+          status.classList.add('is-error');
+        } finally {
+          ratingRow.classList.remove('is-saving');
+        }
+      };
+
+      REVIEW_RATINGS.forEach(value => {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.dataset.value = value;
+        btn.dataset.rating = value;
+        btn.className = 'flash-rating-btn';
+        const variant = RATING_CLASS[value];
+        if (variant) btn.classList.add(variant);
+        btn.textContent = RATING_LABELS[value];
+        btn.setAttribute('aria-pressed', 'false');
+        btn.addEventListener('click', (event) => {
+          event.stopPropagation();
           handleRating(value);
-        }
+        });
+        btn.addEventListener('keydown', (event) => {
+          event.stopPropagation();
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            handleRating(value);
+          }
+        });
+        ratingButtons.appendChild(btn);
       });
-      ratingButtons.appendChild(btn);
-    });
 
-    const unlockRating = () => {
-      if (!ratingLocked) return;
-      ratingLocked = false;
-      ratingRow.classList.remove('is-locked');
-      ratingButtons.hidden = false;
-      status.classList.remove('flash-rating-status-action');
-      status.removeAttribute('role');
-      status.removeAttribute('tabindex');
-      status.textContent = previousRating ? 'Update rating' : 'Select a rating (optional)';
-    };
+      const unlockRating = () => {
+        if (!ratingLocked) return;
+        ratingLocked = false;
+        ratingRow.classList.remove('is-locked');
+        ratingButtons.hidden = false;
+        status.classList.remove('flash-rating-status-action');
+        status.removeAttribute('role');
+        status.removeAttribute('tabindex');
+        status.textContent = previousRating ? 'Update rating' : 'Select a rating (optional)';
+      };
 
-    if (lockedByQueue) {
-      ratingLocked = true;
-      ratingRow.classList.add('is-locked');
-      ratingButtons.hidden = true;
-      const label = queueStatusLabel(snapshot);
-      status.textContent = `${label} — click to adjust`;
-      status.classList.add('flash-rating-status-action');
-      status.setAttribute('role', 'button');
-      status.setAttribute('tabindex', '0');
-      status.setAttribute('aria-label', 'Update review rating');
-      status.addEventListener('click', (event) => {
-        event.stopPropagation();
-        unlockRating();
-      });
-      status.addEventListener('keydown', (event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault();
+      if (lockedByQueue) {
+        ratingLocked = true;
+        ratingRow.classList.add('is-locked');
+        ratingButtons.hidden = true;
+        const label = queueStatusLabel(snapshot);
+        status.textContent = `${label} — click to adjust`;
+        status.classList.add('flash-rating-status-action');
+        status.setAttribute('role', 'button');
+        status.setAttribute('tabindex', '0');
+        status.setAttribute('aria-label', 'Update review rating');
+        status.addEventListener('click', (event) => {
+          event.stopPropagation();
           unlockRating();
-        }
-      });
-    } else if (previousRating) {
-      status.textContent = 'Saved';
+        });
+        status.addEventListener('keydown', (event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            unlockRating();
+          }
+        });
+      } else if (previousRating) {
+        status.textContent = 'Saved';
+      } else {
+        status.textContent = 'Select a rating (optional)';
+      }
+
+      if (previousRating) {
+        selectRating(previousRating);
+      }
+
+      ratingRow.appendChild(ratingButtons);
+      ratingRow.appendChild(status);
     } else {
-      status.textContent = 'Select a rating (optional)';
+      sec.classList.add('flash-section-extra');
     }
-
-    if (previousRating) {
-      selectRating(previousRating);
-
-    }
-
-    ratingRow.appendChild(ratingButtons);
-    ratingRow.appendChild(status);
 
     setToggleState(sec, false, 'revealed');
     const toggleReveal = () => {
@@ -358,7 +362,7 @@ export function renderFlashcards(root, redraw) {
 
     sec.appendChild(head);
     sec.appendChild(body);
-    sec.appendChild(ratingRow);
+    if (ratingRow) sec.appendChild(ratingRow);
     card.appendChild(sec);
   });
 

--- a/js/ui/components/quiz.js
+++ b/js/ui/components/quiz.js
@@ -185,7 +185,7 @@ export function renderQuiz(root, redraw) {
     emptySection.textContent = 'No card content available for this entry.';
     details.appendChild(emptySection);
   } else {
-    sections.forEach(({ key, label }) => {
+    sections.forEach(({ key, label, body: sectionBody = '', isExtra }) => {
       const block = document.createElement('div');
       block.className = 'quiz-section';
 
@@ -196,7 +196,10 @@ export function renderQuiz(root, redraw) {
 
       const body = document.createElement('div');
       body.className = 'quiz-section-body';
-      renderRichText(body, item[key] || '');
+      renderRichText(body, sectionBody || '');
+      if (isExtra) {
+        block.classList.add('quiz-section-extra');
+      }
       block.appendChild(body);
 
       details.appendChild(block);

--- a/js/ui/components/rich-text.js
+++ b/js/ui/components/rich-text.js
@@ -267,6 +267,17 @@ export function createRichTextEditor({ value = '', onChange, ariaLabel, ariaLabe
   toolbar.setAttribute('aria-label', 'Text formatting toolbar');
   wrapper.appendChild(toolbar);
 
+  const toolbarMain = document.createElement('div');
+  toolbarMain.className = 'rich-editor-toolbar-row';
+  toolbar.appendChild(toolbarMain);
+
+  const advancedRow = document.createElement('div');
+  advancedRow.className = 'rich-editor-toolbar-row rich-editor-toolbar-advanced';
+  advancedRow.hidden = true;
+  const advancedRowId = `rich-editor-advanced-${Math.random().toString(36).slice(2)}`;
+  advancedRow.id = advancedRowId;
+  toolbar.appendChild(advancedRow);
+
   const imageFileInput = document.createElement('input');
   imageFileInput.type = 'file';
   imageFileInput.accept = 'image/*';
@@ -1116,11 +1127,11 @@ export function createRichTextEditor({ value = '', onChange, ariaLabel, ariaLabe
     }, { requireSelection: true });
   }
 
-  function createGroup(extraClass){
+  function createGroup(extraClass, target = toolbarMain){
     const group = document.createElement('div');
     group.className = 'rich-editor-group';
     if (extraClass) group.classList.add(extraClass);
-    toolbar.appendChild(group);
+    target.appendChild(group);
     return group;
   }
   const inlineGroup = createGroup();
@@ -1153,7 +1164,7 @@ export function createRichTextEditor({ value = '', onChange, ariaLabel, ariaLabe
     colorInput.dataset.lastColor = colorInput.value;
   });
   colorWrap.appendChild(colorInput);
-  const colorGroup = createGroup('rich-editor-color-group');
+  const colorGroup = createGroup('rich-editor-color-group', advancedRow);
   colorGroup.appendChild(colorWrap);
 
   const highlightRow = document.createElement('div');
@@ -1233,7 +1244,7 @@ export function createRichTextEditor({ value = '', onChange, ariaLabel, ariaLabe
     listGroup.appendChild(btn);
   });
 
-  const typographyGroup = createGroup('rich-editor-typography-group');
+  const typographyGroup = createGroup('rich-editor-typography-group', advancedRow);
 
   const fontInfo = document.createElement('div');
   fontInfo.className = 'rich-editor-font-info';
@@ -1392,6 +1403,33 @@ export function createRichTextEditor({ value = '', onChange, ariaLabel, ariaLabe
   const utilityGroup = createGroup('rich-editor-utility-group');
   utilityGroup.appendChild(clozeTool);
   utilityGroup.appendChild(clearBtn);
+
+  let advancedOpen = false;
+  const advancedToggle = createToolbarButton('⋯', 'More formatting options', (event) => {
+    event.preventDefault();
+    setAdvancedOpen(!advancedOpen);
+  });
+  advancedToggle.classList.add('rich-editor-more-btn');
+  advancedToggle.dataset.toggle = 'false';
+  advancedToggle.dataset.active = 'false';
+  advancedToggle.setAttribute('aria-expanded', 'false');
+  advancedToggle.setAttribute('aria-controls', advancedRowId);
+  utilityGroup.appendChild(advancedToggle);
+
+  function setAdvancedOpen(open) {
+    advancedOpen = Boolean(open);
+    advancedRow.hidden = !advancedOpen;
+    advancedToggle.dataset.active = advancedOpen ? 'true' : 'false';
+    advancedToggle.setAttribute('aria-pressed', advancedOpen ? 'true' : 'false');
+    advancedToggle.setAttribute('aria-expanded', advancedOpen ? 'true' : 'false');
+    advancedToggle.classList.toggle('is-active', advancedOpen);
+    if (!advancedOpen) {
+      advancedRow.setAttribute('aria-hidden', 'true');
+    } else {
+      advancedRow.removeAttribute('aria-hidden');
+    }
+  }
+  setAdvancedOpen(false);
 
   let settingValue = false;
   editable.addEventListener('input', () => {

--- a/js/ui/components/section-utils.js
+++ b/js/ui/components/section-utils.js
@@ -1,6 +1,50 @@
 import { sectionDefsForKind } from './sections.js';
 import { hasRichTextContent } from './rich-text.js';
 
+const EXTRA_PREFIX = 'extra:';
+
+function escapeHtml(str = '') {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function normalizeExtras(item) {
+  if (Array.isArray(item?.extras) && item.extras.length) {
+    return item.extras
+      .map((extra, index) => {
+        if (!extra || typeof extra !== 'object') return null;
+        const body = typeof extra.body === 'string' ? extra.body : '';
+        if (!hasRichTextContent(body)) return null;
+        const id = extra.id != null ? String(extra.id) : String(index);
+        return {
+          id,
+          title: typeof extra.title === 'string' && extra.title.trim() ? extra.title.trim() : 'Additional Section',
+          body
+        };
+      })
+      .filter(Boolean);
+  }
+  if (Array.isArray(item?.facts) && item.facts.length) {
+    return [
+      {
+        id: 'legacy-facts',
+        title: 'Highlights',
+        body: `<ul>${item.facts.map(fact => `<li>${escapeHtml(fact)}</li>`).join('')}</ul>`
+      }
+    ];
+  }
+  return [];
+}
+
+function extraKeyFor(extra, index) {
+  const rawId = extra?.id != null ? String(extra.id) : String(index);
+  return `${EXTRA_PREFIX}${rawId}`;
+}
+
 export function hasSectionContent(item, key) {
   if (!item || !key) return false;
   const defs = sectionDefsForKind(item.kind);
@@ -13,13 +57,42 @@ export function hasSectionContent(item, key) {
 export function sectionsForItem(item, allowedKeys = null) {
   const defs = sectionDefsForKind(item.kind);
   const allowSet = allowedKeys ? new Set(allowedKeys) : null;
-  return defs
+  const sections = defs
     .filter(def => (!allowSet || allowSet.has(def.key)) && hasSectionContent(item, def.key))
-    .map(def => ({ key: def.key, label: def.label }));
+    .map(def => ({
+      key: def.key,
+      label: def.label,
+      body: item?.[def.key] || '',
+      isExtra: false
+    }));
+
+  const extras = normalizeExtras(item);
+  extras.forEach((extra, index) => {
+    const key = extraKeyFor(extra, index);
+    sections.push({
+      key,
+      label: extra.title || 'Additional Section',
+      body: extra.body,
+      isExtra: true
+    });
+  });
+
+  return sections;
 }
 
 export function getSectionLabel(item, key) {
   const defs = sectionDefsForKind(item.kind);
   const def = defs.find(entry => entry.key === key);
-  return def ? def.label : key;
+  if (def) return def.label;
+  if (typeof key === 'string' && key.startsWith(EXTRA_PREFIX)) {
+    const extras = normalizeExtras(item);
+    const match = extras.find((extra, index) => extraKeyFor(extra, index) === key);
+    if (match) return match.title || 'Custom Section';
+    return 'Custom Section';
+  }
+  return key;
+}
+
+export function isExtraSectionKey(key) {
+  return typeof key === 'string' && key.startsWith(EXTRA_PREFIX);
 }

--- a/style.css
+++ b/style.css
@@ -937,6 +937,11 @@ button:not(.tab):not(.fab-btn):not(.builder-pill):not(.builder-mode-toggle):not(
   gap: var(--pad-sm);
 }
 
+.quiz-section-extra {
+  border-style: dashed;
+  border-color: rgba(148, 163, 184, 0.35);
+}
+
 .quiz-section-title {
   font-weight: 600;
   letter-spacing: 0.02em;
@@ -1922,19 +1927,34 @@ input[type="checkbox"]:checked::after {
 
 .rich-editor-toolbar {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 6px;
+  align-items: stretch;
+}
+
+.rich-editor-toolbar-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
   align-items: center;
+}
+
+.rich-editor-toolbar-advanced {
+  padding: 6px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  background: rgba(8, 13, 23, 0.5);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
 }
 
 .rich-editor-group {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  padding: 4px 6px;
+  padding: 2px 4px;
   border-radius: var(--radius-sm);
-  border: 1px solid rgba(148, 163, 184, 0.16);
-  background: rgba(8, 13, 23, 0.5);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  background: rgba(8, 13, 23, 0.45);
   backdrop-filter: blur(8px);
 }
 
@@ -1952,12 +1972,18 @@ input[type="checkbox"]:checked::after {
   flex-wrap: wrap;
 }
 
+.rich-editor-more-btn {
+  font-weight: 700;
+  min-width: 32px;
+  justify-content: center;
+}
+
 .rich-editor-btn {
-  background: rgba(15, 23, 42, 0.35);
-  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.38);
+  border: 1px solid rgba(148, 163, 184, 0.22);
   color: var(--text-muted);
-  padding: 6px 8px;
-  font-size: 0.85rem;
+  padding: 4px 6px;
+  font-size: 0.78rem;
   cursor: pointer;
   border-radius: var(--radius-sm);
   font-weight: 600;
@@ -3166,6 +3192,15 @@ button.builder-pill.builder-pill-outline {
 
 .flash-section.revealed .flash-rating {
   display: flex;
+}
+
+.flash-section-extra {
+  border-style: dashed;
+  border-color: rgba(148, 163, 184, 0.35);
+}
+
+.flash-section-extra .flash-heading {
+  color: var(--text-muted);
 }
 
 .flash-rating-options {


### PR DESCRIPTION
## Summary
- ensure deck section headers respond consistently when collapsing cards in lecture decks
- show custom card sections across flashcards and quiz views with supporting styling updates
- streamline the rich text editor toolbar with a compact primary row and optional advanced controls

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de894083a88322b9ec41fd53e8142e