### PR TITLE
Improve concept map edge interactions and styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -4997,23 +4997,63 @@ button.builder-pill.builder-pill-outline {
   line-height: 1.4;
 }
 
+.map-edge-hitbox {
+  stroke: transparent;
+  fill: none;
+  pointer-events: stroke;
+  cursor: inherit;
+}
+
 .line-menu {
   position: absolute;
   background: var(--panel);
   border: 1px solid var(--border);
-  padding: 8px;
+  padding: 12px;
   border-radius: var(--radius);
   color: var(--text);
   z-index: 1000;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 8px;
+  min-width: 240px;
+  max-width: 320px;
+  box-shadow: 0 18px 44px rgba(15, 23, 42, 0.45);
 }
 .line-menu label {
   display: flex;
   flex-direction: column;
   font-size: 12px;
-  gap: 2px;
+  gap: 4px;
+}
+.line-menu select,
+.line-menu input[type="text"] {
+  width: 100%;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.35);
+  color: inherit;
+  padding: 6px 8px;
+  font-size: 13px;
+}
+.line-menu input[type="color"] {
+  width: 100%;
+  height: 32px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.35);
+  padding: 0;
+}
+.line-menu input[type="color"]::-webkit-color-swatch {
+  border: none;
+  border-radius: var(--radius-sm);
+}
+.line-menu input[type="color"]::-moz-color-swatch {
+  border: none;
+  border-radius: var(--radius-sm);
+}
+.line-menu input[type="color"]::-ms-color-swatch {
+  border: none;
+  border-radius: var(--radius-sm);
 }
 
 .line-menu-toggle {
@@ -5028,6 +5068,30 @@ button.builder-pill.builder-pill-outline {
 .line-menu-toggle input {
   width: 16px;
   height: 16px;
+}
+
+.line-menu-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.line-menu-actions .btn {
+  display: flex;
+  align-items: center;
+  flex: 1 1 0;
+  min-width: 120px;
+  justify-content: center;
+}
+
+.line-menu-footer {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 4px;
+}
+
+.line-menu-footer .btn {
+  min-width: 120px;
 }
 
 .map-wrapper {


### PR DESCRIPTION
## Summary
- add generous SVG hitboxes and dynamic marker coloring so map edges stay attached to nodes and are easier to bend and edit
- rework the line style menu to stay on screen, close predictably, and offer direction swapping while refreshing supporting styles
- streamline map rendering by fetching item sets in parallel and tightening selection radius calculations, rebuilding the bundle with the updates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ef3bb9d0e483229e513c517053efec