### PR TITLE
Polish exam menu overlay and question map states

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -1,4 +1,31 @@
-(() => {
+var Sevenn = (() => {
+  var __defProp = Object.defineProperty;
+  var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+  var __getOwnPropNames = Object.getOwnPropertyNames;
+  var __hasOwnProp = Object.prototype.hasOwnProperty;
+  var __export = (target, all) => {
+    for (var name in all)
+      __defProp(target, name, { get: all[name], enumerable: true });
+  };
+  var __copyProps = (to, from, except, desc) => {
+    if (from && typeof from === "object" || typeof from === "function") {
+      for (let key of __getOwnPropNames(from))
+        if (!__hasOwnProp.call(to, key) && key !== except)
+          __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+    }
+    return to;
+  };
+  var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+  // js/main.js
+  var main_exports = {};
+  __export(main_exports, {
+    render: () => renderApp,
+    renderApp: () => renderApp,
+    resolveListKind: () => resolveListKind,
+    tabs: () => tabs
+  });
+
   // js/storage/preferences.js
   var STORAGE_KEY = "sevenn-ui-preferences";
   var cache = null;
@@ -17312,17 +17339,28 @@
     menuToggle.className = "exam-card-menu-toggle";
     menuToggle.setAttribute("aria-haspopup", "true");
     menuToggle.setAttribute("aria-expanded", "false");
-    const menuIcon = document.createElement("span");
-    menuIcon.className = "exam-card-menu-icon";
-    menuToggle.appendChild(menuIcon);
-    const menuLabel = document.createElement("span");
-    menuLabel.className = "sr-only";
-    menuLabel.textContent = "More options";
-    menuToggle.appendChild(menuLabel);
+    const menuId = `exam-card-menu-${exam.id}`;
+    menuToggle.setAttribute("aria-controls", menuId);
+    const menuToggleIcon = document.createElement("span");
+    menuToggleIcon.className = "exam-card-menu-toggle__icon";
+    const menuToggleIconBar = document.createElement("span");
+    menuToggleIconBar.className = "exam-card-menu-toggle__icon-bar";
+    menuToggleIcon.appendChild(menuToggleIconBar);
+    menuToggle.appendChild(menuToggleIcon);
+    const menuToggleLabel = document.createElement("span");
+    menuToggleLabel.className = "exam-card-menu-toggle__label";
+    menuToggleLabel.textContent = "Actions";
+    menuToggle.appendChild(menuToggleLabel);
+    const menuToggleSr = document.createElement("span");
+    menuToggleSr.className = "sr-only";
+    menuToggleSr.textContent = "Toggle exam actions";
+    menuToggle.appendChild(menuToggleSr);
     menuWrap.appendChild(menuToggle);
     const menuPanel = document.createElement("div");
     menuPanel.className = "exam-card-menu-panel";
-    menuPanel.hidden = true;
+    menuPanel.id = menuId;
+    menuPanel.setAttribute("aria-hidden", "true");
+    menuPanel.setAttribute("role", "menu");
     menuWrap.appendChild(menuPanel);
     let menuOpen = false;
     const handleOutside = (event) => {
@@ -17330,21 +17368,38 @@
       if (menuWrap.contains(event.target)) return;
       closeMenu();
     };
+    const handleKeydown = (event) => {
+      if (!menuOpen) return;
+      if (event.key === "Escape") {
+        event.preventDefault();
+        closeMenu();
+        menuToggle.focus();
+      }
+    };
+    const handleFocus = (event) => {
+      if (!menuOpen) return;
+      if (menuWrap.contains(event.target)) return;
+      closeMenu();
+    };
     function openMenu() {
       if (menuOpen) return;
       menuOpen = true;
-      menuPanel.hidden = false;
       menuWrap.classList.add("exam-card-menu--open");
       menuToggle.setAttribute("aria-expanded", "true");
+      menuPanel.setAttribute("aria-hidden", "false");
       document.addEventListener("click", handleOutside, true);
+      document.addEventListener("keydown", handleKeydown, true);
+      document.addEventListener("focusin", handleFocus, true);
     }
     function closeMenu() {
       if (!menuOpen) return;
       menuOpen = false;
-      menuPanel.hidden = true;
       menuWrap.classList.remove("exam-card-menu--open");
       menuToggle.setAttribute("aria-expanded", "false");
+      menuPanel.setAttribute("aria-hidden", "true");
       document.removeEventListener("click", handleOutside, true);
+      document.removeEventListener("keydown", handleKeydown, true);
+      document.removeEventListener("focusin", handleFocus, true);
     }
     menuToggle.addEventListener("click", (event) => {
       event.stopPropagation();
@@ -17354,10 +17409,14 @@
         openMenu();
       }
     });
+    menuPanel.addEventListener("click", (event) => {
+      event.stopPropagation();
+    });
     const addMenuAction = (label, handler, options = {}) => {
       const item = document.createElement("button");
       item.type = "button";
       item.className = "exam-card-menu-item";
+      item.setAttribute("role", "menuitem");
       if (options.variant === "danger") {
         item.classList.add("is-danger");
       }
@@ -26596,5 +26655,5 @@
   if (typeof window !== "undefined" && !globalThis.__SEVENN_TEST__) {
     bootstrap();
   }
+  return __toCommonJS(main_exports);
 })();
-//# sourceMappingURL=bundle.js.map

--- a/js/ui/components/exams.js
+++ b/js/ui/components/exams.js
@@ -1203,18 +1203,33 @@ function buildExamCard(exam, render, savedSession, statusEl, layout) {
   menuToggle.className = 'exam-card-menu-toggle';
   menuToggle.setAttribute('aria-haspopup', 'true');
   menuToggle.setAttribute('aria-expanded', 'false');
-  const menuIcon = document.createElement('span');
-  menuIcon.className = 'exam-card-menu-icon';
-  menuToggle.appendChild(menuIcon);
-  const menuLabel = document.createElement('span');
-  menuLabel.className = 'sr-only';
-  menuLabel.textContent = 'More options';
-  menuToggle.appendChild(menuLabel);
+  const menuId = `exam-card-menu-${exam.id}`;
+  menuToggle.setAttribute('aria-controls', menuId);
+
+  const menuToggleIcon = document.createElement('span');
+  menuToggleIcon.className = 'exam-card-menu-toggle__icon';
+  const menuToggleIconBar = document.createElement('span');
+  menuToggleIconBar.className = 'exam-card-menu-toggle__icon-bar';
+  menuToggleIcon.appendChild(menuToggleIconBar);
+  menuToggle.appendChild(menuToggleIcon);
+
+  const menuToggleLabel = document.createElement('span');
+  menuToggleLabel.className = 'exam-card-menu-toggle__label';
+  menuToggleLabel.textContent = 'Actions';
+  menuToggle.appendChild(menuToggleLabel);
+
+  const menuToggleSr = document.createElement('span');
+  menuToggleSr.className = 'sr-only';
+  menuToggleSr.textContent = 'Toggle exam actions';
+  menuToggle.appendChild(menuToggleSr);
+
   menuWrap.appendChild(menuToggle);
 
   const menuPanel = document.createElement('div');
   menuPanel.className = 'exam-card-menu-panel';
-  menuPanel.hidden = true;
+  menuPanel.id = menuId;
+  menuPanel.setAttribute('aria-hidden', 'true');
+  menuPanel.setAttribute('role', 'menu');
   menuWrap.appendChild(menuPanel);
 
   let menuOpen = false;
@@ -1224,22 +1239,41 @@ function buildExamCard(exam, render, savedSession, statusEl, layout) {
     closeMenu();
   };
 
+  const handleKeydown = event => {
+    if (!menuOpen) return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closeMenu();
+      menuToggle.focus();
+    }
+  };
+
+  const handleFocus = event => {
+    if (!menuOpen) return;
+    if (menuWrap.contains(event.target)) return;
+    closeMenu();
+  };
+
   function openMenu() {
     if (menuOpen) return;
     menuOpen = true;
-    menuPanel.hidden = false;
     menuWrap.classList.add('exam-card-menu--open');
     menuToggle.setAttribute('aria-expanded', 'true');
+    menuPanel.setAttribute('aria-hidden', 'false');
     document.addEventListener('click', handleOutside, true);
+    document.addEventListener('keydown', handleKeydown, true);
+    document.addEventListener('focusin', handleFocus, true);
   }
 
   function closeMenu() {
     if (!menuOpen) return;
     menuOpen = false;
-    menuPanel.hidden = true;
     menuWrap.classList.remove('exam-card-menu--open');
     menuToggle.setAttribute('aria-expanded', 'false');
+    menuPanel.setAttribute('aria-hidden', 'true');
     document.removeEventListener('click', handleOutside, true);
+    document.removeEventListener('keydown', handleKeydown, true);
+    document.removeEventListener('focusin', handleFocus, true);
   }
 
   menuToggle.addEventListener('click', event => {
@@ -1251,10 +1285,15 @@ function buildExamCard(exam, render, savedSession, statusEl, layout) {
     }
   });
 
+  menuPanel.addEventListener('click', event => {
+    event.stopPropagation();
+  });
+
   const addMenuAction = (label, handler, options = {}) => {
     const item = document.createElement('button');
     item.type = 'button';
     item.className = 'exam-card-menu-item';
+    item.setAttribute('role', 'menuitem');
     if (options.variant === 'danger') {
       item.classList.add('is-danger');
     }

--- a/style.css
+++ b/style.css
@@ -6559,7 +6559,7 @@ body.map-toolbox-dragging {
   background: linear-gradient(150deg, rgba(15, 23, 42, 0.92), rgba(30, 64, 175, 0.38));
   box-shadow: 0 26px 52px rgba(2, 6, 23, 0.5);
   transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease, background 0.25s ease;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .exam-card--row {
@@ -6746,89 +6746,268 @@ body.map-toolbox-dragging {
 
 .exam-card-menu {
   position: relative;
+  display: flex;
+  justify-content: flex-end;
 }
 
 .exam-card-menu-toggle {
   display: inline-flex;
   align-items: center;
+  gap: 0.55rem;
+  padding: 0.55rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  background: radial-gradient(circle at 20% 20%, rgba(37, 99, 235, 0.42), rgba(15, 23, 42, 0.78));
+  color: rgba(226, 232, 240, 0.9);
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  box-shadow: 0 14px 32px rgba(2, 6, 23, 0.55);
+  backdrop-filter: blur(6px);
+  transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.3s ease, border-color 0.3s ease, background 0.3s ease, color 0.3s ease;
+}
+
+.exam-card-menu-toggle__label {
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+}
+
+.exam-card-menu-toggle__icon {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
   justify-content: center;
-  width: 42px;
-  height: 42px;
-  border-radius: 50%;
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  background: rgba(15, 23, 42, 0.75);
-  color: rgba(226, 232, 240, 0.82);
-  box-shadow: 0 12px 24px rgba(2, 6, 23, 0.45);
-  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+  width: 24px;
+  height: 24px;
+  border-radius: 999px;
+  border: 1px solid rgba(125, 211, 252, 0.5);
+  background: linear-gradient(140deg, rgba(59, 130, 246, 0.35), rgba(14, 165, 233, 0.28));
+  color: rgba(224, 242, 254, 0.95);
+  box-shadow: inset 0 0 12px rgba(59, 130, 246, 0.45);
+  overflow: hidden;
+}
+
+.exam-card-menu-toggle__icon-bar {
+  position: relative;
+  display: inline-block;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+  transition: transform 0.32s ease;
+}
+
+.exam-card-menu-toggle__icon-bar::before,
+.exam-card-menu-toggle__icon-bar::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  width: 12px;
+  height: 2px;
+  border-radius: inherit;
+  background: currentColor;
+  transition: transform 0.32s ease, opacity 0.32s ease;
+}
+
+.exam-card-menu-toggle__icon-bar::before {
+  transform: translateY(-4px);
+}
+
+.exam-card-menu-toggle__icon-bar::after {
+  transform: translateY(4px);
 }
 
 .exam-card-menu-toggle:hover,
 .exam-card-menu-toggle:focus-visible,
 .exam-card-menu--open .exam-card-menu-toggle {
-  background: rgba(56, 189, 248, 0.22);
-  border-color: rgba(56, 189, 248, 0.5);
-  color: rgba(224, 242, 254, 0.95);
-  transform: translateY(-1px);
+  transform: translateY(-2px);
+  border-color: rgba(96, 165, 250, 0.65);
+  color: rgba(224, 242, 254, 0.98);
+  background: radial-gradient(circle at 20% 20%, rgba(59, 130, 246, 0.58), rgba(30, 64, 175, 0.78));
+  box-shadow: 0 20px 36px rgba(2, 6, 23, 0.6);
 }
 
-.exam-card-menu-icon {
-  font-size: 1.35rem;
-  line-height: 1;
+.exam-card-menu--open .exam-card-menu-toggle__icon-bar {
+  transform: rotate(45deg);
 }
 
-.exam-card-menu-icon::before {
-  content: '\22EE';
+.exam-card-menu--open .exam-card-menu-toggle__icon-bar::before {
+  transform: rotate(-90deg);
+}
+
+.exam-card-menu--open .exam-card-menu-toggle__icon-bar::after {
+  opacity: 0;
+  transform: translateY(0) scaleX(0.2);
 }
 
 .exam-card-menu-panel {
   position: absolute;
-  top: calc(100% + 8px);
+  top: calc(100% + 14px);
   right: 0;
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  padding: 10px;
-  border-radius: var(--radius);
+  gap: 8px;
+  padding: 14px;
+  border-radius: 16px;
   border: 1px solid rgba(148, 163, 184, 0.28);
-  background: rgba(8, 15, 31, 0.96);
-  box-shadow: 0 24px 46px rgba(2, 6, 23, 0.55);
-  min-width: 200px;
-  z-index: 20;
+  background: linear-gradient(160deg, rgba(9, 14, 29, 0.98), rgba(30, 58, 138, 0.82));
+  box-shadow: 0 32px 60px rgba(2, 6, 23, 0.65);
+  min-width: 220px;
+  z-index: 40;
+  opacity: 0;
+  transform: translateY(-10px) scale(0.98);
+  pointer-events: none;
+  transition: opacity 0.24s ease, transform 0.24s ease;
 }
 
-.exam-card-menu-panel[hidden] {
-  display: none;
+.exam-card-menu-panel::before {
+  content: '';
+  position: absolute;
+  top: -10px;
+  right: 32px;
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  background: inherit;
+  border-top: 1px solid rgba(148, 163, 184, 0.28);
+  border-left: 1px solid rgba(148, 163, 184, 0.28);
+  transform: rotate(45deg);
+  box-shadow: -4px -4px 16px rgba(2, 6, 23, 0.4);
+}
+
+.exam-card-menu--open .exam-card-menu-panel {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
 }
 
 .exam-card-menu-item {
   display: flex;
   align-items: center;
-  justify-content: flex-start;
-  gap: 0.4rem;
-  padding: 8px 12px;
-  border-radius: var(--radius-sm);
-  border: none;
-  background: transparent;
-  color: rgba(226, 232, 240, 0.88);
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  background: rgba(15, 23, 42, 0.45);
+  color: rgba(224, 242, 254, 0.9);
   font-size: 0.95rem;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease;
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .exam-card-menu-item:hover,
 .exam-card-menu-item:focus-visible {
-  background: rgba(56, 189, 248, 0.18);
-  color: rgba(224, 242, 254, 0.96);
+  transform: translateY(-1px);
+  border-color: rgba(96, 165, 250, 0.45);
+  background: rgba(59, 130, 246, 0.24);
+  color: rgba(224, 242, 254, 0.98);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.55);
+}
+
+.exam-card-menu-item:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  background: rgba(15, 23, 42, 0.2);
+  color: rgba(148, 163, 184, 0.65);
+  box-shadow: none;
 }
 
 .exam-card-menu-item.is-danger {
   color: rgba(254, 202, 202, 0.92);
+  background: rgba(69, 10, 10, 0.32);
 }
 
 .exam-card-menu-item.is-danger:hover,
 .exam-card-menu-item.is-danger:focus-visible {
-  background: rgba(248, 113, 113, 0.2);
-  color: rgba(254, 242, 242, 0.95);
+  border-color: rgba(248, 113, 113, 0.5);
+  background: rgba(248, 113, 113, 0.28);
+  color: rgba(254, 242, 242, 0.98);
+}
+
+@media (max-width: 960px) {
+  .exam-card-header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1.25rem;
+  }
+
+  .exam-card-summary {
+    width: 100%;
+  }
+
+  .exam-card-cta {
+    width: 100%;
+    align-items: stretch;
+  }
+
+  .exam-card-primary {
+    width: 100%;
+  }
+
+  .exam-card-menu {
+    width: 100%;
+  }
+
+  .exam-card-menu-toggle {
+    justify-content: center;
+    width: 100%;
+  }
+
+  .exam-card-menu-panel {
+    right: auto;
+    left: 50%;
+    transform: translate(-50%, -10px) scale(0.98);
+  }
+
+  .exam-card-menu-panel::before {
+    right: auto;
+    left: calc(50% - 9px);
+  }
+
+  .exam-card-menu--open .exam-card-menu-panel {
+    transform: translate(-50%, 0) scale(1);
+  }
+}
+
+@media (max-width: 560px) {
+  .exam-card-summary-content {
+    gap: 0.75rem;
+  }
+
+  .exam-card-menu-toggle {
+    padding: 0.55rem 0.75rem;
+  }
+
+  .exam-card-menu-toggle__label {
+    letter-spacing: 0.12em;
+  }
+
+  .exam-card-menu-panel {
+    min-width: min(220px, calc(100vw - 48px));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .exam-card-menu-toggle,
+  .exam-card-menu-panel,
+  .exam-card-menu-item,
+  .exam-card-menu-toggle__icon-bar,
+  .exam-card-menu-toggle__icon-bar::before,
+  .exam-card-menu-toggle__icon-bar::after {
+    transition: none;
+  }
+
+  .exam-card-menu-toggle:hover,
+  .exam-card-menu-toggle:focus-visible,
+  .exam-card-menu--open .exam-card-menu-toggle,
+  .exam-card-menu-item:hover,
+  .exam-card-menu-item:focus-visible {
+    transform: none;
+    box-shadow: none;
+  }
 }
 
 
@@ -7498,59 +7677,117 @@ body.map-toolbox-dragging {
 }
 
 .question-map__item {
-  border-radius: 10px;
-  border: 1px solid rgba(148, 163, 184, 0.32);
-  background: rgba(15, 23, 42, 0.68);
-  color: rgba(226, 232, 240, 0.85);
-  padding: 6px 0;
-  font-weight: 600;
-  font-size: 0.95rem;
+  --qm-background: linear-gradient(150deg, rgba(15, 23, 42, 0.82), rgba(15, 23, 42, 0.6));
+  --qm-border: rgba(148, 163, 184, 0.32);
+  --qm-text: rgba(226, 232, 240, 0.85);
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  line-height: 1;
-  min-height: 34px;
   width: 100%;
+  min-height: 36px;
+  padding: 6px 0;
+  font-weight: 600;
+  font-size: 0.95rem;
+  line-height: 1;
   font-variant-numeric: tabular-nums;
-  transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease, color 0.18s ease, box-shadow 0.18s ease;
+  border-radius: 12px;
+  border: 1px solid var(--qm-border);
+  background: var(--qm-background);
+  color: var(--qm-text);
+  text-shadow: 0 1px 0 rgba(15, 23, 42, 0.32);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease, border-color 0.2s ease;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.question-map__item::before,
+.question-map__item::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.question-map__item::before {
+  background: linear-gradient(135deg, rgba(168, 85, 247, 0.45), rgba(59, 130, 246, 0.35));
+  mix-blend-mode: screen;
+}
+
+.question-map__item::after {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.16), rgba(148, 163, 184, 0.08));
 }
 
 .question-map__item:hover,
 .question-map__item:focus-visible {
-  transform: translateY(-1px);
-  border-color: rgba(56, 189, 248, 0.55);
-  background: rgba(37, 99, 235, 0.22);
-  color: rgba(224, 242, 254, 0.98);
+  transform: translateY(-2px);
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.45);
+  border-color: rgba(148, 163, 184, 0.5);
+  filter: brightness(1.05);
+}
+
+.question-map__item:hover::after,
+.question-map__item:focus-visible::after {
+  opacity: 1;
 }
 
 .question-map__item.is-current {
-  border-color: rgba(56, 189, 248, 0.7);
-  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.35);
+  box-shadow: 0 0 0 2px rgba(168, 85, 247, 0.45), 0 18px 32px rgba(76, 29, 149, 0.38);
+  border-color: rgba(196, 181, 253, 0.75);
+}
+
+.question-map__item.is-current::before {
+  opacity: 1;
 }
 
 .question-map__item[data-status="answered"],
 .question-map__item.is-answered {
-  border-color: rgba(59, 130, 246, 0.45);
-  background: rgba(59, 130, 246, 0.18);
-  color: rgba(224, 242, 254, 0.96);
+  --qm-background: linear-gradient(135deg, rgba(37, 99, 235, 0.5), rgba(29, 78, 216, 0.65));
+  --qm-border: rgba(96, 165, 250, 0.75);
+  --qm-text: rgba(224, 242, 254, 0.98);
 }
 
 .question-map__item[data-status="correct"] {
-  border-color: rgba(74, 222, 128, 0.6);
-  background: rgba(34, 197, 94, 0.24);
-  color: rgba(209, 250, 229, 0.95);
+  --qm-background: linear-gradient(135deg, rgba(34, 197, 94, 0.48), rgba(16, 185, 129, 0.68));
+  --qm-border: rgba(134, 239, 172, 0.85);
+  --qm-text: rgba(240, 253, 244, 0.96);
 }
 
 .question-map__item[data-status="incorrect"] {
-  border-color: rgba(248, 113, 113, 0.68);
-  background: rgba(239, 68, 68, 0.22);
-  color: rgba(254, 226, 226, 0.95);
+  --qm-background: linear-gradient(135deg, rgba(239, 68, 68, 0.5), rgba(220, 38, 38, 0.68));
+  --qm-border: rgba(248, 113, 113, 0.85);
+  --qm-text: rgba(254, 226, 226, 0.96);
+}
+
+.question-map__item[data-status="unanswered"],
+.question-map__item.is-unanswered,
+.question-map__item[data-status="review-unanswered"] {
+  --qm-background: linear-gradient(150deg, rgba(15, 23, 42, 0.82), rgba(15, 23, 42, 0.6));
+  --qm-border: rgba(100, 116, 139, 0.38);
+  --qm-text: rgba(148, 163, 184, 0.78);
 }
 
 .question-map__item.is-review-unanswered,
 .question-map__item[data-status="review-unanswered"] {
   border-style: dashed;
-  color: rgba(226, 232, 240, 0.74);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .question-map__item,
+  .question-map__item::before,
+  .question-map__item::after {
+    transition: none;
+  }
+
+  .question-map__item:hover,
+  .question-map__item:focus-visible {
+    transform: none;
+    box-shadow: none;
+    filter: none;
+  }
 }
 
 .question-map__item[data-flagged="true"] {


### PR DESCRIPTION
## Summary
- replace the exam card overflow menu with a floating "Actions" toggle that animates open, closes on focus loss, and works on small screens
- allow exam cards to surface the new overlay panel and add responsive tweaks so the tab scales with window size changes
- refresh the question map styling so current, unanswered, answered, correct, and incorrect states all have distinct colors and hover feedback

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f955971ea88322996bf4a5b8df7919