### PR TITLE
Handle null lectures when building search tokens

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -30,7 +30,13 @@ export function buildTokens(item) {
   } else if (item.facts && item.facts.length) {
     fields.push(...item.facts);
   }
-  if (item.lectures) fields.push(...item.lectures.map(l => l.name));
+  if (Array.isArray(item.lectures)) {
+    item.lectures.forEach(lecture => {
+      if (lecture && typeof lecture.name === 'string' && lecture.name) {
+        fields.push(lecture.name);
+      }
+    });
+  }
   contentFields.forEach(field => {
     if (typeof item[field] === 'string' && item[field]) {
       fields.push(stripHtml(item[field]));

--- a/test/search.test.js
+++ b/test/search.test.js
@@ -21,3 +21,9 @@ test('buildTokens includes rich text content', () => {
     assert(tokens.includes(tok));
   });
 });
+
+test('buildTokens tolerates incomplete lecture data', () => {
+  const item = { lectures: [null, undefined, { name: 'Delta' }, {}] };
+  const tokens = buildTokens(item).split(' ');
+  assert(tokens.includes('delta'));
+});


### PR DESCRIPTION
## Summary
- guard search token building against null lecture records
- add a regression test covering incomplete lecture data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68faa78f45c88322a094d1cbffaf4888