### PR TITLE
Fix concept map drag alignment and marquee selection

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -19862,10 +19862,7 @@
           const selectionSet = new Set(mapState.selectionIds);
           let allowDrag = true;
           if (e.shiftKey) {
-            if (selectionSet.has(it.id)) {
-              selectionSet.delete(it.id);
-              allowDrag = false;
-            } else {
+            if (!selectionSet.has(it.id)) {
               selectionSet.add(it.id);
             }
           } else if (!selectionSet.has(it.id)) {
@@ -19887,6 +19884,7 @@
             dragIds.push(it.id);
           }
           const primarySource = mapState.positions[it.id] || positions[it.id] || current;
+          const pointerOffset = { x: 0, y: 0 };
           const targets = dragIds.map((id) => {
             const source = mapState.positions[id] || positions[id] || current;
             return {
@@ -19902,7 +19900,8 @@
             targets,
             pointerId: e.pointerId,
             captureTarget: e.currentTarget || circle,
-            client: { x: e.clientX, y: e.clientY }
+            client: { x: e.clientX, y: e.clientY },
+            pointerOffset
           };
           if (mapState.nodeDrag.captureTarget?.setPointerCapture) {
             try {
@@ -19912,6 +19911,10 @@
           }
           mapState.nodeWasDragged = false;
           setAreaInteracting(true);
+          const applied = applyNodeDragFromPointer(pointer, { markDragged: false });
+          if (applied) {
+            flushNodePositionUpdates({ cancelFrame: true });
+          }
         } else {
           mapState.areaDrag = {
             ids: [...mapState.selectionIds],
@@ -19941,6 +19944,15 @@
         e.stopPropagation();
         if (mapState.tool === TOOL.NAVIGATE && e.shiftKey) {
           mapState.suppressNextClick = false;
+          const set = new Set(mapState.selectionIds);
+          if (set.has(it.id)) {
+            set.delete(it.id);
+          } else {
+            set.add(it.id);
+          }
+          mapState.selectionIds = Array.from(set);
+          mapState.previewSelection = null;
+          updateSelectionHighlight();
           mapState.nodeWasDragged = false;
           return;
         }
@@ -19991,6 +20003,15 @@
         e.stopPropagation();
         if (mapState.tool === TOOL.NAVIGATE && e.shiftKey) {
           mapState.suppressNextClick = false;
+          const set = new Set(mapState.selectionIds);
+          if (set.has(it.id)) {
+            set.delete(it.id);
+          } else {
+            set.add(it.id);
+          }
+          mapState.selectionIds = Array.from(set);
+          mapState.previewSelection = null;
+          updateSelectionHighlight();
           mapState.nodeWasDragged = false;
           return;
         }
@@ -20245,6 +20266,32 @@
     }
     return [];
   }
+  function applyNodeDragFromPointer(pointer, options = {}) {
+    if (!pointer) return false;
+    const drag = mapState.nodeDrag;
+    if (!drag) return false;
+    const targets = getNodeDragTargets();
+    if (!targets.length) return false;
+    const offset = drag.pointerOffset || { x: 0, y: 0 };
+    const baseX = pointer.x + offset.x;
+    const baseY = pointer.y + offset.y;
+    let applied = false;
+    targets.forEach((target) => {
+      if (!target) return;
+      const { id, delta = { x: 0, y: 0 } } = target;
+      if (!id) return;
+      const entry = mapState.elements.get(id);
+      if (!entry || !entry.circle) return;
+      const nx = baseX + delta.x;
+      const ny = baseY + delta.y;
+      scheduleNodePositionUpdate(id, { x: nx, y: ny }, { immediate: true });
+      applied = true;
+    });
+    if (applied && options.markDragged !== false) {
+      mapState.nodeWasDragged = true;
+    }
+    return applied;
+  }
   function handlePointerMove(e) {
     if (!mapState.svg) return;
     if (mapState.toolboxDrag) {
@@ -20285,22 +20332,10 @@
       return;
     }
     if (mapState.nodeDrag && mapState.nodeDrag.pointerId === e.pointerId) {
-      const targets = getNodeDragTargets();
-      if (!targets.length) return;
       mapState.nodeDrag.client = { x: e.clientX, y: e.clientY };
       updateAutoPanFromPointer(e.clientX, e.clientY, { allowDuringDrag: true });
       const pointer = clientToMap(e.clientX, e.clientY);
-      targets.forEach((target) => {
-        if (!target) return;
-        const { id, delta = { x: 0, y: 0 } } = target;
-        if (!id) return;
-        const entry = mapState.elements.get(id);
-        if (!entry || !entry.circle) return;
-        const nx = pointer.x + delta.x;
-        const ny = pointer.y + delta.y;
-        scheduleNodePositionUpdate(id, { x: nx, y: ny }, { immediate: true });
-      });
-      mapState.nodeWasDragged = true;
+      applyNodeDragFromPointer(pointer);
       return;
     }
     if (mapState.areaDrag && mapState.areaDrag.pointerId === e.pointerId) {
@@ -20580,6 +20615,44 @@
       y: viewBox.y + ratioY * viewBox.h
     };
   }
+  function getElementPosition(entry, id) {
+    if (entry?.circle) {
+      const cx = Number(entry.circle.getAttribute("cx"));
+      const cy = Number(entry.circle.getAttribute("cy"));
+      if (Number.isFinite(cx) && Number.isFinite(cy)) {
+        return { x: cx, y: cy };
+      }
+    }
+    return mapState.positions?.[id] || null;
+  }
+  function getElementRadius(entry, id) {
+    if (entry?.circle) {
+      const r = Number(entry.circle.getAttribute("r"));
+      if (Number.isFinite(r) && r > 0) {
+        return r;
+      }
+    }
+    return getNodeRadius(id);
+  }
+  function collectNodesInRect(minX, maxX, minY, maxY) {
+    const preview = [];
+    const epsilon = 1e-4;
+    mapState.elements.forEach((entry, id) => {
+      const pos = getElementPosition(entry, id);
+      if (!pos) return;
+      const radius = getElementRadius(entry, id);
+      const nodeMinX = pos.x - radius;
+      const nodeMaxX = pos.x + radius;
+      const nodeMinY = pos.y - radius;
+      const nodeMaxY = pos.y + radius;
+      const fullyInside = nodeMinX >= minX - epsilon && nodeMaxX <= maxX + epsilon && nodeMinY >= minY - epsilon && nodeMaxY <= maxY + epsilon;
+      const intersects = nodeMaxX >= minX - epsilon && nodeMinX <= maxX + epsilon && nodeMaxY >= minY - epsilon && nodeMinY <= maxY + epsilon;
+      if (fullyInside || intersects) {
+        preview.push(id);
+      }
+    });
+    return preview;
+  }
   function updateSelectionBox() {
     if (!mapState.selectionRect || !mapState.selectionBox || !mapState.svg) return;
     const { startClient, currentClient, startMap, currentMap } = mapState.selectionRect;
@@ -20599,15 +20672,7 @@
     const maxX = Math.max(startMap.x, currentMap.x);
     const minY = Math.min(startMap.y, currentMap.y);
     const maxY = Math.max(startMap.y, currentMap.y);
-    const preview = [];
-    Object.entries(mapState.positions).forEach(([id, pos]) => {
-      if (!pos) return;
-      const inside = pos.x >= minX && pos.x <= maxX && pos.y >= minY && pos.y <= maxY;
-      if (inside) {
-        preview.push(id);
-      }
-    });
-    mapState.previewSelection = preview;
+    mapState.previewSelection = collectNodesInRect(minX, maxX, minY, maxY);
     updateSelectionHighlight();
   }
   function refreshSelectionRectFromClients({ updateStart = false } = {}) {
@@ -20740,16 +20805,7 @@
     }
     if (mapState.nodeDrag?.client) {
       const pointer = clientToMap(mapState.nodeDrag.client.x, mapState.nodeDrag.client.y);
-      const targets = getNodeDragTargets();
-      targets.forEach((target) => {
-        if (!target) return;
-        const { id, delta = { x: 0, y: 0 } } = target;
-        if (!id) return;
-        scheduleNodePositionUpdate(id, { x: pointer.x + delta.x, y: pointer.y + delta.y }, { immediate: true });
-      });
-      if (targets.length) {
-        mapState.nodeWasDragged = true;
-      }
+      applyNodeDragFromPointer(pointer);
     }
     if (mapState.areaDrag?.client) {
       const pointer = clientToMap(mapState.areaDrag.client.x, mapState.areaDrag.client.y);


### PR DESCRIPTION
## Summary
- align concept map drag logic with the pointer and keep multi-select groups synced while panning
- ensure selection rectangles use live node geometry so circles fully inside are captured
- rebuild the compiled bundle with the updated interaction logic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0c1c22a008322b1cbe27cbcb7836c