### PR TITLE
Enhance exam editing with rich media support and CSV workflows

### DIFF
--- a/js/ui/components/exams.js
+++ b/js/ui/components/exams.js
@@ -2,13 +2,124 @@ import { listExams, upsertExam, deleteExam, listExamSessions, loadExamSession, s
 import { state, setExamSession, setExamAttemptExpanded } from '../../state.js';
 import { uid, setToggleState, deepClone } from '../../utils.js';
 import { confirmModal } from './confirm.js';
+import { createRichTextEditor, sanitizeHtml, htmlToPlainText, isEmptyHtml } from './rich-text.js';
+import { createFloatingWindow } from './window-manager.js';
 
 const DEFAULT_SECONDS = 60;
+const CSV_MAX_OPTIONS = 8;
+const CSV_HEADERS = (() => {
+  const base = ['type', 'examTitle', 'timerMode', 'secondsPerQuestion', 'stem'];
+  for (let i = 1; i <= CSV_MAX_OPTIONS; i += 1) {
+    base.push(`option${i}`);
+    base.push(`option${i}Correct`);
+  }
+  base.push('explanation', 'tags', 'media');
+  return base;
+})();
+const CSV_ROW_META = 'meta';
+const CSV_ROW_QUESTION = 'question';
+const CSV_EXPLANATION_INDEX = CSV_HEADERS.indexOf('explanation');
+const CSV_TAGS_INDEX = CSV_HEADERS.indexOf('tags');
+const CSV_MEDIA_INDEX = CSV_HEADERS.indexOf('media');
+
+function csvOptionIndex(optionNumber) {
+  return 5 + (optionNumber - 1) * 2;
+}
+
+function csvOptionCorrectIndex(optionNumber) {
+  return csvOptionIndex(optionNumber) + 1;
+}
 
 const timerHandles = new WeakMap();
 let keyHandler = null;
 let keyHandlerSession = null;
 let lastExamStatusMessage = '';
+
+function sanitizeRichText(value) {
+  const raw = value == null ? '' : String(value);
+  if (!raw) return '';
+  const looksHtml = /<([a-z][^>]*>)/i.test(raw);
+  const normalized = looksHtml ? raw : raw.replace(/\r?\n/g, '<br>');
+  const sanitized = sanitizeHtml(normalized);
+  return isEmptyHtml(sanitized) ? '' : sanitized;
+}
+
+function ensureArrayTags(tags) {
+  if (!Array.isArray(tags)) {
+    if (tags == null) return [];
+    if (typeof tags === 'string') {
+      return tags.split(/[|,]/).map(tag => tag.trim()).filter(Boolean);
+    }
+    return [];
+  }
+  return tags.map(tag => String(tag).trim()).filter(Boolean);
+}
+
+function parseTagString(tags) {
+  if (!tags) return [];
+  return String(tags).split(/[|,]/).map(tag => tag.trim()).filter(Boolean);
+}
+
+function parseBooleanFlag(value) {
+  if (value == null) return false;
+  const str = String(value).trim().toLowerCase();
+  return ['true', '1', 'yes', 'y', 'correct'].includes(str);
+}
+
+function csvEscape(value) {
+  const str = value == null ? '' : String(value);
+  if (!str) return '';
+  if (/["]/.test(str) || /[\n\r,]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+function downloadBlob(blob, filename) {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+function scorePercentage(result) {
+  if (!result || !Number.isFinite(result.correct) || !Number.isFinite(result.total) || result.total <= 0) {
+    return null;
+  }
+  return Math.round((result.correct / result.total) * 100);
+}
+
+function scoreBadgeClass(pct) {
+  if (!Number.isFinite(pct)) return 'neutral';
+  if (pct >= 85) return 'good';
+  if (pct >= 70) return 'warn';
+  return 'bad';
+}
+
+function createScoreBadge(result, label) {
+  const pct = scorePercentage(result);
+  const badge = document.createElement('span');
+  badge.className = ['exam-score-badge', `exam-score-badge--${scoreBadgeClass(pct)}`].join(' ');
+  if (label) {
+    const labelEl = document.createElement('span');
+    labelEl.className = 'exam-score-badge-label';
+    labelEl.textContent = label;
+    badge.appendChild(labelEl);
+  }
+  const value = document.createElement('span');
+  value.className = 'exam-score-badge-value';
+  if (pct == null) {
+    value.textContent = '—';
+  } else {
+    value.textContent = `${pct}%`;
+  }
+  badge.appendChild(value);
+  return badge;
+}
 
 function setTimerElement(sess, element) {
   if (!sess) return;
@@ -463,6 +574,191 @@ function triggerExamDownload(exam) {
 }
 
 
+function examToCsv(exam) {
+  const rows = [];
+  rows.push(CSV_HEADERS);
+
+  const metaRow = new Array(CSV_HEADERS.length).fill('');
+  metaRow[0] = CSV_ROW_META;
+  metaRow[1] = exam.examTitle || '';
+  metaRow[2] = exam.timerMode === 'timed' ? 'timed' : 'untimed';
+  metaRow[3] = Number.isFinite(exam.secondsPerQuestion) ? String(exam.secondsPerQuestion) : String(DEFAULT_SECONDS);
+  rows.push(metaRow);
+
+  (exam.questions || []).forEach(question => {
+    const row = new Array(CSV_HEADERS.length).fill('');
+    row[0] = CSV_ROW_QUESTION;
+    row[4] = question.stem || '';
+    const options = Array.isArray(question.options) ? question.options : [];
+    options.slice(0, CSV_MAX_OPTIONS).forEach((opt, idx) => {
+      const optionCol = csvOptionIndex(idx + 1);
+      const correctCol = csvOptionCorrectIndex(idx + 1);
+      row[optionCol] = opt.text || '';
+      row[correctCol] = opt.id === question.answer ? 'TRUE' : '';
+    });
+    if (CSV_EXPLANATION_INDEX >= 0) row[CSV_EXPLANATION_INDEX] = question.explanation || '';
+    if (CSV_TAGS_INDEX >= 0) row[CSV_TAGS_INDEX] = Array.isArray(question.tags) ? question.tags.join(' | ') : '';
+    if (CSV_MEDIA_INDEX >= 0) row[CSV_MEDIA_INDEX] = question.media || '';
+    rows.push(row);
+  });
+
+  return rows.map(row => row.map(csvEscape).join(',')).join('\r\n');
+}
+
+function downloadExamCsv(exam) {
+  const csv = examToCsv(exam);
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  downloadBlob(blob, `${slugify(exam.examTitle || 'exam')}.csv`);
+}
+
+function downloadExamCsvTemplate() {
+  const sampleQuestion = createBlankQuestion();
+  sampleQuestion.stem = sanitizeRichText('What is the capital of France?');
+  sampleQuestion.options = [
+    { id: uid(), text: sanitizeRichText('Paris') },
+    { id: uid(), text: sanitizeRichText('London') },
+    { id: uid(), text: sanitizeRichText('Rome') }
+  ];
+  sampleQuestion.answer = sampleQuestion.options[0]?.id || '';
+  sampleQuestion.explanation = sanitizeRichText('Paris is the capital and most populous city of France.');
+  sampleQuestion.tags = ['geography'];
+
+  const { exam } = ensureExamShape({
+    examTitle: 'Example Exam',
+    timerMode: 'untimed',
+    secondsPerQuestion: DEFAULT_SECONDS,
+    questions: [sampleQuestion],
+    results: []
+  });
+
+  const csv = examToCsv(exam);
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  downloadBlob(blob, 'exam-template.csv');
+}
+
+function parseCsv(text) {
+  const rows = [];
+  let current = '';
+  let row = [];
+  let inQuotes = false;
+
+  for (let i = 0; i < text.length; i += 1) {
+    const char = text[i];
+    if (inQuotes) {
+      if (char === '"') {
+        if (text[i + 1] === '"') {
+          current += '"';
+          i += 1;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        current += char;
+      }
+    } else if (char === '"') {
+      inQuotes = true;
+    } else if (char === ',') {
+      row.push(current);
+      current = '';
+    } else if (char === '\r') {
+      row.push(current);
+      rows.push(row);
+      row = [];
+      current = '';
+      if (text[i + 1] === '\n') i += 1;
+    } else if (char === '\n') {
+      row.push(current);
+      rows.push(row);
+      row = [];
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  row.push(current);
+  if (row.length > 1 || row[0].trim()) {
+    rows.push(row);
+  }
+
+  return rows.filter(r => !(r.length === 1 && r[0].trim() === ''));
+}
+
+function examFromCsv(text) {
+  const rows = parseCsv(text);
+  if (!rows.length) {
+    throw new Error('Empty CSV');
+  }
+  const header = rows[0].map(col => col.trim());
+  const indexMap = new Map();
+  header.forEach((name, idx) => {
+    if (!name) return;
+    indexMap.set(name, idx);
+  });
+
+  const getCell = (row, key) => {
+    const idx = indexMap.has(key) ? indexMap.get(key) : -1;
+    if (idx == null || idx < 0) return '';
+    return row[idx] ?? '';
+  };
+
+  const base = {
+    examTitle: 'Imported Exam',
+    timerMode: 'untimed',
+    secondsPerQuestion: DEFAULT_SECONDS,
+    questions: [],
+    results: []
+  };
+
+  rows.slice(1).forEach(row => {
+    const type = String(getCell(row, 'type') || '').trim().toLowerCase();
+    if (!type) return;
+    if (type === CSV_ROW_META) {
+      const title = String(getCell(row, 'examTitle') || '').trim();
+      if (title) base.examTitle = title;
+      const mode = String(getCell(row, 'timerMode') || '').trim().toLowerCase();
+      if (mode === 'timed' || mode === 'untimed') base.timerMode = mode;
+      const seconds = Number(getCell(row, 'secondsPerQuestion'));
+      if (Number.isFinite(seconds) && seconds > 0) base.secondsPerQuestion = seconds;
+      return;
+    }
+    if (type !== CSV_ROW_QUESTION) return;
+
+    const question = createBlankQuestion();
+    question.stem = sanitizeRichText(getCell(row, 'stem'));
+    question.explanation = sanitizeRichText(getCell(row, 'explanation'));
+    question.tags = parseTagString(getCell(row, 'tags'));
+    question.media = String(getCell(row, 'media') || '').trim();
+    question.options = [];
+    question.answer = '';
+
+    for (let i = 1; i <= CSV_MAX_OPTIONS; i += 1) {
+      const optionHtml = sanitizeRichText(getCell(row, `option${i}`));
+      if (!optionHtml) continue;
+      const option = { id: uid(), text: optionHtml };
+      question.options.push(option);
+      if (!question.answer && parseBooleanFlag(getCell(row, `option${i}Correct`))) {
+        question.answer = option.id;
+      }
+    }
+
+    if (question.options.length < 2) {
+      return;
+    }
+    if (!question.answer) {
+      question.answer = question.options[0].id;
+    }
+    base.questions.push(question);
+  });
+
+  if (!base.questions.length) {
+    throw new Error('No questions found in CSV');
+  }
+
+  return ensureExamShape(base).exam;
+}
+
+
 function ensureExamShape(exam) {
   const next = clone(exam) || {};
   let changed = false;
@@ -484,7 +780,9 @@ function ensureExamShape(exam) {
   next.questions = next.questions.map(q => {
     const question = { ...q };
     if (!question.id) { question.id = uid(); changed = true; }
-    question.stem = question.stem ? String(question.stem) : '';
+    const originalStem = question.stem;
+    question.stem = sanitizeRichText(question.stem);
+    if (originalStem !== question.stem) changed = true;
     if (!Array.isArray(question.options)) {
       question.options = [];
       changed = true;
@@ -492,20 +790,25 @@ function ensureExamShape(exam) {
     question.options = question.options.map(opt => {
       const option = { ...opt };
       if (!option.id) { option.id = uid(); changed = true; }
-      option.text = option.text ? String(option.text) : '';
+      const originalText = option.text;
+      option.text = sanitizeRichText(option.text);
+      if (originalText !== option.text) changed = true;
       return option;
     });
     if (!question.answer || !question.options.some(opt => opt.id === question.answer)) {
       question.answer = question.options[0]?.id || '';
       changed = true;
     }
-    if (question.explanation == null) { question.explanation = ''; changed = true; }
-    if (!Array.isArray(question.tags)) {
-      if (question.tags == null) question.tags = [];
-      else question.tags = Array.isArray(question.tags) ? question.tags : [String(question.tags)];
+    const originalExplanation = question.explanation;
+    question.explanation = sanitizeRichText(question.explanation);
+    if (originalExplanation !== question.explanation) changed = true;
+    const normalizedTags = ensureArrayTags(question.tags);
+    if (question.tags?.length !== normalizedTags.length || question.tags?.some((t, idx) => t !== normalizedTags[idx])) {
+      question.tags = normalizedTags;
       changed = true;
+    } else {
+      question.tags = normalizedTags;
     }
-    question.tags = question.tags.map(t => String(t)).filter(Boolean);
     if (question.media == null) { question.media = ''; changed = true; }
     return question;
   });
@@ -617,20 +920,30 @@ export async function renderExams(root, render) {
 
   const fileInput = document.createElement('input');
   fileInput.type = 'file';
-  fileInput.accept = 'application/json';
+  fileInput.accept = '.json,.csv,application/json,text/csv';
   fileInput.style.display = 'none';
   fileInput.addEventListener('change', async e => {
     const file = e.target.files?.[0];
     if (!file) return;
     try {
-      const text = await file.text();
-      const parsed = JSON.parse(text);
-      const { exam } = ensureExamShape(parsed);
-      await upsertExam({ ...exam, updatedAt: Date.now() });
-      render();
+      const name = (file.name || '').toLowerCase();
+      if (name.endsWith('.csv') || (file.type || '').includes('csv')) {
+        const text = await file.text();
+        const imported = examFromCsv(text);
+        await upsertExam({ ...imported, updatedAt: Date.now() });
+        lastExamStatusMessage = `Imported "${imported.examTitle}" from CSV.`;
+        render();
+      } else {
+        const text = await file.text();
+        const parsed = JSON.parse(text);
+        const { exam } = ensureExamShape(parsed);
+        await upsertExam({ ...exam, updatedAt: Date.now() });
+        lastExamStatusMessage = `Imported "${exam.examTitle}" from JSON.`;
+        render();
+      }
     } catch (err) {
       console.warn('Failed to import exam', err);
-      status.textContent = 'Unable to import exam — invalid JSON structure.';
+      status.textContent = 'Unable to import exam — check the file format.';
     } finally {
       fileInput.value = '';
     }
@@ -639,9 +952,24 @@ export async function renderExams(root, render) {
   const importBtn = document.createElement('button');
   importBtn.type = 'button';
   importBtn.className = 'btn secondary';
-  importBtn.textContent = 'Import Exam';
+  importBtn.textContent = 'Import JSON/CSV';
   importBtn.addEventListener('click', () => fileInput.click());
   actions.appendChild(importBtn);
+
+  const templateBtn = document.createElement('button');
+  templateBtn.type = 'button';
+  templateBtn.className = 'btn secondary';
+  templateBtn.textContent = 'CSV Template';
+  templateBtn.addEventListener('click', () => {
+    try {
+      downloadExamCsvTemplate();
+      status.textContent = 'CSV template downloaded.';
+    } catch (err) {
+      console.warn('Failed to create CSV template', err);
+      status.textContent = 'Unable to download template.';
+    }
+  });
+  actions.appendChild(templateBtn);
 
   const newBtn = document.createElement('button');
   newBtn.type = 'button';
@@ -688,7 +1016,7 @@ export async function renderExams(root, render) {
   if (!exams.length) {
     const empty = document.createElement('div');
     empty.className = 'exam-empty';
-    empty.innerHTML = '<p>No exams yet. Import a JSON exam or create one from scratch.</p>';
+    empty.innerHTML = '<p>No exams yet. Import a JSON or CSV exam, download the template, or create one from scratch.</p>';
     root.appendChild(empty);
     return;
   }
@@ -702,61 +1030,100 @@ export async function renderExams(root, render) {
 }
 
 function buildExamCard(exam, render, savedSession, statusEl) {
+  const expandedState = state.examAttemptExpanded[exam.id];
+  const isExpanded = expandedState != null ? expandedState : false;
+  const last = latestResult(exam);
+  const best = bestResult(exam);
+
   const card = document.createElement('article');
   card.className = 'card exam-card';
+  card.classList.toggle('expanded', isExpanded);
+
+  const header = document.createElement('div');
+  header.className = 'exam-card-header';
+  card.appendChild(header);
+
+  const summaryButton = document.createElement('button');
+  summaryButton.type = 'button';
+  summaryButton.className = 'exam-card-summary';
+  summaryButton.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+  summaryButton.addEventListener('click', () => {
+    setExamAttemptExpanded(exam.id, !isExpanded);
+    render();
+  });
+  header.appendChild(summaryButton);
+
+  const titleGroup = document.createElement('div');
+  titleGroup.className = 'exam-card-title-group';
+  summaryButton.appendChild(titleGroup);
 
   const title = document.createElement('h2');
   title.className = 'exam-card-title';
   title.textContent = exam.examTitle;
-  card.appendChild(title);
+  titleGroup.appendChild(title);
 
   const meta = document.createElement('div');
   meta.className = 'exam-card-meta';
   const questionCount = document.createElement('span');
   questionCount.textContent = `${exam.questions.length} question${exam.questions.length === 1 ? '' : 's'}`;
   meta.appendChild(questionCount);
-  if (exam.timerMode === 'timed') {
-    const timed = document.createElement('span');
-    timed.textContent = `Timed • ${exam.secondsPerQuestion}s/question`;
-    meta.appendChild(timed);
-  } else {
-    const timed = document.createElement('span');
-    timed.textContent = 'Untimed';
-    meta.appendChild(timed);
-  }
-  card.appendChild(meta);
+  const timerInfo = document.createElement('span');
+  timerInfo.textContent = exam.timerMode === 'timed'
+    ? `Timed • ${exam.secondsPerQuestion}s/question`
+    : 'Untimed';
+  meta.appendChild(timerInfo);
+  titleGroup.appendChild(meta);
 
-  const stats = document.createElement('div');
-  stats.className = 'exam-card-stats';
-  stats.appendChild(createStat('Attempts', String(exam.results.length)));
-  const last = latestResult(exam);
+  const glance = document.createElement('div');
+  glance.className = 'exam-card-glance';
+  summaryButton.appendChild(glance);
+
+  const attemptsChip = document.createElement('span');
+  attemptsChip.className = 'exam-chip';
+  attemptsChip.textContent = `${exam.results.length} attempt${exam.results.length === 1 ? '' : 's'}`;
+  glance.appendChild(attemptsChip);
+
+  if (best) {
+    const badge = createScoreBadge(best, 'Best');
+    badge.title = formatScore(best);
+    glance.appendChild(badge);
+  }
+  if (last && (!best || last.id !== best.id)) {
+    const badge = createScoreBadge(last, 'Last');
+    badge.title = formatScore(last);
+    glance.appendChild(badge);
+  }
   if (last) {
-    stats.appendChild(createStat('Last Score', formatScore(last)));
-    const best = bestResult(exam);
-    if (best) stats.appendChild(createStat('Best Score', formatScore(best)));
-  } else {
-    stats.appendChild(createStat('Last Score', '—'));
-    stats.appendChild(createStat('Best Score', '—'));
+    const lastChip = document.createElement('span');
+    lastChip.className = 'exam-chip exam-chip--ghost';
+    const date = new Date(last.when);
+    lastChip.textContent = `Last • ${date.toLocaleDateString()}`;
+    glance.appendChild(lastChip);
   }
-  card.appendChild(stats);
-
   if (savedSession) {
-    const banner = document.createElement('div');
-    banner.className = 'exam-saved-banner';
-    const updated = savedSession.updatedAt ? new Date(savedSession.updatedAt).toLocaleString() : null;
-    banner.textContent = updated ? `Saved attempt • ${updated}` : 'Saved attempt available';
-    card.appendChild(banner);
+    const progressChip = document.createElement('span');
+    progressChip.className = 'exam-chip exam-chip--progress';
+    progressChip.textContent = 'In progress';
+    glance.appendChild(progressChip);
   }
 
-  const actions = document.createElement('div');
-  actions.className = 'exam-card-actions';
+  const chevron = document.createElement('span');
+  chevron.className = 'exam-card-toggle-icon';
+  chevron.setAttribute('aria-hidden', 'true');
+  summaryButton.appendChild(chevron);
+
+  const quickAction = document.createElement('div');
+  quickAction.className = 'exam-card-quick-action';
+  header.appendChild(quickAction);
+
+  const quickBtn = document.createElement('button');
+  quickBtn.className = 'btn exam-card-primary';
+  quickBtn.disabled = exam.questions.length === 0;
+  quickAction.appendChild(quickBtn);
 
   if (savedSession) {
-    const resumeBtn = document.createElement('button');
-    resumeBtn.className = 'btn';
-    resumeBtn.textContent = 'Resume Attempt';
-    resumeBtn.disabled = exam.questions.length === 0;
-    resumeBtn.addEventListener('click', async () => {
+    quickBtn.textContent = 'Resume';
+    quickBtn.addEventListener('click', async () => {
       const latest = await loadExamSession(exam.id);
       if (!latest) {
         if (statusEl) statusEl.textContent = 'Saved attempt could not be found.';
@@ -767,23 +1134,54 @@ function buildExamCard(exam, render, savedSession, statusEl) {
       setExamSession(session);
       render();
     });
-    actions.appendChild(resumeBtn);
+  } else {
+    quickBtn.textContent = 'Start';
+    quickBtn.addEventListener('click', () => {
+      setExamSession(createTakingSession(exam));
+      render();
+    });
   }
 
-  const startBtn = document.createElement('button');
-  startBtn.className = savedSession ? 'btn secondary' : 'btn';
-  startBtn.textContent = savedSession ? 'Start Fresh' : 'Start Exam';
-  startBtn.disabled = exam.questions.length === 0;
-  startBtn.addEventListener('click', async () => {
-    if (savedSession) {
+  const details = document.createElement('div');
+  details.className = 'exam-card-details';
+  if (!isExpanded) {
+    details.setAttribute('hidden', 'true');
+  }
+  card.appendChild(details);
+
+  const stats = document.createElement('div');
+  stats.className = 'exam-card-stats';
+  stats.appendChild(createStat('Attempts', String(exam.results.length)));
+  stats.appendChild(createStat('Best Score', best ? formatScore(best) : '—'));
+  stats.appendChild(createStat('Last Score', last ? formatScore(last) : '—'));
+  details.appendChild(stats);
+
+  if (savedSession) {
+    const banner = document.createElement('div');
+    banner.className = 'exam-saved-banner';
+    const updated = savedSession.updatedAt ? new Date(savedSession.updatedAt).toLocaleString() : null;
+    banner.textContent = updated ? `Saved attempt • ${updated}` : 'Saved attempt available';
+    details.appendChild(banner);
+  }
+
+  const actions = document.createElement('div');
+  actions.className = 'exam-card-actions';
+  details.appendChild(actions);
+
+  if (savedSession) {
+    const startFresh = document.createElement('button');
+    startFresh.className = 'btn secondary';
+    startFresh.textContent = 'Start Fresh';
+    startFresh.disabled = exam.questions.length === 0;
+    startFresh.addEventListener('click', async () => {
       const confirm = await confirmModal('Start a new attempt and discard saved progress?');
       if (!confirm) return;
       await deleteExamSessionProgress(exam.id);
-    }
-    setExamSession(createTakingSession(exam));
-    render();
-  });
-  actions.appendChild(startBtn);
+      setExamSession(createTakingSession(exam));
+      render();
+    });
+    actions.appendChild(startFresh);
+  }
 
   if (last) {
     const reviewBtn = document.createElement('button');
@@ -798,22 +1196,36 @@ function buildExamCard(exam, render, savedSession, statusEl) {
 
   const editBtn = document.createElement('button');
   editBtn.className = 'btn secondary';
-  editBtn.textContent = 'Edit';
+  editBtn.textContent = 'Edit Exam';
   editBtn.addEventListener('click', () => openExamEditor(exam, render));
   actions.appendChild(editBtn);
 
-  const exportBtn = document.createElement('button');
-  exportBtn.className = 'btn secondary';
-  exportBtn.textContent = 'Export';
-  exportBtn.addEventListener('click', () => {
+  const exportJsonBtn = document.createElement('button');
+  exportJsonBtn.className = 'btn secondary';
+  exportJsonBtn.textContent = 'Export JSON';
+  exportJsonBtn.addEventListener('click', () => {
     const ok = triggerExamDownload(exam);
     if (!ok && statusEl) {
       statusEl.textContent = 'Unable to export exam.';
     } else if (ok && statusEl) {
-      statusEl.textContent = 'Exam exported.';
+      statusEl.textContent = 'Exam exported as JSON.';
     }
   });
-  actions.appendChild(exportBtn);
+  actions.appendChild(exportJsonBtn);
+
+  const exportCsvBtn = document.createElement('button');
+  exportCsvBtn.className = 'btn secondary';
+  exportCsvBtn.textContent = 'Export CSV';
+  exportCsvBtn.addEventListener('click', () => {
+    try {
+      downloadExamCsv(exam);
+      if (statusEl) statusEl.textContent = 'Exam exported as CSV.';
+    } catch (err) {
+      console.warn('Failed to export exam CSV', err);
+      if (statusEl) statusEl.textContent = 'Unable to export exam CSV.';
+    }
+  });
+  actions.appendChild(exportCsvBtn);
 
   const delBtn = document.createElement('button');
   delBtn.className = 'btn danger';
@@ -827,32 +1239,11 @@ function buildExamCard(exam, render, savedSession, statusEl) {
   });
   actions.appendChild(delBtn);
 
-  card.appendChild(actions);
-
   const attemptsWrap = document.createElement('div');
   attemptsWrap.className = 'exam-attempts';
-  const attemptsHeader = document.createElement('div');
-  attemptsHeader.className = 'exam-attempts-header';
   const attemptsTitle = document.createElement('h3');
   attemptsTitle.textContent = 'Attempts';
-  attemptsHeader.appendChild(attemptsTitle);
-
-  const expandedState = state.examAttemptExpanded[exam.id];
-  const isExpanded = expandedState != null ? expandedState : true;
-  if (exam.results.length) {
-    const toggle = document.createElement('button');
-    toggle.type = 'button';
-    toggle.className = 'exam-attempt-toggle';
-    toggle.textContent = isExpanded ? 'Hide Attempts' : 'Show Attempts';
-    toggle.addEventListener('click', () => {
-      setExamAttemptExpanded(exam.id, !isExpanded);
-      render();
-    });
-    attemptsHeader.appendChild(toggle);
-  }
-
-  attemptsWrap.appendChild(attemptsHeader);
-  attemptsWrap.classList.toggle('collapsed', !isExpanded && exam.results.length > 0);
+  attemptsWrap.appendChild(attemptsTitle);
 
   if (!exam.results.length) {
     const none = document.createElement('p');
@@ -870,7 +1261,7 @@ function buildExamCard(exam, render, savedSession, statusEl) {
     attemptsWrap.appendChild(list);
   }
 
-  card.appendChild(attemptsWrap);
+  details.appendChild(attemptsWrap);
   return card;
 }
 
@@ -880,22 +1271,29 @@ function buildAttemptRow(exam, result, render) {
 
   const info = document.createElement('div');
   info.className = 'exam-attempt-info';
+  const badge = createScoreBadge(result);
+  badge.classList.add('exam-attempt-score');
+  badge.title = formatScore(result);
+  info.appendChild(badge);
 
-  const title = document.createElement('div');
-  title.className = 'exam-attempt-score';
-  title.textContent = formatScore(result);
-  info.appendChild(title);
+  const date = document.createElement('div');
+  date.className = 'exam-attempt-date';
+  date.textContent = new Date(result.when).toLocaleString();
+  info.appendChild(date);
 
   const meta = document.createElement('div');
   meta.className = 'exam-attempt-meta';
-  const date = new Date(result.when).toLocaleString();
   const answeredText = `${result.answered}/${result.total} answered`;
   const flaggedText = `${result.flagged.length} flagged`;
   const durationText = result.durationMs ? formatDuration(result.durationMs) : '—';
-  meta.textContent = `${date} • ${answeredText} • ${flaggedText} • ${durationText}`;
+  meta.textContent = `${answeredText} • ${flaggedText} • ${durationText}`;
   info.appendChild(meta);
 
   row.appendChild(info);
+
+  const actions = document.createElement('div');
+  actions.className = 'exam-attempt-actions';
+  row.appendChild(actions);
 
   const review = document.createElement('button');
   review.className = 'btn secondary';
@@ -904,7 +1302,7 @@ function buildAttemptRow(exam, result, render) {
     setExamSession({ mode: 'review', exam: clone(exam), result: clone(result), idx: 0 });
     render();
   });
-  row.appendChild(review);
+  actions.appendChild(review);
 
   return row;
 }
@@ -957,7 +1355,8 @@ function formatDuration(ms) {
 }
 
 function optionText(question, id) {
-  return question.options.find(opt => opt.id === id)?.text || '';
+  const html = question.options.find(opt => opt.id === id)?.text || '';
+  return htmlToPlainText(html).trim();
 }
 
 function mediaElement(source) {
@@ -1241,7 +1640,8 @@ export function renderExamRunner(root, render) {
 
   const stem = document.createElement('div');
   stem.className = 'exam-stem';
-  stem.textContent = question.stem || '(No prompt)';
+  const stemHtml = question.stem && !isEmptyHtml(question.stem) ? question.stem : '';
+  stem.innerHTML = stemHtml || '<p class="exam-stem-empty">(No prompt)</p>';
   main.appendChild(stem);
 
   const media = mediaElement(question.media);
@@ -1280,7 +1680,7 @@ export function renderExamRunner(root, render) {
 
     const label = document.createElement('span');
     label.className = 'option-text';
-    label.textContent = opt.text || '(Empty option)';
+    label.innerHTML = opt.text || '<span class="exam-option-empty">(Empty option)</span>';
     choice.appendChild(label);
     const isSelected = selected === opt.id;
     if (sess.mode === 'taking') {
@@ -1404,13 +1804,14 @@ export function renderExamRunner(root, render) {
       }
     }
 
-    if (question.explanation) {
+    if (question.explanation && !isEmptyHtml(question.explanation)) {
       const explain = document.createElement('div');
       explain.className = 'exam-explanation';
       const title = document.createElement('h3');
       title.textContent = 'Explanation';
-      const body = document.createElement('p');
-      body.textContent = question.explanation;
+      const body = document.createElement('div');
+      body.className = 'exam-explanation-body';
+      body.innerHTML = question.explanation;
       explain.appendChild(title);
       explain.appendChild(body);
       main.appendChild(explain);
@@ -1727,26 +2128,6 @@ function renderSummary(root, render, sess) {
 }
 
 function openExamEditor(existing, render) {
-  const overlay = document.createElement('div');
-  overlay.className = 'modal';
-
-  const form = document.createElement('form');
-  form.className = 'card modal-form exam-editor';
-
-  let dirty = false;
-  const markDirty = () => { dirty = true; };
-
-  const closeBtn = document.createElement('button');
-  closeBtn.type = 'button';
-  closeBtn.className = 'modal-close';
-  closeBtn.setAttribute('aria-label', 'Close exam editor');
-  closeBtn.innerHTML = '&times;';
-  form.appendChild(closeBtn);
-
-  const removeOverlay = () => {
-    if (overlay.parentNode) document.body.removeChild(overlay);
-  };
-
   const { exam } = ensureExamShape(existing || {
     id: uid(),
     examTitle: 'New Exam',
@@ -1756,28 +2137,59 @@ function openExamEditor(existing, render) {
     results: []
   });
 
-  const heading = document.createElement('h2');
-  heading.textContent = existing ? 'Edit Exam' : 'Create Exam';
-  form.appendChild(heading);
+  let dirty = false;
+  const markDirty = () => { dirty = true; };
+
+  const floating = createFloatingWindow({
+    title: existing ? 'Edit Exam' : 'Create Exam',
+    width: 980,
+    onBeforeClose: async (reason) => {
+      if (reason === 'saved') return true;
+      if (!dirty) return true;
+      const choice = await promptSaveChoice();
+      if (choice === 'cancel') return false;
+      if (choice === 'discard') return true;
+      if (choice === 'save') {
+        const ok = await persistExam();
+        if (ok) {
+          dirty = false;
+          render();
+        }
+        return ok;
+      }
+      return false;
+    }
+  });
+
+  const form = document.createElement('form');
+  form.className = 'exam-editor';
+  floating.body.appendChild(form);
 
   const error = document.createElement('div');
   error.className = 'exam-error';
   form.appendChild(error);
 
-  const titleLabel = document.createElement('label');
+  const titleField = document.createElement('label');
+  titleField.className = 'exam-field';
+  const titleLabel = document.createElement('span');
+  titleLabel.className = 'exam-field-label';
   titleLabel.textContent = 'Title';
   const titleInput = document.createElement('input');
   titleInput.className = 'input';
   titleInput.value = exam.examTitle;
   titleInput.addEventListener('input', () => { exam.examTitle = titleInput.value; markDirty(); });
-  titleLabel.appendChild(titleInput);
-  form.appendChild(titleLabel);
+  titleField.append(titleLabel, titleInput);
+  form.appendChild(titleField);
 
   const timerRow = document.createElement('div');
   timerRow.className = 'exam-timer-row';
+  form.appendChild(timerRow);
 
-  const modeLabel = document.createElement('label');
-  modeLabel.textContent = 'Timer Mode';
+  const modeField = document.createElement('label');
+  modeField.className = 'exam-field';
+  const modeSpan = document.createElement('span');
+  modeSpan.className = 'exam-field-label';
+  modeSpan.textContent = 'Timer Mode';
   const modeSelect = document.createElement('select');
   modeSelect.className = 'input';
   ['untimed', 'timed'].forEach(mode => {
@@ -1789,14 +2201,17 @@ function openExamEditor(existing, render) {
   modeSelect.value = exam.timerMode;
   modeSelect.addEventListener('change', () => {
     exam.timerMode = modeSelect.value;
-    secondsLabel.style.display = exam.timerMode === 'timed' ? 'flex' : 'none';
+    secondsField.classList.toggle('is-hidden', exam.timerMode !== 'timed');
     markDirty();
   });
-  modeLabel.appendChild(modeSelect);
-  timerRow.appendChild(modeLabel);
+  modeField.append(modeSpan, modeSelect);
+  timerRow.appendChild(modeField);
 
-  const secondsLabel = document.createElement('label');
-  secondsLabel.textContent = 'Seconds per question';
+  const secondsField = document.createElement('label');
+  secondsField.className = 'exam-field';
+  const secondsSpan = document.createElement('span');
+  secondsSpan.className = 'exam-field-label';
+  secondsSpan.textContent = 'Seconds per question';
   const secondsInput = document.createElement('input');
   secondsInput.type = 'number';
   secondsInput.min = '10';
@@ -1809,15 +2224,9 @@ function openExamEditor(existing, render) {
       markDirty();
     }
   });
-  secondsLabel.appendChild(secondsInput);
-  secondsLabel.style.display = exam.timerMode === 'timed' ? 'flex' : 'none';
-  timerRow.appendChild(secondsLabel);
-
-  form.appendChild(timerRow);
-
-  const questionSection = document.createElement('div');
-  questionSection.className = 'exam-question-section';
-  form.appendChild(questionSection);
+  secondsField.append(secondsSpan, secondsInput);
+  if (exam.timerMode !== 'timed') secondsField.classList.add('is-hidden');
+  timerRow.appendChild(secondsField);
 
   const questionsHeader = document.createElement('div');
   questionsHeader.className = 'exam-question-header';
@@ -1832,9 +2241,12 @@ function openExamEditor(existing, render) {
     markDirty();
     renderQuestions();
   });
-  questionsHeader.appendChild(qTitle);
-  questionsHeader.appendChild(addQuestion);
+  questionsHeader.append(qTitle, addQuestion);
   form.appendChild(questionsHeader);
+
+  const questionSection = document.createElement('div');
+  questionSection.className = 'exam-question-section';
+  form.appendChild(questionSection);
 
   function renderQuestions() {
     questionSection.innerHTML = '';
@@ -1850,13 +2262,12 @@ function openExamEditor(existing, render) {
       const card = document.createElement('div');
       card.className = 'exam-question-editor';
 
-      question.tags = Array.isArray(question.tags) ? question.tags : [];
-      if (!Array.isArray(question.options)) question.options = [];
-
       const header = document.createElement('div');
       header.className = 'exam-question-editor-header';
-      const title = document.createElement('h4');
-      title.textContent = `Question ${idx + 1}`;
+      const label = document.createElement('h4');
+      label.textContent = `Question ${idx + 1}`;
+      header.appendChild(label);
+
       const remove = document.createElement('button');
       remove.type = 'button';
       remove.className = 'ghost-btn';
@@ -1866,27 +2277,44 @@ function openExamEditor(existing, render) {
         markDirty();
         renderQuestions();
       });
-      header.appendChild(title);
       header.appendChild(remove);
       card.appendChild(header);
 
-      const stemLabel = document.createElement('label');
+      const stemField = document.createElement('div');
+      stemField.className = 'exam-field exam-field--rich';
+      const stemLabel = document.createElement('span');
+      stemLabel.className = 'exam-field-label';
       stemLabel.textContent = 'Prompt';
-      const stemInput = document.createElement('textarea');
-      stemInput.className = 'input';
-      stemInput.value = question.stem;
-      stemInput.addEventListener('input', () => { question.stem = stemInput.value; markDirty(); });
-      stemLabel.appendChild(stemInput);
-      card.appendChild(stemLabel);
+      stemField.appendChild(stemLabel);
+      const stemEditor = createRichTextEditor({
+        value: question.stem,
+        ariaLabel: `Question ${idx + 1} prompt`,
+        onChange: () => {
+          question.stem = stemEditor.getValue();
+          markDirty();
+        }
+      });
+      stemEditor.element.classList.add('exam-rich-input');
+      stemField.appendChild(stemEditor.element);
+      card.appendChild(stemField);
 
-      const mediaLabel = document.createElement('label');
+      const mediaField = document.createElement('div');
+      mediaField.className = 'exam-field exam-field--media';
+      const mediaLabel = document.createElement('span');
+      mediaLabel.className = 'exam-field-label';
       mediaLabel.textContent = 'Media (URL or upload)';
+      mediaField.appendChild(mediaLabel);
+
       const mediaInput = document.createElement('input');
       mediaInput.className = 'input';
       mediaInput.placeholder = 'https://example.com/image.png';
       mediaInput.value = question.media || '';
-      mediaInput.addEventListener('input', () => { question.media = mediaInput.value.trim(); updatePreview(); markDirty(); });
-      mediaLabel.appendChild(mediaInput);
+      mediaInput.addEventListener('input', () => {
+        question.media = mediaInput.value.trim();
+        updatePreview();
+        markDirty();
+      });
+      mediaField.appendChild(mediaInput);
 
       const mediaUpload = document.createElement('input');
       mediaUpload.type = 'file';
@@ -1904,7 +2332,7 @@ function openExamEditor(existing, render) {
         };
         reader.readAsDataURL(file);
       });
-      mediaLabel.appendChild(mediaUpload);
+      mediaField.appendChild(mediaUpload);
 
       const clearMedia = document.createElement('button');
       clearMedia.type = 'button';
@@ -1917,8 +2345,9 @@ function openExamEditor(existing, render) {
         updatePreview();
         markDirty();
       });
-      mediaLabel.appendChild(clearMedia);
-      card.appendChild(mediaLabel);
+      mediaField.appendChild(clearMedia);
+
+      card.appendChild(mediaField);
 
       const preview = document.createElement('div');
       preview.className = 'exam-media-preview';
@@ -1930,26 +2359,38 @@ function openExamEditor(existing, render) {
       updatePreview();
       card.appendChild(preview);
 
-      const tagsLabel = document.createElement('label');
-      tagsLabel.textContent = 'Tags (comma separated)';
+      const tagsField = document.createElement('label');
+      tagsField.className = 'exam-field';
+      const tagsLabel = document.createElement('span');
+      tagsLabel.className = 'exam-field-label';
+      tagsLabel.textContent = 'Tags (comma or | separated)';
       const tagsInput = document.createElement('input');
       tagsInput.className = 'input';
       tagsInput.value = question.tags.join(', ');
       tagsInput.addEventListener('input', () => {
-        question.tags = tagsInput.value.split(',').map(t => t.trim()).filter(Boolean);
+        question.tags = parseTagString(tagsInput.value);
         markDirty();
       });
-      tagsLabel.appendChild(tagsInput);
-      card.appendChild(tagsLabel);
+      tagsField.append(tagsLabel, tagsInput);
+      card.appendChild(tagsField);
 
-      const explanationLabel = document.createElement('label');
+      const explanationField = document.createElement('div');
+      explanationField.className = 'exam-field exam-field--rich';
+      const explanationLabel = document.createElement('span');
+      explanationLabel.className = 'exam-field-label';
       explanationLabel.textContent = 'Explanation';
-      const explanationInput = document.createElement('textarea');
-      explanationInput.className = 'input';
-      explanationInput.value = question.explanation || '';
-      explanationInput.addEventListener('input', () => { question.explanation = explanationInput.value; markDirty(); });
-      explanationLabel.appendChild(explanationInput);
-      card.appendChild(explanationLabel);
+      explanationField.appendChild(explanationLabel);
+      const explanationEditor = createRichTextEditor({
+        value: question.explanation,
+        ariaLabel: `Question ${idx + 1} explanation`,
+        onChange: () => {
+          question.explanation = explanationEditor.getValue();
+          markDirty();
+        }
+      });
+      explanationEditor.element.classList.add('exam-rich-input');
+      explanationField.appendChild(explanationEditor.element);
+      card.appendChild(explanationField);
 
       const optionsWrap = document.createElement('div');
       optionsWrap.className = 'exam-option-editor-list';
@@ -1964,14 +2405,22 @@ function openExamEditor(existing, render) {
           radio.type = 'radio';
           radio.name = `correct-${question.id}`;
           radio.checked = question.answer === opt.id;
-          radio.addEventListener('change', () => { question.answer = opt.id; markDirty(); });
+          radio.addEventListener('change', () => {
+            question.answer = opt.id;
+            markDirty();
+          });
+          row.appendChild(radio);
 
-          const text = document.createElement('input');
-          text.className = 'input';
-          text.type = 'text';
-          text.placeholder = `Option ${optIdx + 1}`;
-          text.value = opt.text;
-          text.addEventListener('input', () => { opt.text = text.value; markDirty(); });
+          const editor = createRichTextEditor({
+            value: opt.text,
+            ariaLabel: `Option ${optIdx + 1}`,
+            onChange: () => {
+              opt.text = editor.getValue();
+              markDirty();
+            }
+          });
+          editor.element.classList.add('exam-option-rich');
+          row.appendChild(editor.element);
 
           const removeBtn = document.createElement('button');
           removeBtn.type = 'button';
@@ -1986,10 +2435,8 @@ function openExamEditor(existing, render) {
             markDirty();
             renderOptions();
           });
-
-          row.appendChild(radio);
-          row.appendChild(text);
           row.appendChild(removeBtn);
+
           optionsWrap.appendChild(row);
         });
       }
@@ -2017,12 +2464,19 @@ function openExamEditor(existing, render) {
   renderQuestions();
 
   const actions = document.createElement('div');
-  actions.className = 'modal-actions';
-  const save = document.createElement('button');
-  save.type = 'submit';
-  save.className = 'btn';
-  save.textContent = 'Save Exam';
-  actions.appendChild(save);
+  actions.className = 'exam-editor-actions';
+  const saveBtn = document.createElement('button');
+  saveBtn.type = 'submit';
+  saveBtn.className = 'btn';
+  saveBtn.textContent = 'Save Exam';
+  actions.appendChild(saveBtn);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.type = 'button';
+  closeBtn.className = 'btn secondary';
+  closeBtn.textContent = 'Close';
+  closeBtn.addEventListener('click', () => { void floating.close('cancel'); });
+  actions.appendChild(closeBtn);
 
   form.appendChild(actions);
 
@@ -2040,21 +2494,28 @@ function openExamEditor(existing, render) {
       return false;
     }
 
-    for (let i = 0; i < exam.questions.length; i++) {
+    for (let i = 0; i < exam.questions.length; i += 1) {
       const question = exam.questions[i];
-      question.stem = question.stem.trim();
-      question.explanation = question.explanation?.trim() || '';
+      question.stem = sanitizeRichText(question.stem);
+      question.explanation = sanitizeRichText(question.explanation);
       question.media = question.media?.trim() || '';
-      question.options = question.options.map(opt => ({ id: opt.id, text: opt.text.trim() })).filter(opt => opt.text);
+      question.options = question.options.map(opt => ({
+        id: opt.id || uid(),
+        text: sanitizeRichText(opt.text)
+      })).filter(opt => !isEmptyHtml(opt.text));
+      question.tags = ensureArrayTags(question.tags);
+
+      if (isEmptyHtml(question.stem)) {
+        error.textContent = `Question ${i + 1} needs a prompt.`;
+        return false;
+      }
       if (question.options.length < 2) {
         error.textContent = `Question ${i + 1} needs at least two answer options.`;
         return false;
       }
       if (!question.answer || !question.options.some(opt => opt.id === question.answer)) {
-        error.textContent = `Select a correct answer for question ${i + 1}.`;
-        return false;
+        question.answer = question.options[0].id;
       }
-      question.tags = question.tags.map(t => t.trim()).filter(Boolean);
     }
 
     const payload = {
@@ -2067,14 +2528,14 @@ function openExamEditor(existing, render) {
     return true;
   }
 
-  async function saveAndClose() {
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
     const ok = await persistExam();
-    if (!ok) return false;
+    if (!ok) return;
     dirty = false;
-    removeOverlay();
+    await floating.close('saved');
     render();
-    return true;
-  }
+  });
 
   function promptSaveChoice() {
     return new Promise(resolve => {
@@ -2109,9 +2570,7 @@ function openExamEditor(existing, render) {
       cancelBtn.textContent = 'Keep Editing';
       cancelBtn.addEventListener('click', () => { cleanup(); resolve('cancel'); });
 
-      actionsRow.appendChild(saveBtn);
-      actionsRow.appendChild(discardBtn);
-      actionsRow.appendChild(cancelBtn);
+      actionsRow.append(saveBtn, discardBtn, cancelBtn);
       card.appendChild(actionsRow);
       modal.appendChild(card);
 
@@ -2131,33 +2590,5 @@ function openExamEditor(existing, render) {
     });
   }
 
-  async function attemptClose() {
-    if (!dirty) {
-      removeOverlay();
-      return;
-    }
-    const choice = await promptSaveChoice();
-    if (choice === 'cancel') return;
-    if (choice === 'discard') {
-      dirty = false;
-      removeOverlay();
-      return;
-    }
-    if (choice === 'save') {
-      await saveAndClose();
-    }
-  }
-
-  closeBtn.addEventListener('click', attemptClose);
-
-  form.addEventListener('submit', async e => {
-    e.preventDefault();
-    await saveAndClose();
-  });
-
-  overlay.appendChild(form);
-
-  document.body.appendChild(overlay);
   titleInput.focus();
 }
-

--- a/js/ui/components/rich-text.js
+++ b/js/ui/components/rich-text.js
@@ -220,6 +220,10 @@ function sanitizeToPlainText(html = '') {
   return text.replace(/\u00a0/g, ' ');
 }
 
+export function htmlToPlainText(html = '') {
+  return sanitizeToPlainText(html);
+}
+
 function normalizeInput(value = ''){
   if (value == null) return '';
   const str = String(value);
@@ -241,7 +245,7 @@ const FONT_OPTIONS = [
   { value: '"Comic Neue", "Comic Sans MS", cursive', label: 'Handwriting' }
 ];
 
-function isEmptyHtml(html = ''){
+export function isEmptyHtml(html = ''){
   if (!html) return true;
   const template = document.createElement('template');
   template.innerHTML = html;

--- a/style.css
+++ b/style.css
@@ -6412,6 +6412,22 @@ body.map-toolbox-dragging {
   font-weight: 700;
 }
 
+.ghost-btn {
+  background: transparent;
+  border: none;
+  color: rgba(226, 232, 240, 0.7);
+  padding: 0;
+  font: inherit;
+  text-decoration: underline;
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.ghost-btn:hover,
+.ghost-btn:focus-visible {
+  color: var(--text);
+}
+
 /* Exams */
 .exam-view {
   padding: var(--pad-lg);
@@ -6423,7 +6439,14 @@ body.map-toolbox-dragging {
 .exam-controls {
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
   gap: var(--pad);
+}
+
+.exam-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
 }
 
 .exam-heading h1 {
@@ -6431,87 +6454,276 @@ body.map-toolbox-dragging {
 }
 
 .exam-heading p {
-  margin: 4px 0 0;
-  color: var(--gray);
+  margin: 0;
+  color: var(--text-muted);
   font-size: 0.95rem;
 }
 
 .exam-control-actions {
   display: flex;
-  gap: var(--pad);
   flex-wrap: wrap;
+  gap: var(--pad);
+  align-items: center;
 }
 
 .exam-status {
-  color: #f97373;
   min-height: 1.2em;
+  font-size: 0.95rem;
+  color: rgba(248, 113, 113, 0.95);
 }
 
 .exam-grid {
   display: grid;
   gap: var(--pad-lg);
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: stretch;
 }
 
 .exam-card {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: var(--pad);
+  padding: var(--pad-lg);
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: linear-gradient(150deg, rgba(30, 41, 59, 0.88), rgba(15, 23, 42, 0.82));
+  box-shadow: 0 24px 46px rgba(2, 6, 23, 0.5);
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+  overflow: hidden;
+}
+
+.exam-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 32px 64px rgba(2, 6, 23, 0.62);
+  border-color: rgba(148, 163, 184, 0.32);
+}
+
+.exam-card.expanded {
+  grid-column: 1 / -1;
+}
+
+.exam-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--pad);
+}
+
+.exam-card-summary {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  align-items: flex-start;
+  background: none;
+  border: none;
+  padding: 0;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
+.exam-card-summary:focus-visible {
+  outline: 2px solid rgba(56, 189, 248, 0.6);
+  outline-offset: 4px;
 }
 
 .exam-card-title {
   margin: 0;
+  font-size: 1.35rem;
+  letter-spacing: 0.01em;
+}
+
+.exam-card-title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
 }
 
 .exam-card-meta {
   display: flex;
-  gap: var(--pad);
   flex-wrap: wrap;
-  color: var(--gray);
+  gap: 0.6rem;
   font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.68);
+}
+
+.exam-card-meta span::before {
+  content: '\2022';
+  margin-right: 6px;
+  color: rgba(148, 163, 184, 0.6);
+}
+
+.exam-card-meta span:first-child::before {
+  content: '';
+  margin: 0;
+}
+
+.exam-card-glance {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.exam-card-toggle-icon {
+  align-self: flex-start;
+  width: 30px;
+  height: 30px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.25s ease, border-color 0.25s ease, background 0.25s ease;
+}
+
+.exam-card-toggle-icon::before {
+  content: '\25BC';
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.78);
+}
+
+.exam-card-summary:hover .exam-card-toggle-icon,
+.exam-card-summary:focus-visible .exam-card-toggle-icon {
+  border-color: rgba(148, 163, 184, 0.45);
+  background: rgba(148, 163, 184, 0.18);
+}
+
+.exam-card.expanded .exam-card-toggle-icon {
+  transform: rotate(180deg);
+}
+
+.exam-card-quick-action {
+  flex-shrink: 0;
+  display: flex;
+  align-items: flex-start;
+}
+
+.exam-card-primary {
+  min-width: 132px;
+}
+
+.exam-card-details {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  padding-top: var(--pad);
+  border-top: 1px solid rgba(148, 163, 184, 0.16);
 }
 
 .exam-card-stats {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: var(--pad);
 }
 
-.exam-saved-banner {
-  background: rgba(166, 217, 255, 0.15);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: var(--pad-sm) var(--pad);
-  color: var(--blue);
-  font-size: 0.9rem;
-}
-
 .exam-stat {
-  background: var(--muted);
+  background: rgba(148, 163, 184, 0.12);
   border-radius: var(--radius);
   padding: var(--pad-sm) var(--pad);
-  min-width: 110px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 0.35rem;
 }
 
 .exam-stat-label {
   font-size: 0.75rem;
-  color: var(--gray);
+  color: rgba(226, 232, 240, 0.68);
+  letter-spacing: 0.05em;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
 }
 
 .exam-stat-value {
   font-size: 1.1rem;
   font-weight: 600;
+  color: var(--text);
 }
 
 .exam-card-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--pad);
+  gap: 0.75rem;
+}
+
+.exam-saved-banner {
+  background: rgba(59, 130, 246, 0.15);
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  border-radius: var(--radius);
+  padding: var(--pad-sm) var(--pad);
+  color: rgba(191, 219, 254, 0.95);
+  font-size: 0.92rem;
+}
+
+.exam-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.18);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.exam-chip--ghost {
+  background: rgba(226, 232, 240, 0.08);
+  border-color: rgba(148, 163, 184, 0.25);
+}
+
+.exam-chip--progress {
+  background: rgba(96, 165, 250, 0.18);
+  border-color: rgba(96, 165, 250, 0.32);
+  color: rgba(191, 219, 254, 0.94);
+}
+
+.exam-score-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 6px 12px;
+  border-radius: 12px;
+  font-weight: 600;
+  font-size: 0.9rem;
+  letter-spacing: 0.02em;
+}
+
+.exam-score-badge-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.exam-score-badge-value {
+  font-size: 1rem;
+}
+
+.exam-score-badge--good {
+  background: rgba(74, 222, 128, 0.18);
+  color: rgba(187, 247, 208, 0.95);
+  border: 1px solid rgba(74, 222, 128, 0.35);
+}
+
+.exam-score-badge--warn {
+  background: rgba(250, 204, 21, 0.18);
+  color: rgba(254, 240, 138, 0.95);
+  border: 1px solid rgba(250, 204, 21, 0.32);
+}
+
+.exam-score-badge--bad {
+  background: rgba(248, 113, 113, 0.18);
+  color: rgba(254, 202, 202, 0.95);
+  border: 1px solid rgba(248, 113, 113, 0.32);
+}
+
+.exam-score-badge--neutral {
+  background: rgba(148, 163, 184, 0.18);
+  color: rgba(226, 232, 240, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.3);
 }
 
 .exam-attempts {
@@ -6524,35 +6736,9 @@ body.map-toolbox-dragging {
   margin: 0;
 }
 
-.exam-attempts-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--pad);
-}
-
-.exam-attempts.collapsed .exam-attempt-list {
-  display: none;
-}
-
-.exam-attempt-toggle {
-  background: none;
-  border: 1px solid var(--border);
-  color: var(--gray);
-  font-size: 0.85rem;
-  padding: 4px 10px;
-}
-
-.exam-attempt-toggle:hover {
-  transform: none;
-  box-shadow: none;
-  border-color: var(--blue);
-  color: var(--blue);
-}
-
 .exam-attempt-empty {
   margin: 0;
-  color: var(--gray);
+  color: rgba(226, 232, 240, 0.65);
 }
 
 .exam-attempt-list {
@@ -6563,671 +6749,51 @@ body.map-toolbox-dragging {
 
 .exam-attempt-row {
   display: flex;
-  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--pad-sm);
   align-items: center;
-  gap: var(--pad);
-  background: var(--muted);
-  border-radius: var(--radius);
+  justify-content: space-between;
   padding: var(--pad-sm) var(--pad);
+  border-radius: var(--radius);
+  background: rgba(148, 163, 184, 0.14);
 }
 
 .exam-attempt-info {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 0.25rem;
 }
 
 .exam-attempt-score {
   font-weight: 600;
 }
 
+.exam-attempt-date {
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
 .exam-attempt-meta {
-  color: var(--gray);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  color: rgba(226, 232, 240, 0.6);
   font-size: 0.85rem;
 }
 
+.exam-attempt-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
 .exam-empty {
+  padding: calc(var(--pad-lg) * 1.5);
+  border-radius: var(--radius-lg);
+  border: 1px dashed rgba(148, 163, 184, 0.3);
+  background: rgba(30, 41, 59, 0.55);
   text-align: center;
-  color: var(--gray);
-  padding: 80px 0;
-  display: flex;
-  flex-direction: column;
-  gap: var(--pad);
-  align-items: center;
-}
-
-.exam-session {
-  padding: var(--pad-lg);
-  display: flex;
-  flex-direction: column;
-  gap: var(--pad-lg);
-}
-
-.exam-runner {
-  display: flex;
-  flex-direction: column;
-  gap: var(--pad-lg);
-}
-
-@media (min-width: 960px) {
-  .exam-runner {
-    flex-direction: row;
-    align-items: flex-start;
-  }
-}
-
-.exam-main {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: var(--pad);
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: var(--pad-lg);
-}
-
-.exam-sidebar {
-  width: 280px;
-  display: flex;
-  flex-direction: column;
-  gap: var(--pad);
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: var(--pad-lg);
-}
-
-@media (max-width: 959px) {
-  .exam-sidebar {
-    width: 100%;
-  }
-}
-
-.exam-topbar {
-  display: flex;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  gap: var(--pad);
-  align-items: center;
-}
-
-.exam-progress {
-  font-weight: 600;
-}
-
-.exam-timer {
-  margin-left: auto;
-  font-weight: 600;
-  background: var(--muted);
-  border-radius: var(--radius);
-  padding: 6px 12px;
-}
-
-.flag-btn {
-  background: none;
-  border: 1px solid var(--border);
-  color: var(--gray);
-  padding: 6px 12px;
-  border-radius: var(--radius);
-  cursor: pointer;
-}
-
-.flag-btn:hover {
-  transform: none;
-  box-shadow: none;
-}
-
-.flag-btn.active {
-  background: linear-gradient(135deg, #fef3c7, #fde68a);
-  color: #854d0e;
-  border-color: rgba(251, 191, 36, 0.8);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
-}
-
-.flag-btn:disabled {
-  opacity: 0.6;
-  cursor: default;
-}
-
-.exam-stem {
-  white-space: pre-wrap;
-  line-height: 1.6;
-}
-
-.exam-media img,
-.exam-media video {
-  width: 100%;
-  max-height: 320px;
-  border-radius: var(--radius);
-  object-fit: contain;
-}
-
-.exam-media audio {
-  width: 100%;
-}
-
-.exam-tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
-.exam-tag {
-  background: var(--muted);
-  border-radius: 999px;
-  padding: 2px 8px;
-  font-size: 0.8rem;
-  color: var(--gray);
-}
-
-.exam-options {
-  display: flex;
-  flex-direction: column;
-  gap: var(--pad-sm);
-}
-
-.exam-option {
-  background: var(--muted);
-  border: 2px solid var(--border);
-  border-radius: var(--radius);
-  padding: var(--pad);
-  text-align: left;
-  cursor: pointer;
-  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
-  position: relative;
-  box-shadow: none;
-  display: flex;
-  align-items: flex-start;
-  gap: 14px;
-}
-
-.exam-option .option-indicator {
-  width: 24px;
-  height: 24px;
-  border-radius: 999px;
-  border: 2px solid var(--border);
-  background: rgba(15, 23, 42, 0.65);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
-  position: relative;
-}
-
-.exam-option .option-indicator::after {
-  content: '';
-  width: 10px;
-  height: 10px;
-  border-radius: 999px;
-  background: transparent;
-  transition: background 0.2s ease, transform 0.2s ease;
-}
-
-.exam-option .option-text {
-  flex: 1;
-  display: block;
-}
-
-.exam-option:hover {
-  transform: none;
-  box-shadow: none;
-  border-color: rgba(96, 165, 250, 0.6);
-}
-
-.exam-option:focus-visible {
-  outline: 2px solid rgba(56, 189, 248, 0.65);
-  outline-offset: 3px;
-}
-
-.exam-option.selected {
-  border-color: rgba(59, 130, 246, 0.95);
-  background: linear-gradient(135deg, #bfdbfe, #60a5fa);
-  color: #0f172a;
-
-  font-weight: 600;
-  box-shadow: 0 8px 18px rgba(37, 99, 235, 0.15), inset 0 0 0 1px rgba(255, 255, 255, 0.8);
-}
-
-.exam-option.selected .option-indicator {
-  border-color: rgba(59, 130, 246, 0.95);
-  background: rgba(191, 219, 254, 0.75);
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.28);
-}
-
-.exam-option.selected .option-indicator::after {
-  background: rgba(37, 99, 235, 0.92);
-  transform: scale(0.9);
-
-}
-
-.exam-option.correct-answer {
-  border-color: rgba(52, 211, 153, 0.9);
-  background: linear-gradient(135deg, rgba(187, 247, 208, 0.85), rgba(134, 239, 172, 0.8));
-  color: #064e3b;
-}
-
-.exam-option.correct-answer .option-indicator {
-  border-color: rgba(52, 211, 153, 0.9);
-  background: rgba(187, 247, 208, 0.85);
-}
-
-.exam-option.correct-answer .option-indicator::after {
-  background: rgba(22, 163, 74, 0.9);
-  transform: scale(0.85);
-}
-
-.exam-option.incorrect-answer {
-  border-color: rgba(248, 113, 113, 0.9);
-  background: linear-gradient(135deg, rgba(254, 205, 211, 0.8), rgba(252, 165, 165, 0.78));
-  color: #7f1d1d;
-}
-
-.exam-option.incorrect-answer .option-indicator {
-  border-color: rgba(248, 113, 113, 0.9);
-  background: rgba(254, 205, 211, 0.8);
-}
-
-.exam-option.incorrect-answer .option-indicator::after {
-  background: rgba(220, 38, 38, 0.85);
-  transform: scale(0.85);
-}
-
-.exam-option.selected.correct-answer {
-  box-shadow: inset 0 0 0 2px rgba(16, 185, 129, 0.35);
-}
-
-.exam-option.selected.incorrect-answer {
-  box-shadow: inset 0 0 0 2px rgba(248, 113, 113, 0.35);
-}
-
-.exam-option.selected,
-.exam-option.chosen {
-  position: relative;
-}
-
-.exam-option.selected::after,
-.exam-option.chosen::after {
-  position: absolute;
-  top: 8px;
-  right: 12px;
-  font-size: 0.75rem;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  color: rgba(30, 41, 59, 0.72);
-}
-
-.exam-option.selected::after {
-  content: 'Selected';
-}
-
-.exam-option.chosen::after {
-  content: 'Your answer';
-}
-
-.exam-option.review {
-  cursor: default;
-}
-
-.exam-option.review:hover {
-  border-color: var(--border);
-}
-
-.exam-warning {
-  color: #fbbf24;
-}
-
-.exam-verdict {
-  font-weight: 600;
-  padding: 8px 12px;
-  border-radius: var(--radius);
-}
-
-.exam-verdict.correct {
-  background: rgba(164, 251, 196, 0.18);
-  color: var(--green);
-}
-
-.exam-verdict.incorrect {
-  background: rgba(249, 115, 115, 0.18);
-  color: #f97373;
-}
-
-.exam-verdict.neutral {
-  background: var(--muted);
-  color: var(--gray);
-}
-
-.exam-answer-summary {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.exam-explanation {
-  background: var(--muted);
-  border-radius: var(--radius);
-  padding: var(--pad);
-}
-
-.exam-explanation h3 {
-  margin: 0 0 4px;
-}
-
-.exam-palette {
-  display: flex;
-  flex-direction: column;
-  gap: var(--pad-sm);
-}
-
-.exam-palette-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(44px, 1fr));
-  gap: 8px;
-}
-
-
-.palette-button {
-  position: relative;
-  background: #e2e8f0;
-  border: 2px solid rgba(148, 163, 184, 0.55);
-  border-radius: var(--radius);
-  padding: 10px 0;
-  cursor: pointer;
-  color: rgba(15, 23, 42, 0.78);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: 600;
-  line-height: 1;
-  min-height: 44px;
-  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
-  box-shadow: inset 0 -1px 0 rgba(148, 163, 184, 0.2);
-}
-
-.palette-button:hover {
-  transform: none;
-  box-shadow: inset 0 -1px 0 rgba(148, 163, 184, 0.3), 0 0 0 2px rgba(148, 163, 184, 0.12);
-  border-color: rgba(148, 163, 184, 0.75);
-}
-
-.palette-button.active {
-  border-color: #ffffff;
-  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.85);
-}
-
-.palette-button.unanswered,
-.palette-button[data-status='unanswered'] {
-  background: #e2e8f0 !important;
-  border-color: rgba(148, 163, 184, 0.45) !important;
-  color: rgba(15, 23, 42, 0.58) !important;
-  opacity: 0.55;
-  filter: grayscale(0.35);
-}
-
-.palette-button.review-unanswered,
-.palette-button[data-status='review-unanswered'] {
-  background: #dbe3ef !important;
-  border-color: rgba(100, 116, 139, 0.34) !important;
-  color: rgba(15, 23, 42, 0.5) !important;
-  opacity: 0.45;
-  filter: grayscale(0.4);
-}
-
-.palette-button.answered,
-.palette-button[data-status='answered'] {
-  background: linear-gradient(135deg, #60a5fa 0%, #2563eb 100%);
-  border-color: rgba(37, 99, 235, 0.8);
-  color: #f8fafc;
-  font-weight: 700;
-  text-shadow: 0 1px 2px rgba(15, 23, 42, 0.25);
-  opacity: 1;
-  filter: none;
-}
-
-.palette-button.correct,
-.palette-button[data-status='correct'] {
-  background: linear-gradient(135deg, #16a34a 0%, #0f766e 100%) !important;
-  border-color: rgba(22, 163, 74, 0.9) !important;
-  color: #f0fdf4 !important;
-  box-shadow: inset 0 0 0 1px rgba(240, 253, 244, 0.5);
-  text-shadow: 0 1px 2px rgba(4, 47, 46, 0.35);
-  opacity: 1;
-  filter: none;
-}
-
-.palette-button.incorrect,
-.palette-button[data-status='incorrect'] {
-  background: linear-gradient(135deg, #fb7185 0%, #dc2626 55%, #991b1b 100%) !important;
-  border-color: rgba(220, 38, 38, 0.9) !important;
-  color: #fee2e2 !important;
-  box-shadow: inset 0 0 0 1px rgba(254, 226, 226, 0.55);
-  text-shadow: 0 1px 2px rgba(76, 5, 25, 0.4);
-  opacity: 1;
-  filter: none;
-}
-
-.palette-button.flagged[data-mode='taking'] {
-  background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
-  border-color: rgba(250, 204, 21, 0.6);
-  color: #854d0e;
-}
-
-.palette-button.flagged::after {
-  content: '🚩';
-  position: absolute;
-  bottom: 4px;
-  left: 4px;
-  font-size: 0.8rem;
-  line-height: 1;
-  pointer-events: none;
-  filter: drop-shadow(0 1px 0 rgba(15, 23, 42, 0.2));
-}
-
-
-.palette-button.flagged[data-mode='taking'].answered,
-.palette-button.flagged[data-mode='taking'][data-status='answered'] {
-  background: linear-gradient(135deg, #fef3c7 0%, #fde68a 45%, #60a5fa 100%);
-  border-color: rgba(251, 191, 36, 0.65);
-  color: #78350f;
-}
-
-.palette-button.flagged[data-mode='taking'].correct,
-.palette-button.flagged[data-mode='taking'][data-status='correct'] {
-  background: linear-gradient(135deg, #fef3c7 0%, #fde68a 35%, #16a34a 100%);
-  border-color: rgba(251, 191, 36, 0.65);
-  color: #78350f;
-}
-
-.palette-button.flagged[data-mode='taking'].incorrect,
-.palette-button.flagged[data-mode='taking'][data-status='incorrect'] {
-  background: linear-gradient(135deg, #fef3c7 0%, #fde68a 35%, #ef4444 100%);
-  border-color: rgba(251, 191, 36, 0.65);
-  color: #78350f;
-}
-
-.palette-button.flagged[data-mode='review'] {
-  box-shadow: inset 0 0 0 2px rgba(250, 204, 21, 0.45);
-}
-
-.palette-button.flagged[data-mode='review'][data-status='correct'],
-.palette-button.flagged[data-mode='review'][data-status='incorrect'] {
-  color: inherit;
-}
-
-.palette-button[data-mode='taking'][data-status='unanswered'] {
-  background: #e2e8f0 !important;
-  border-color: rgba(148, 163, 184, 0.45) !important;
-  color: rgba(15, 23, 42, 0.58) !important;
-  filter: grayscale(0.35);
-  opacity: 0.55;
-}
-
-.palette-button[data-mode='review'][data-status='review-unanswered'] {
-  background: #d8dee8 !important;
-  border-color: rgba(100, 116, 139, 0.32) !important;
-  color: rgba(15, 23, 42, 0.5) !important;
-  opacity: 0.45;
-  filter: grayscale(0.4);
-}
-
-.palette-button[data-change-direction]::after {
-  content: '';
-  position: absolute;
-  top: 6px;
-  right: 6px;
-  width: 12px;
-  height: 12px;
-  border-radius: 999px;
-  border: 2px solid rgba(255, 255, 255, 0.9);
-  box-shadow: 0 0 0 2px rgba(15, 23, 42, 0.12);
-}
-
-.palette-button[data-change-direction='right-to-wrong']::after {
-  background: linear-gradient(135deg, #fb7185, #ef4444);
-}
-
-.palette-button[data-change-direction='wrong-to-right']::after {
-  background: linear-gradient(135deg, #34d399, #22c55e);
-}
-
-.palette-button[data-change-direction='changed']::after {
-  background: linear-gradient(135deg, #818cf8, #6366f1);
-}
-
-.palette-button[data-change-direction='returned']::after {
-  background: linear-gradient(135deg, #38bdf8, #0284c7);
-}
-
-.exam-review-insights {
-  margin-top: 12px;
-  background: rgba(99, 102, 241, 0.08);
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  border-radius: var(--radius);
-  padding: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  font-size: 0.95rem;
-  color: var(--gray);
-}
-
-.exam-review-insights strong {
-  color: var(--text);
-}
-
-
-.palette-button.correct.active,
-.palette-button.incorrect.active,
-.palette-button.flagged.active {
-  border-color: #ffffff;
-  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8);
-}
-
-.exam-palette-summary {
-  margin-top: 12px;
-  padding: 12px;
-  border-radius: var(--radius);
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: linear-gradient(135deg, rgba(226, 232, 240, 0.45), rgba(226, 232, 240, 0.2));
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.exam-palette-summary-title {
-  font-size: 0.95rem;
-  font-weight: 600;
-  color: var(--text);
-}
-
-.exam-palette-summary-stats {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  font-size: 0.9rem;
-  color: var(--gray);
-}
-
-.exam-palette-summary-stats span strong {
-  color: var(--text);
-  font-weight: 700;
-}
-
-.exam-sidebar-info {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  color: var(--gray);
-  font-size: 0.9rem;
-}
-
-.exam-nav {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--pad);
-  justify-content: flex-end;
-}
-
-.exam-summary {
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: var(--pad-lg);
-  display: flex;
-  flex-direction: column;
-  gap: var(--pad);
-  align-items: center;
-  text-align: center;
-}
-
-.exam-summary-score {
-  display: flex;
-  align-items: baseline;
-  gap: 12px;
-}
-
-.score-number {
-  font-size: 2.5rem;
-  font-weight: 700;
-}
-
-.score-percent {
-  font-size: 1.2rem;
-  color: var(--gray);
-}
-
-.exam-summary-metrics {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--pad);
-  justify-content: center;
-}
-
-.exam-summary-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--pad);
-  justify-content: center;
-}
-
-.exam-error {
-  color: #f97373;
-  min-height: 1.2em;
-}
-
-.exam-editor {
-  width: min(960px, 95vw);
-  max-height: 90vh;
-  overflow-y: auto;
-  gap: var(--pad);
-}
-
-.exam-timer-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--pad);
+  color: rgba(226, 232, 240, 0.7);
 }
 
 .exam-question-section {
@@ -7238,25 +6804,26 @@ body.map-toolbox-dragging {
 
 .exam-question-header {
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  justify-content: space-between;
   gap: var(--pad);
-  margin-top: var(--pad);
 }
 
 .exam-question-empty {
-  color: var(--gray);
   margin: 0;
+  color: rgba(226, 232, 240, 0.65);
+  font-style: italic;
 }
 
 .exam-question-editor {
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: var(--pad);
   display: flex;
   flex-direction: column;
   gap: var(--pad);
-  background: var(--panel);
+  padding: var(--pad);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(15, 23, 42, 0.78);
+  box-shadow: 0 18px 36px rgba(2, 6, 23, 0.45);
 }
 
 .exam-question-editor-header {
@@ -7265,20 +6832,40 @@ body.map-toolbox-dragging {
   align-items: center;
 }
 
-.ghost-btn {
-  background: none;
-  border: 1px solid transparent;
-  color: var(--gray);
-  padding: 4px 8px;
-  border-radius: var(--radius);
-  cursor: pointer;
+.exam-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
 }
 
-.ghost-btn:hover {
-  border-color: var(--border);
-  color: var(--text);
-  transform: none;
-  box-shadow: none;
+.exam-field.is-hidden {
+  display: none;
+}
+
+.exam-field-label {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: rgba(226, 232, 240, 0.76);
+}
+
+.exam-field--rich .exam-rich-input {
+  min-height: 220px;
+}
+
+.exam-field--media {
+  gap: 0.6rem;
+}
+
+.exam-field--media input[type="file"] {
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.exam-rich-input .rich-editor {
+  width: 100%;
+}
+
+.exam-rich-input .rich-editor-area {
+  min-height: 200px;
 }
 
 .exam-media-preview {
@@ -7288,7 +6875,8 @@ body.map-toolbox-dragging {
   display: flex;
   justify-content: center;
   align-items: center;
-  min-height: 60px;
+  min-height: 120px;
+  background: rgba(148, 163, 184, 0.08);
 }
 
 .exam-media-preview .exam-media {
@@ -7302,14 +6890,550 @@ body.map-toolbox-dragging {
 }
 
 .exam-option-editor {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: var(--pad);
+  align-items: flex-start;
+}
+
+.exam-option-editor input[type="radio"] {
+  margin-top: 10px;
+}
+
+.exam-option-rich {
+  width: 100%;
+}
+
+.exam-option-rich .rich-editor-area {
+  min-height: 120px;
+}
+
+.exam-editor {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  gap: var(--pad);
+  min-height: 0;
+}
+
+.exam-error {
+  color: rgba(248, 113, 113, 0.95);
+  min-height: 1.2em;
+}
+
+.exam-timer-row {
+  display: flex;
+  flex-wrap: wrap;
   gap: var(--pad);
 }
 
-.exam-option-editor .input {
-  flex: 1;
+.exam-editor-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--pad);
+  padding-top: var(--pad);
+  border-top: 1px solid rgba(148, 163, 184, 0.18);
 }
+
+.exam-media {
+  margin: var(--pad) 0;
+  border-radius: var(--radius);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: var(--pad);
+  background: rgba(15, 23, 42, 0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--pad);
+}
+
+.exam-media img,
+.exam-media video {
+  max-width: 100%;
+  border-radius: var(--radius-sm);
+}
+
+.exam-media audio {
+  width: 100%;
+}
+
+.exam-session {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-lg);
+  padding: var(--pad-lg);
+}
+
+.exam-runner {
+  display: grid;
+  gap: var(--pad-lg);
+  grid-template-columns: minmax(0, 1fr) 320px;
+  align-items: flex-start;
+}
+
+.exam-main {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  padding: var(--pad-lg);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(12, 18, 32, 0.78);
+  box-shadow: 0 22px 44px rgba(2, 6, 23, 0.5);
+}
+
+.exam-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  padding: var(--pad);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.72);
+  max-height: calc(100vh - 200px);
+  overflow-y: auto;
+}
+
+.exam-topbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad);
+  align-items: center;
+  justify-content: space-between;
+}
+
+.exam-progress {
+  flex: 1;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.flag-btn {
+  background: rgba(250, 204, 21, 0.18);
+  border: 1px solid rgba(250, 204, 21, 0.32);
+  color: rgba(254, 240, 138, 0.95);
+  border-radius: var(--radius);
+  padding: 6px 12px;
+}
+
+.flag-btn.active,
+.flag-btn[data-active="true"] {
+  background: rgba(250, 204, 21, 0.3);
+  border-color: rgba(250, 204, 21, 0.55);
+}
+
+.exam-timer {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.exam-stem {
+  font-size: 1.05rem;
+  line-height: 1.6;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.exam-stem-empty {
+  color: rgba(226, 232, 240, 0.55);
+  font-style: italic;
+}
+
+.exam-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.exam-tag {
+  padding: 2px 10px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.16);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.exam-options {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+  counter-reset: exam-option;
+}
+
+.exam-option {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--pad);
+  padding: var(--pad);
+  border-radius: var(--radius);
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  background: rgba(15, 23, 42, 0.7);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease, background 0.2s ease;
+  cursor: pointer;
+}
+
+.exam-option button {
+  text-align: left;
+}
+
+.exam-option .option-indicator {
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  border-radius: 999px;
+  border: 2px solid rgba(148, 163, 184, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+}
+
+.exam-option .option-indicator::before {
+  counter-increment: exam-option;
+  content: counter(exam-option, upper-alpha);
+}
+
+.exam-option .option-text {
+  flex: 1;
+  display: block;
+}
+
+.exam-option .option-text img,
+.exam-option .option-text video {
+  max-width: 100%;
+  border-radius: var(--radius-sm);
+}
+
+.exam-option .option-text audio {
+  width: 100%;
+}
+
+.exam-option:hover,
+.exam-option:focus-visible {
+  border-color: rgba(56, 189, 248, 0.55);
+  box-shadow: 0 10px 24px rgba(56, 189, 248, 0.25);
+  transform: translateY(-1px);
+}
+
+.exam-option.selected {
+  border-color: rgba(56, 189, 248, 0.65);
+  background: rgba(56, 189, 248, 0.16);
+}
+
+.exam-option.correct-answer {
+  border-color: rgba(74, 222, 128, 0.6);
+  background: rgba(74, 222, 128, 0.16);
+}
+
+.exam-option.incorrect-answer {
+  border-color: rgba(248, 113, 113, 0.6);
+  background: rgba(248, 113, 113, 0.12);
+}
+
+.exam-option.review {
+  cursor: default;
+}
+
+.exam-option.review:hover,
+.exam-option.review:focus-visible {
+  transform: none;
+  box-shadow: none;
+}
+
+.exam-option.chosen.correct-answer {
+  box-shadow: 0 0 0 2px rgba(74, 222, 128, 0.45);
+}
+
+.exam-option.chosen.incorrect-answer {
+  box-shadow: 0 0 0 2px rgba(248, 113, 113, 0.45);
+}
+
+.exam-option-empty {
+  color: rgba(226, 232, 240, 0.6);
+  font-style: italic;
+}
+
+.exam-warning {
+  margin: 0;
+  color: rgba(248, 113, 113, 0.95);
+  font-weight: 500;
+}
+
+.exam-verdict {
+  padding: var(--pad);
+  border-radius: var(--radius);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.exam-verdict.correct {
+  background: rgba(74, 222, 128, 0.18);
+  border: 1px solid rgba(74, 222, 128, 0.35);
+  color: rgba(187, 247, 208, 0.96);
+}
+
+.exam-verdict.incorrect {
+  background: rgba(248, 113, 113, 0.18);
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  color: rgba(254, 202, 202, 0.95);
+}
+
+.exam-verdict.neutral {
+  background: rgba(148, 163, 184, 0.16);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.exam-answer-summary {
+  display: grid;
+  gap: 0.6rem;
+  background: rgba(148, 163, 184, 0.12);
+  border-radius: var(--radius);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  padding: var(--pad);
+  font-size: 0.95rem;
+}
+
+.exam-review-insights {
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.exam-explanation {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background: rgba(30, 41, 59, 0.55);
+  border-radius: var(--radius);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  padding: var(--pad);
+}
+
+.exam-explanation h3 {
+  margin: 0;
+}
+
+.exam-explanation-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  line-height: 1.6;
+}
+
+.exam-explanation-body img,
+.exam-explanation-body video {
+  max-width: 100%;
+  border-radius: var(--radius-sm);
+}
+
+.exam-explanation-body audio {
+  width: 100%;
+}
+
+.exam-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad);
+  justify-content: space-between;
+}
+
+.exam-sidebar-info {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.exam-palette {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad);
+}
+
+.exam-palette h3 {
+  margin: 0;
+}
+
+.exam-palette-grid {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(auto-fit, minmax(36px, 1fr));
+}
+
+.palette-button {
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(148, 163, 184, 0.14);
+  color: inherit;
+  padding: 6px 0;
+  font-weight: 600;
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.palette-button:hover,
+.palette-button:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(56, 189, 248, 0.55);
+  background: rgba(56, 189, 248, 0.18);
+}
+
+.palette-button.active,
+.palette-button[data-active="true"] {
+  border-color: rgba(56, 189, 248, 0.7);
+  background: rgba(56, 189, 248, 0.22);
+}
+
+.palette-button.correct {
+  border-color: rgba(74, 222, 128, 0.6);
+  background: rgba(74, 222, 128, 0.2);
+}
+
+.palette-button.incorrect {
+  border-color: rgba(248, 113, 113, 0.6);
+  background: rgba(248, 113, 113, 0.2);
+}
+
+.palette-button.answered {
+  border-color: rgba(96, 165, 250, 0.45);
+  background: rgba(96, 165, 250, 0.2);
+}
+
+.palette-button.review-unanswered {
+  border-style: dashed;
+}
+
+.palette-button.flagged {
+  position: relative;
+}
+
+.palette-button.flagged::after {
+  content: '🚩';
+  position: absolute;
+  top: -8px;
+  right: -6px;
+  font-size: 0.75rem;
+}
+
+.palette-button[data-change-direction="right-to-wrong"] {
+  box-shadow: inset 0 0 0 2px rgba(248, 113, 113, 0.65);
+}
+
+.palette-button[data-change-direction="wrong-to-right"] {
+  box-shadow: inset 0 0 0 2px rgba(74, 222, 128, 0.65);
+}
+
+.palette-button[data-change-direction="returned"] {
+  box-shadow: inset 0 0 0 2px rgba(250, 204, 21, 0.6);
+}
+
+.exam-palette-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: var(--pad);
+  border-radius: var(--radius);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.exam-palette-summary-title {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.exam-palette-summary-stats {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+}
+
+.exam-summary {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-lg);
+  padding: var(--pad-lg);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(12, 18, 32, 0.8);
+  box-shadow: 0 22px 44px rgba(2, 6, 23, 0.48);
+}
+
+.exam-summary h2 {
+  margin: 0;
+}
+
+.exam-summary-score {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.exam-summary-score .score-number {
+  font-size: 2.5rem;
+}
+
+.exam-summary-score .score-percent {
+  font-size: 1.2rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.exam-summary-metrics {
+  display: grid;
+  gap: var(--pad);
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.exam-summary-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pad);
+  justify-content: flex-end;
+}
+
+@media (max-width: 1100px) {
+  .exam-runner {
+    grid-template-columns: 1fr;
+  }
+
+  .exam-sidebar {
+    max-height: none;
+  }
+}
+
+@media (max-width: 720px) {
+  .exam-view,
+  .exam-session {
+    padding: var(--pad);
+  }
+
+  .exam-card {
+    padding: var(--pad);
+  }
+
+  .exam-main {
+    padding: var(--pad);
+  }
+
+  .exam-topbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .exam-nav {
+    justify-content: center;
+  }
+}
+
 
 .block-mode-shell {
   display: flex;


### PR DESCRIPTION
## Summary
- add CSV import/export and template support for exams while sanitizing imported rich text
- convert the exam editor into a floating rich-text window with media previews and stronger validation
- refresh the exams tab styling with modern cards, responsive layouts, and color-coded badges for attempts

## Testing
- npm test
- npx esbuild js/main.js --bundle --format=iife --global-name=Sevenn --outfile=bundle.js

------
https://chatgpt.com/codex/tasks/task_e_68f8048c63d083228e4b19a79512c6c8