### PR TITLE
Fix concept map edge geometry updates during drag

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -21492,6 +21492,19 @@ var Sevenn = (() => {
     }
     return [];
   }
+  function refreshEdgesForIds(ids) {
+    if (!Array.isArray(ids) || !ids.length) {
+      return;
+    }
+    const seen = /* @__PURE__ */ new Set();
+    ids.forEach((id) => {
+      if (id == null) return;
+      const key = String(id);
+      if (seen.has(key)) return;
+      seen.add(key);
+      updateEdgesFor(id);
+    });
+  }
   function applyNodeDragFromPointer(pointer, options = {}) {
     if (!pointer) return false;
     const drag = mapState.nodeDrag;
@@ -21505,6 +21518,7 @@ var Sevenn = (() => {
     let applied = false;
     let moved = drag.moved === true;
     const startPointer = drag.startPointer || null;
+    const touchedIds = [];
     targets.forEach((target) => {
       if (!target) return;
       const { id, offset = { dx: 0, dy: 0 }, start } = target;
@@ -21512,6 +21526,7 @@ var Sevenn = (() => {
       const nx = pointer.x - offset.dx;
       const ny = pointer.y - offset.dy;
       scheduleNodePositionUpdate(id, { x: nx, y: ny }, { immediate: true });
+      touchedIds.push(id);
       if (!moved && start) {
         const dx = nx - start.x;
         const dy = ny - start.y;
@@ -21527,6 +21542,7 @@ var Sevenn = (() => {
       mapState.nodeWasDragged = true;
     }
     if (applied) {
+      refreshEdgesForIds(touchedIds);
       flushQueuedEdgeUpdates({ force: true });
     }
     return applied;
@@ -21612,11 +21628,17 @@ var Sevenn = (() => {
       const dx = x - mapState.areaDrag.start.x;
       const dy = y - mapState.areaDrag.start.y;
       mapState.areaDrag.moved = Math.abs(dx) > 0.5 || Math.abs(dy) > 0.5;
+      const touchedIds = [];
       mapState.areaDrag.origin.forEach(({ id, pos }) => {
         const nx = pos.x + dx;
         const ny = pos.y + dy;
         scheduleNodePositionUpdate(id, { x: nx, y: ny }, { immediate: true });
+        touchedIds.push(id);
       });
+      if (touchedIds.length) {
+        refreshEdgesForIds(touchedIds);
+        flushQueuedEdgeUpdates({ force: true });
+      }
       mapState.nodeWasDragged = true;
       return;
     }
@@ -25536,4 +25558,3 @@ var Sevenn = (() => {
   }
   return __toCommonJS(main_exports);
 })();
-//# sourceMappingURL=bundle.js.map

--- a/js/ui/components/map.js
+++ b/js/ui/components/map.js
@@ -3743,6 +3743,20 @@ function getNodeDragTargets() {
   return [];
 }
 
+function refreshEdgesForIds(ids) {
+  if (!Array.isArray(ids) || !ids.length) {
+    return;
+  }
+  const seen = new Set();
+  ids.forEach(id => {
+    if (id == null) return;
+    const key = String(id);
+    if (seen.has(key)) return;
+    seen.add(key);
+    updateEdgesFor(id);
+  });
+}
+
 function applyNodeDragFromPointer(pointer, options = {}) {
   if (!pointer) return false;
   const drag = mapState.nodeDrag;
@@ -3760,6 +3774,7 @@ function applyNodeDragFromPointer(pointer, options = {}) {
   let applied = false;
   let moved = drag.moved === true;
   const startPointer = drag.startPointer || null;
+  const touchedIds = [];
   targets.forEach(target => {
     if (!target) return;
     const { id, offset = { dx: 0, dy: 0 }, start } = target;
@@ -3767,6 +3782,7 @@ function applyNodeDragFromPointer(pointer, options = {}) {
     const nx = pointer.x - offset.dx;
     const ny = pointer.y - offset.dy;
     scheduleNodePositionUpdate(id, { x: nx, y: ny }, { immediate: true });
+    touchedIds.push(id);
     if (!moved && start) {
       const dx = nx - start.x;
       const dy = ny - start.y;
@@ -3782,6 +3798,7 @@ function applyNodeDragFromPointer(pointer, options = {}) {
     mapState.nodeWasDragged = true;
   }
   if (applied) {
+    refreshEdgesForIds(touchedIds);
     flushQueuedEdgeUpdates({ force: true });
   }
   return applied;
@@ -3877,11 +3894,17 @@ function handlePointerMove(e) {
     const dx = x - mapState.areaDrag.start.x;
     const dy = y - mapState.areaDrag.start.y;
     mapState.areaDrag.moved = Math.abs(dx) > 0.5 || Math.abs(dy) > 0.5;
+    const touchedIds = [];
     mapState.areaDrag.origin.forEach(({ id, pos }) => {
       const nx = pos.x + dx;
       const ny = pos.y + dy;
       scheduleNodePositionUpdate(id, { x: nx, y: ny }, { immediate: true });
+      touchedIds.push(id);
     });
+    if (touchedIds.length) {
+      refreshEdgesForIds(touchedIds);
+      flushQueuedEdgeUpdates({ force: true });
+    }
     mapState.nodeWasDragged = true;
     return;
   }

--- a/style.css
+++ b/style.css
@@ -4951,11 +4951,12 @@ button.builder-pill.builder-pill-outline {
   filter: drop-shadow(0 14px 28px rgba(37, 99, 235, 0.45));
   stroke: #ffffff;
 }
-.map-edge { 
+.map-edge {
   stroke: var(--gray);
   stroke-width: 2.8;
   cursor: inherit;
   vector-effect: non-scaling-stroke;
+  shape-rendering: geometricPrecision;
   pointer-events: stroke;
 
   fill: none;


### PR DESCRIPTION
## Summary
- refresh concept-map edge geometry continuously during node and area drags so connections stay attached while moving
- add a rendering hint for map edges to keep dynamic updates crisp and rebuild the bundle

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f7dd9aca18832298a9e671384e547b