### PR TITLE
Improve map linking UX and filter robustness

### DIFF
--- a/js/ui/components/popup.js
+++ b/js/ui/components/popup.js
@@ -83,7 +83,7 @@ function normalizeHex(value) {
 }
 
 export function showPopup(item, options = {}) {
-  const { onEdit, onColorChange } = options;
+  const { onEdit, onColorChange, onLink } = options;
   const titleText = item?.name || item?.concept || 'Item';
   const accent = resolveAccentColor(item);
   const win = createFloatingWindow({ title: titleText, width: 560 });
@@ -195,6 +195,18 @@ export function showPopup(item, options = {}) {
       onEdit();
     });
     actions.appendChild(editBtn);
+  }
+
+  if (typeof onLink === 'function') {
+    const linkBtn = document.createElement('button');
+    linkBtn.type = 'button';
+    linkBtn.className = 'btn secondary';
+    linkBtn.textContent = 'Link';
+    linkBtn.addEventListener('click', () => {
+      void win.close('link');
+      onLink();
+    });
+    actions.appendChild(linkBtn);
   }
 
   const closeBtn = document.createElement('button');

--- a/style.css
+++ b/style.css
@@ -5390,6 +5390,93 @@ button.builder-pill.builder-pill-outline {
   color: rgba(226, 232, 240, 0.8);
 }
 
+.map-linker {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.map-linker-hint {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.map-linker-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.map-linker-field .input {
+  font-size: 15px;
+}
+
+.map-linker-results {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 260px;
+  overflow-y: auto;
+  padding: 12px;
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+}
+
+.map-linker-empty {
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.map-linker-result {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.map-linker-result-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.map-linker-result-title {
+  font-weight: 600;
+  font-size: 15px;
+  color: var(--text);
+}
+
+.map-linker-result-meta {
+  font-size: 12px;
+  color: var(--text-muted);
+  text-transform: capitalize;
+}
+
+.map-linker-result-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.map-linker-result-actions .btn {
+  white-space: nowrap;
+}
+
+.map-linker-result-status {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
 .map-controls {
   width: 100%;
   display: flex;


### PR DESCRIPTION
## Summary
- update the map popup to expose a Link action and open a dedicated linking window with search, label entry, and hidden-link recovery
- fix lecture filtering to handle non-numeric identifiers and keep bundle.js in sync with source changes
- make node and area dragging respond immediately and add styling for the new linking dialog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e98625f12c8322af4a8258ba3e3046