### PR TITLE
Improve concept map interactions

### DIFF
--- a/style.css
+++ b/style.css
@@ -6098,11 +6098,12 @@ body.map-toolbox-dragging {
 
 .map-selection {
   position: absolute;
-  border: 1px dashed var(--blue);
-  background: rgba(166, 217, 255, 0.12);
+  border: 2px solid var(--blue);
+  background: rgba(59, 130, 246, 0.18);
   pointer-events: none;
   will-change: left, top, width, height;
   box-sizing: border-box;
+  border-radius: 6px;
   z-index: 5;
 }
 


### PR DESCRIPTION
## Summary
- build the concept map view off-screen and reuse edge helpers so link updates no longer require full re-renders
- keep the link assistant open for consecutive links while refreshing hidden-link badges and in-place edge visibility
- lower drag/selection thresholds and restyle the selection box for smoother multi-node workflows

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68eec8eac5dc8322ab237d03460325c9