### PR TITLE
Fix concept map node dragging and selection accuracy

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -19915,13 +19915,11 @@ var Sevenn = (() => {
           }
           const targets = dragIds.map((id) => {
             const source = mapState.positions[id] || positions[id] || current;
-            if (id === it.id) {
-              return { id, offset: { x: 0, y: 0 } };
-            }
-            return {
-              id,
-              offset: { x: pointer.x - source.x, y: pointer.y - source.y }
+            const offset = {
+              x: pointer.x - source.x,
+              y: pointer.y - source.y
             };
+            return { id, offset };
           });
           const primaryTarget = targets.find((target) => target.id === it.id) || targets[0];
           mapState.nodeDrag = {
@@ -20641,7 +20639,8 @@ var Sevenn = (() => {
       const right = pos.x + radius;
       const top2 = pos.y - radius;
       const bottom = pos.y + radius;
-      if (left2 >= minX && right <= maxX && top2 >= minY && bottom <= maxY) {
+      const intersects = right >= minX && left2 <= maxX && bottom >= minY && top2 <= maxY;
+      if (intersects) {
         preview.push(id);
       }
     });

--- a/js/ui/components/map.js
+++ b/js/ui/components/map.js
@@ -2221,13 +2221,11 @@ export async function renderMap(root) {
         }
         const targets = dragIds.map(id => {
           const source = mapState.positions[id] || positions[id] || current;
-          if (id === it.id) {
-            return { id, offset: { x: 0, y: 0 } };
-          }
-          return {
-            id,
-            offset: { x: pointer.x - source.x, y: pointer.y - source.y }
+          const offset = {
+            x: pointer.x - source.x,
+            y: pointer.y - source.y
           };
+          return { id, offset };
         });
         const primaryTarget = targets.find(target => target.id === it.id) || targets[0];
         mapState.nodeDrag = {
@@ -2984,7 +2982,8 @@ function updateSelectionBox() {
     const right = pos.x + radius;
     const top = pos.y - radius;
     const bottom = pos.y + radius;
-    if (left >= minX && right <= maxX && top >= minY && bottom <= maxY) {
+    const intersects = right >= minX && left <= maxX && bottom >= minY && top <= maxY;
+    if (intersects) {
       preview.push(id);
     }
   });


### PR DESCRIPTION
## Summary
- preserve pointer offsets when dragging nodes so they stay under the cursor
- detect area selections using rectangle intersections for more intuitive results
- rebuild the application bundle

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0bc0b2f308322a3621e81e73a211e