### PR TITLE
Fix deck slides and surface custom sections in study tools

### DIFF
--- a/js/ui/components/cards.js
+++ b/js/ui/components/cards.js
@@ -562,10 +562,10 @@ export async function renderCards(container, items, onChange) {
 
     function acquireSlide(item) {
       if (!slideCache.has(item)) {
-        slideCache.set(item, createDeckSlide(item, baseContext, { allowEdit: true }));
+        slideCache.set(item, () => createDeckSlide(item, baseContext, { allowEdit: true }));
       }
-      const template = slideCache.get(item);
-      const slide = template.cloneNode(true);
+      const factory = slideCache.get(item);
+      const slide = factory();
       slide.classList.add('deck-slide-full');
       prepareSlideActions(slide, item);
       return slide;

--- a/js/ui/components/flashcards.js
+++ b/js/ui/components/flashcards.js
@@ -190,7 +190,7 @@ export function renderFlashcards(root, redraw) {
     card.appendChild(empty);
   }
 
-  sectionBlocks.forEach(({ key, label }) => {
+  sectionBlocks.forEach(({ key, label, content, extra }) => {
     const ratingId = ratingKey(item, key);
     const previousRating = active.ratings[ratingId] || null;
     const snapshot = getSectionStateSnapshot(item, key);
@@ -200,6 +200,7 @@ export function renderFlashcards(root, redraw) {
     sectionRequirements.set(key, requiresRating);
     const sec = document.createElement('div');
     sec.className = 'flash-section';
+    if (extra) sec.classList.add('flash-section-extra');
     sec.setAttribute('role', 'button');
     sec.tabIndex = 0;
 
@@ -209,7 +210,7 @@ export function renderFlashcards(root, redraw) {
 
     const body = document.createElement('div');
     body.className = 'flash-body';
-    renderRichText(body, item[key] || '', { clozeMode: 'interactive' });
+    renderRichText(body, content || '', { clozeMode: 'interactive' });
 
     const ratingRow = document.createElement('div');
     ratingRow.className = 'flash-rating';

--- a/js/ui/components/quiz.js
+++ b/js/ui/components/quiz.js
@@ -185,9 +185,10 @@ export function renderQuiz(root, redraw) {
     emptySection.textContent = 'No card content available for this entry.';
     details.appendChild(emptySection);
   } else {
-    sections.forEach(({ key, label }) => {
+    sections.forEach(({ key, label, content, extra }) => {
       const block = document.createElement('div');
       block.className = 'quiz-section';
+      if (extra) block.classList.add('quiz-section-extra');
 
       const head = document.createElement('div');
       head.className = 'quiz-section-title';
@@ -196,7 +197,7 @@ export function renderQuiz(root, redraw) {
 
       const body = document.createElement('div');
       body.className = 'quiz-section-body';
-      renderRichText(body, item[key] || '');
+      renderRichText(body, content || '', { clozeMode: 'interactive' });
       block.appendChild(body);
 
       details.appendChild(block);

--- a/js/ui/components/section-utils.js
+++ b/js/ui/components/section-utils.js
@@ -1,25 +1,122 @@
 import { sectionDefsForKind } from './sections.js';
 import { hasRichTextContent } from './rich-text.js';
 
+export const EXTRA_SECTION_PREFIX = 'extra:';
+
+function escapeHtml(str = '') {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function rawExtras(item) {
+  if (Array.isArray(item?.extras) && item.extras.length) {
+    return item.extras;
+  }
+  if (Array.isArray(item?.facts) && item.facts.length) {
+    return [{
+      id: 'legacy-facts',
+      title: 'Highlights',
+      body: `<ul>${item.facts.map(f => `<li>${escapeHtml(f)}</li>`).join('')}</ul>`
+    }];
+  }
+  return [];
+}
+
+function normalizeExtras(item) {
+  const extras = rawExtras(item);
+  const seenKeys = new Set();
+  return extras.map((extra, index) => {
+    const source = extra && typeof extra === 'object' ? extra : {};
+    const title = typeof source.title === 'string' ? source.title.trim() : '';
+    const body = typeof source.body === 'string' ? source.body : '';
+    let keyId = source.id != null && `${source.id}`.trim() ? `${source.id}`.trim() : `idx-${index}`;
+    let key = `${EXTRA_SECTION_PREFIX}${keyId}`;
+    let attempt = 0;
+    while (seenKeys.has(key)) {
+      attempt += 1;
+      key = `${EXTRA_SECTION_PREFIX}${keyId}-${attempt}`;
+    }
+    seenKeys.add(key);
+    return {
+      key,
+      id: source.id ?? null,
+      title,
+      body,
+      index,
+      source
+    };
+  });
+}
+
+function findExtraByKey(item, key) {
+  if (!key || !key.startsWith(EXTRA_SECTION_PREFIX)) return null;
+  return normalizeExtras(item).find(entry => entry.key === key) || null;
+}
+
+function hasRichContent(value) {
+  if (typeof document === 'undefined') {
+    if (value == null) return false;
+    const text = String(value)
+      .replace(/<[^>]*>/g, ' ')
+      .replace(/&nbsp;/g, ' ')
+      .trim();
+    return text.length > 0;
+  }
+  return hasRichTextContent(value);
+}
+
 export function hasSectionContent(item, key) {
   if (!item || !key) return false;
+  if (key.startsWith(EXTRA_SECTION_PREFIX)) {
+    const extra = findExtraByKey(item, key);
+    return extra ? hasRichContent(extra.body) : false;
+  }
   const defs = sectionDefsForKind(item.kind);
   if (!defs.some(def => def.key === key)) return false;
   const raw = item[key];
   if (raw === null || raw === undefined) return false;
-  return hasRichTextContent(raw);
+  return hasRichContent(raw);
 }
 
 export function sectionsForItem(item, allowedKeys = null) {
   const defs = sectionDefsForKind(item.kind);
   const allowSet = allowedKeys ? new Set(allowedKeys) : null;
-  return defs
+  const sections = defs
     .filter(def => (!allowSet || allowSet.has(def.key)) && hasSectionContent(item, def.key))
-    .map(def => ({ key: def.key, label: def.label }));
+    .map(def => ({ key: def.key, label: def.label, content: item?.[def.key] || '' }));
+
+  normalizeExtras(item).forEach(extra => {
+    if (!hasRichContent(extra.body)) return;
+    sections.push({
+      key: extra.key,
+      label: extra.title || 'Additional Notes',
+      content: extra.body,
+      extra: true,
+      extraId: extra.id
+    });
+  });
+
+  return sections;
 }
 
 export function getSectionLabel(item, key) {
+  if (key && key.startsWith(EXTRA_SECTION_PREFIX)) {
+    const extra = findExtraByKey(item, key);
+    return extra ? (extra.title || 'Additional Notes') : key;
+  }
   const defs = sectionDefsForKind(item.kind);
   const def = defs.find(entry => entry.key === key);
   return def ? def.label : key;
+}
+
+export function getSectionContent(item, key) {
+  if (key && key.startsWith(EXTRA_SECTION_PREFIX)) {
+    const extra = findExtraByKey(item, key);
+    return extra ? extra.body || '' : '';
+  }
+  return item?.[key] || '';
 }

--- a/style.css
+++ b/style.css
@@ -937,6 +937,16 @@ button:not(.tab):not(.fab-btn):not(.builder-pill):not(.builder-mode-toggle):not(
   gap: var(--pad-sm);
 }
 
+.quiz-section-extra {
+  border-style: dashed;
+  border-color: rgba(56, 189, 248, 0.3);
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.6), rgba(15, 23, 42, 0.45));
+}
+
+.quiz-section-extra .quiz-section-title {
+  color: color-mix(in srgb, var(--gray) 65%, rgba(56, 189, 248, 0.7));
+}
+
 .quiz-section-title {
   font-weight: 600;
   letter-spacing: 0.02em;
@@ -1913,36 +1923,40 @@ input[type="checkbox"]:checked::after {
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
   background: rgba(15, 23, 42, 0.32);
   border: 1px solid rgba(148, 163, 184, 0.22);
   border-radius: var(--radius);
-  padding: 12px;
+  padding: 10px;
 }
 
 .rich-editor-toolbar {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: 8px;
   align-items: center;
+  padding: 6px 8px;
+  border-radius: var(--radius);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(7, 12, 24, 0.72);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
 
 .rich-editor-group {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  padding: 4px 6px;
+  padding: 2px 4px;
   border-radius: var(--radius-sm);
   border: 1px solid rgba(148, 163, 184, 0.16);
-  background: rgba(8, 13, 23, 0.5);
-  backdrop-filter: blur(8px);
+  background: rgba(12, 19, 35, 0.55);
+  backdrop-filter: blur(6px);
 }
 
 .rich-editor-color-group {
-  gap: 6px;
   flex-wrap: wrap;
   align-items: center;
-  row-gap: 4px;
+  gap: 4px;
 }
 
 .rich-editor-highlight-row {
@@ -1953,47 +1967,48 @@ input[type="checkbox"]:checked::after {
 }
 
 .rich-editor-btn {
-  background: rgba(15, 23, 42, 0.35);
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  color: var(--text-muted);
-  padding: 6px 8px;
-  font-size: 0.85rem;
-  cursor: pointer;
-  border-radius: var(--radius-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  width: 30px;
+  height: 30px;
+  border-radius: 6px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(11, 18, 32, 0.35);
+  color: rgba(226, 232, 240, 0.78);
+  font-size: 0.82rem;
   font-weight: 600;
-  font-style: normal;
   letter-spacing: 0.01em;
-  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
 }
 
 .rich-editor-btn:hover,
-.rich-editor-btn:focus {
-  background: rgba(56, 189, 248, 0.14);
-  color: var(--text);
+.rich-editor-btn:focus-visible {
+  background: rgba(56, 189, 248, 0.16);
+  color: rgba(248, 250, 252, 0.92);
   border-color: rgba(56, 189, 248, 0.35);
   outline: none;
 }
 
-
 .rich-editor-btn:active {
-  color: #000;
+  transform: translateY(0.5px);
 }
 
 .rich-editor-btn.is-active,
 .rich-editor-btn[data-active="true"] {
-  background: linear-gradient(135deg, rgba(56, 189, 248, 0.96), rgba(192, 132, 252, 0.92));
-  border-color: transparent;
-  color: #000;
-  box-shadow: 0 18px 32px rgba(2, 6, 23, 0.42);
-  transform: translateY(-1px);
+  background: rgba(56, 189, 248, 0.22);
+  border-color: rgba(56, 189, 248, 0.45);
+  color: rgba(248, 250, 252, 0.94);
 }
 
 .rich-editor-btn.is-active:hover,
-.rich-editor-btn.is-active:focus,
+.rich-editor-btn.is-active:focus-visible,
 .rich-editor-btn[data-active="true"]:hover,
-.rich-editor-btn[data-active="true"]:focus {
-  background: linear-gradient(135deg, rgba(56, 189, 248, 0.98), rgba(192, 132, 252, 0.96));
-  color: #000;
+.rich-editor-btn[data-active="true"]:focus-visible {
+  background: rgba(56, 189, 248, 0.3);
+  border-color: rgba(56, 189, 248, 0.5);
 }
 
 .rich-editor-color {
@@ -2002,31 +2017,31 @@ input[type="checkbox"]:checked::after {
 }
 
 .rich-editor-color input {
-  width: 28px;
-  height: 26px;
+  width: 24px;
+  height: 24px;
   border: 1px solid rgba(148, 163, 184, 0.25);
-  border-radius: var(--radius-sm);
-  background: rgba(15, 23, 42, 0.45);
+  border-radius: 6px;
+  background: rgba(15, 23, 42, 0.55);
   padding: 0;
   cursor: pointer;
 }
 
 .rich-editor-swatch {
   position: relative;
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   border-radius: 50%;
-  border: 2px solid rgba(8, 13, 23, 0.75);
-  background: linear-gradient(135deg, rgba(15, 23, 42, 0.35), rgba(15, 23, 42, 0.1));
-  box-shadow: 0 0 0 2px rgba(148, 163, 184, 0.45);
+  border: 1px solid rgba(8, 13, 23, 0.65);
+  background: rgba(15, 23, 42, 0.3);
+  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.45);
   cursor: pointer;
   overflow: hidden;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .rich-editor-swatch:hover,
-.rich-editor-swatch:focus {
-  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.55), 0 0 0 4px rgba(8, 13, 23, 0.65);
+.rich-editor-swatch:focus-visible {
+  box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.6), 0 0 0 3px rgba(8, 13, 23, 0.65);
   transform: translateY(-1px);
   outline: none;
 }
@@ -2054,17 +2069,17 @@ input[type="checkbox"]:checked::after {
 }
 
 .rich-editor-swatch--clear:hover,
-.rich-editor-swatch--clear:focus {
-  color: var(--text);
+.rich-editor-swatch--clear:focus-visible {
+  color: rgba(248, 250, 252, 0.92);
 }
 
 .rich-editor-select {
-  background: rgba(15, 23, 42, 0.52);
-  border: 1px solid rgba(148, 163, 184, 0.22);
-  border-radius: var(--radius-sm);
-  color: var(--text);
-  padding: 6px 32px 6px 12px;
-  font-size: 0.85rem;
+  background: rgba(11, 18, 32, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 6px;
+  color: rgba(226, 232, 240, 0.92);
+  padding: 4px 28px 4px 10px;
+  font-size: 0.82rem;
   line-height: 1.3;
   min-width: 0;
   font-family: inherit;
@@ -2073,21 +2088,21 @@ input[type="checkbox"]:checked::after {
   -moz-appearance: none;
   background-image: linear-gradient(45deg, rgba(148, 163, 184, 0.42) 50%, transparent 50%),
     linear-gradient(135deg, rgba(148, 163, 184, 0.42) 50%, transparent 50%);
-  background-position: calc(100% - 14px) calc(50% - 3px), calc(100% - 8px) calc(50% - 3px);
-  background-size: 7px 7px;
+  background-position: calc(100% - 12px) calc(50% - 2px), calc(100% - 6px) calc(50% - 2px);
+  background-size: 6px 6px;
   background-repeat: no-repeat;
   cursor: pointer;
   transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .rich-editor-select:hover {
-  border-color: rgba(148, 163, 184, 0.35);
+  border-color: rgba(148, 163, 184, 0.34);
 }
 
 .rich-editor-select:focus-visible {
   outline: none;
   border-color: rgba(56, 189, 248, 0.45);
-  box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.25);
+  box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.3);
 }
 
 .rich-editor-select option {
@@ -2100,31 +2115,31 @@ input[type="checkbox"]:checked::after {
 }
 
 .rich-editor-font-select {
-  min-width: 160px;
+  min-width: 150px;
 }
 
 .rich-editor-size {
-  min-width: 110px;
+  min-width: 96px;
 }
 
 .rich-editor-font-info {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 130px;
-  font-size: 0.75rem;
-  color: var(--text-muted);
-  line-height: 1.3;
-}
-
-.rich-editor-font-info span {
-  display: block;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.72rem;
+  color: rgba(226, 232, 240, 0.7);
   white-space: nowrap;
 }
 
+.rich-editor-font-info span {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .rich-editor-typography-group {
-  align-items: stretch;
-  gap: 8px;
+  align-items: center;
+  gap: 6px;
 }
 
 .rich-editor-area {
@@ -3124,6 +3139,17 @@ button.builder-pill.builder-pill-outline {
   border: 1px solid var(--flash-accent-subtle);
   background: var(--flash-neutral-inactive);
   transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
+}
+
+.flash-section-extra {
+  border-style: dashed;
+  border-color: color-mix(in srgb, var(--flash-accent-border) 45%, transparent);
+  background: color-mix(in srgb, var(--flash-neutral-inactive) 82%, rgba(56, 189, 248, 0.12));
+}
+
+.flash-section-extra[data-active="true"] {
+  background: linear-gradient(135deg, var(--flash-accent-soft), color-mix(in srgb, var(--flash-accent-strong) 78%, rgba(56, 189, 248, 0.3)));
+  border-style: solid;
 }
 
 .flash-section:focus-visible {


### PR DESCRIPTION
## Summary
- ensure deck slide sections keep their toggle listeners by caching factory functions instead of cloned nodes
- surface custom "extras" sections in flashcards, quiz, and review scheduling while styling them distinctly
- condense the rich text toolbar layout for the editor to a more compact design

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de894083a88322b9ec41fd53e8142e